### PR TITLE
Fixed an issue where Retrieve calls for a specific would fail, because the request was not being referenced

### DIFF
--- a/lib/core/table/TableStorageManager.js
+++ b/lib/core/table/TableStorageManager.js
@@ -101,10 +101,10 @@ class TableStorageManager {
         const coll = this.db.getCollection(request.tableName);
         const findExpr = {};
         if (request.partitionKey) {
-            findExpr['partitionKey'] = partitionKey;
+            findExpr['partitionKey'] = request.partitionKey;
         }
         if (request.rowKey) {
-            findExpr['rowKey'] = rowKey;
+            findExpr['rowKey'] = request.rowKey;
         }
 
         const chain = coll.chain().find(findExpr);


### PR DESCRIPTION
There is a small typo where the request is not being used an error is being throw from JavaScript strict mode (`paritionKey` is not defined)