### PR TITLE
When PartitionKey and RowKey is passed in filter they are keept in Pa…

### DIFF
--- a/lib/model/table/AzuriteTableRequest.js
+++ b/lib/model/table/AzuriteTableRequest.js
@@ -109,7 +109,7 @@ class AzuriteTableRequest {
                 !token.includes('`') &&
                 !['===', '>', '>=', '<', '<=', '!==', '&&', '||', '!', '(', ')'].includes(token)) {
                 if (token === 'PartitionKey' || token === 'RowKey') {
-                    transformedQuery += `item.${token} `;
+                    transformedQuery += `item.${token[0].toLowerCase()}${token.slice(1)} `;
                 } else {
                     transformedQuery += `item.attribs.${token} `;
                 }


### PR DESCRIPTION
This is a fix for [Issue#26](https://github.com/Azure/Azurite/issues/26).

When PartitionKey and RowKey are passed in filter they are kept in pascal case, the db has them set to camel case 