### PR TITLE
Fixed result when requesting single entity with rowkey and partitionkey

### DIFF
--- a/lib/actions/table/QueryEntities.js
+++ b/lib/actions/table/QueryEntities.js
@@ -12,18 +12,37 @@ class QueryEntities {
         tableStorageManager.queryEntities(request)
             .then((response) => {
                 res.set(response.httpProps);
-                const payload = this._createResponsePayload(response.payload, request.tableName, request.accept);
+                const payload = this._createResponsePayload(response.payload, request.tableName, request.accept, request.singleEntity);
                 res.status(200).send(payload);
             });
     }
 
-    _createResponsePayload(payload, tableName, accept) {
-        const response = {};
+    _createResponsePayload(payload, tableName, accept, singleEntity) {
+
+        let response = {};
+
         if (accept !== ODataMode.NONE) {
             response['odata.metadata'] = `http://127.0.0.1:10002/devstoreaccount1/$metadata#${tableName}`;
         }
+
+        if(singleEntity) {
+
+            for (const item of payload) {
+
+                response['PartitionKey'] = item.partitionKey;
+                response['RowKey'] = item.rowKey;
+
+                response = Object.assign({}, response, item.attribs(ODataMode.FULL));
+
+            }
+
+            return response;
+        }
+
         response.value = [];
+
         let i = 0;
+
         for (const item of payload) {
             response.value.push(item.attribs(accept));
             response.value[i]['PartitionKey'] = item.partitionKey;
@@ -37,7 +56,9 @@ class QueryEntities {
             }
             ++i;
         }
+
         return response;
+
     }
 }
 

--- a/lib/model/table/AzuriteTableRequest.js
+++ b/lib/model/table/AzuriteTableRequest.js
@@ -27,6 +27,11 @@ class AzuriteTableRequest {
         this.partitionKey = this.payload.PartitionKey || partitionKey;
         this.rowKey = this.payload.RowKey || rowKey;
 
+        //If PartitionKey and Rowkey is passed in header a single entity is to be retireived
+        if(this.partitionKey && this.rowKey) {
+            this.singleEntity = true;
+        }
+
         this.filter = req.query.$filter ? this._mapFilterQueryString(decodeURI(req.query.$filter)) : undefined;
         // Maximum of 1000 items at one time are allowed, 
         // see https://docs.microsoft.com/rest/api/storageservices/query-timeout-and-pagination


### PR DESCRIPTION
When using this with azure-storage-node and calling the api with retrieveEntity the wrong format is returned, it handles the response as it does when querying several entities

Return value when requesting one entity from dev

```json
{
	"value": {
		"_": [{
			"Timestamp": "2018-06-08T10:09:31.010Z",
			"Timestamp@odata.type": "Edm.DateTime",
			"type": 1,
			"PartitionKey": "asdasd123",
			"RowKey": "a6c09770-6a69-11e8-ac4a-ddbdcad9d221"
		}]
	},
	".metadata": {
		"metadata": "http://127.0.0.1:10002/devstoreaccount1/$metadata#revokelist",
		"etag": "W/\"fe-/JfNhqfuZdZakFgYTVFcUMDIGdc\""
	}
}
```
Return value when requesting one entity from azure table
```json
{
	"PartitionKey": {
		"$": "Edm.String",
		"_": "asdasd"
	},
	"RowKey": {
		"$": "Edm.String",
		"_": "839408a0-6a68-11e8-a3a3-fd722a41ad6b"
	},
	"Timestamp": {
		"$": "Edm.DateTime",
		"_": "2018-06-07T15:38:11.801Z"
	},
	"type": {
		"_": 1
	},
	".metadata": {
		"metadata": "https://{url}/$metadata#revokelist/@Element",
		"etag": "W/\"datetime'2018-06-07T15%3A38%3A11.8019139Z'\""
	}
}
```

Return value of one entity with fix
```json
{
	"PartitionKey": {
		"$": "Edm.String",
		"_": "asdasd123"
	},
	"RowKey": {
		"$": "Edm.String",
		"_": "a6c09770-6a69-11e8-ac4a-ddbdcad9d221"
	},
	"Timestamp": {
		"$": "Edm.DateTime",
		"_": "2018-06-08T10:09:31.010Z"
	},
	"type": {
		"_": 1
	},
	".metadata": {
		"metadata": "http://127.0.0.1:10002/devstoreaccount1/$metadata#revokelist",
		"etag": "W/\"f2-OvSglgZEq3Cvo1EjrlNQtBG4j6o\""
	}
}
```
RowKey and PartitionKey will only be set in header when calling with retrieveEntity
