### PR TITLE
Always set the copyProgress field.

### DIFF
--- a/lib/core/blob/StorageManager.js
+++ b/lib/core/blob/StorageManager.js
@@ -603,6 +603,7 @@ class StorageManager {
             blobProxyDestination = this._createOrUpdateBlob(coll, request),
             copyId = uuidv4();
 
+        blobProxyDestination.original.copyProgress = `0/${sourceProxy.original.size}`;
         blobProxyDestination.original.copyStatus = CopyStatus.PENDING;
         blobProxyDestination.original.copyStatusDescription = '';
         blobProxyDestination.original.copyId = copyId;
@@ -610,6 +611,7 @@ class StorageManager {
         let bytesCopied = 0;
         to.on('finish', () => {
             if (blobProxyDestination.original.copyStatus !== CopyStatus.FAILED) {
+                blobProxyDestination.original.copyProgress = `${sourceProxy.original.size}/${sourceProxy.original.size}`;
                 blobProxyDestination.original.copyCompletionTime = new Date().toGMTString();
                 blobProxyDestination.original.copyStatus = CopyStatus.SUCCESS;
                 delete blobProxyDestination.original.copyStatusDescription;


### PR DESCRIPTION
Before this change, the Azure Java SDK was failing on the list operation if it included copied blobs:

```
Exception in thread "main" java.util.NoSuchElementException: An error occurred while enumerating the result, check the original exception for details.
        at com.microsoft.azure.storage.core.LazySegmentedIterator.hasNext(LazySegmentedIterator.java:113)
[...]
Caused by: com.microsoft.azure.storage.StorageException: OK
        at com.microsoft.azure.storage.StorageException.translateException(StorageException.java:87)
        at com.microsoft.azure.storage.core.ExecutionEngine.executeWithRetry(ExecutionEngine.java:209)
        at com.microsoft.azure.storage.core.LazySegmentedIterator.hasNext(LazySegmentedIterator.java:109)
        ... 4 more
Caused by: java.lang.NumberFormatException: For input string: "undefined"
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
        at java.lang.Long.parseLong(Long.java:589)
        at java.lang.Long.parseLong(Long.java:631)
        at com.microsoft.azure.storage.blob.BlobListHandler.setProperties(BlobListHandler.java:312)
        at com.microsoft.azure.storage.blob.BlobListHandler.endElement(BlobListHandler.java:188)
[... SAX parsing ...]
        at com.microsoft.azure.storage.blob.BlobListHandler.getBlobList(BlobListHandler.java:75)
        at com.microsoft.azure.storage.blob.CloudBlobContainer$7.postProcessResponse(CloudBlobContainer.java:1473)
        at com.microsoft.azure.storage.blob.CloudBlobContainer$7.postProcessResponse(CloudBlobContainer.java:1437)
        at com.microsoft.azure.storage.core.ExecutionEngine.executeWithRetry(ExecutionEngine.java:155)
```