### PR TITLE
Fix an issue with CORS when a preflight request has an empty headers list

### DIFF
--- a/lib/middleware/blob/cors.js
+++ b/lib/middleware/blob/cors.js
@@ -7,6 +7,25 @@ const BbPromise = require('bluebird'),
     Operations = require('./../../core/Constants').Operations,
     sm = require('./../../core/blob/StorageManager');
 
+// Returns the dict of allowed headers for a given request
+function getAllowedHeaders (req) {
+    const request = req.azuriteRequest;
+    if (req.azuriteOperation === Operations.Account.PREFLIGHT_BLOB_REQUEST) {
+        if (request.httpProps[N.ACCESS_CONTROL_REQUEST_HEADERS] === undefined) {
+            return {}
+        } else {
+            return request.httpProps[N.ACCESS_CONTROL_REQUEST_HEADERS].toLowerCase().split(',')
+                .reduce((acc, e) => {
+                    const key = Object.keys(e)[0];
+                    acc[key] = e[key];
+                    return acc;
+                }, {});
+        }
+    } else {
+        return req.headers;
+    }
+}
+
 // Performs CORS rule-validation iff CORS is enabled and request header 'origin' is set.
 module.exports = (req, res, next) => {
     BbPromise.try(() => {
@@ -18,18 +37,10 @@ module.exports = (req, res, next) => {
                         ? request.httpProps[N.ACCESS_CONTROL_REQUEST_METHOD].toLowerCase()
                         : req.method.toLowerCase();
 
-                    const allowedHeaders = req.azuriteOperation === Operations.Account.PREFLIGHT_BLOB_REQUEST
-                        ? request.httpProps[N.ACCESS_CONTROL_REQUEST_HEADERS].toLowerCase().split(',')
-                            .reduce((acc, e) => {
-                                const key = Object.keys(e)[0];
-                                acc[key] = e[key];
-                                return acc;
-                            }, {})
-                        : req.headers;
+                    const allowedHeaders = getAllowedHeaders(req)
 
                     let valid = null;
                     for (const rule of response.payload.StorageServiceProperties.Cors.CorsRule) {
-                        valid = false;
                         rule.AllowedOrigins = rule.AllowedOrigins.toLowerCase();
                         rule.AllowedMethods = rule.AllowedMethods.toLowerCase();
                         if (!rule.AllowedOrigins.includes(request.httpProps[N.ORIGIN]) && !rule.AllowedOrigins.includes('*')) {
@@ -40,6 +51,8 @@ module.exports = (req, res, next) => {
                             continue;
                         }
 
+                        // Start at true to handle the case where allowedHeaders is an empty list
+                        valid = true;
                         rule.AllowedHeaders.split(',')
                             .forEach((e) => {
                                 Object.keys(allowedHeaders).forEach((requestHeader) => {


### PR DESCRIPTION
Without this fix, azurite would fail because it was trying to call

  ```request.httpProps[N.ACCESS_CONTROL_REQUEST_HEADERS].toLowerCase()```

which will result in trying to call undefined.toLowerCase() if the preflight
request doesn't specify access-control-request-headers.

In addition, when validating a request against the CORS, the request would
fail to be validated if access-control-request-headers was empty.