### PR TITLE
Address issue **PANIC** while creating storage container policy #12

### DIFF
--- a/lib/xml/Serializers.js
+++ b/lib/xml/Serializers.js
@@ -26,7 +26,7 @@ exports.parseSignedIdentifiers = (body) => {
                             start = si.AccessPolicy.Start[0];
                         }
                         else{
-                            console.error('WARN: ACCESS POLICY START UNDEFINED ' , si );
+                            console.log(new Date().toISOString(), ' INFO ACCESS_POLICY_START_UNDEFINED \"', si , '\"');
                         }
 
                         if(typeof si.AccessPolicy.Expiry != 'undefined'){
@@ -34,7 +34,9 @@ exports.parseSignedIdentifiers = (body) => {
                         }
                         else{
                             // if you have no expiry set on your SAS Key, you are doing something wrong
-                            console.error('ERROR: ACCESS POLICY EXPIRY UNDEFINED ' , si );
+                            console.log(new Date().toISOString(), ' ERROR ACCESS_POLICY_EXPIRY_UNDEFINED \"', si, '\"');
+                            let MAX_TIMESTAMP = 8640000000000000;
+                            expiry = new Date(MAX_TIMESTAMP).toISOString();
                         }
 
                         if(typeof si.AccessPolicy.Permission != 'undefined'){
@@ -45,7 +47,7 @@ exports.parseSignedIdentifiers = (body) => {
                     else
                     {
                         // as Azurite is a tool to aid development, we should notify developers that a mistake has been made
-                        console.error('ERROR: ACCESS POLICY UNDEFINED ' , si );
+                        console.log(new Date().toISOString(), ' ERROR ACCESS_POLICY_UNDEFINED \"', si,'\"');
                     }
                     
                 }

--- a/lib/xml/Serializers.js
+++ b/lib/xml/Serializers.js
@@ -6,6 +6,7 @@ const BbPromise = require('bluebird'),
     parseStringAsyncNoArray = BbPromise.promisify(new xml2js.Parser({ explicitArray: false }).parseString),
     xml2jsAsync = BbPromise.promisify(require('xml2js').parseString);
 
+// see https://docs.microsoft.com/en-us/rest/api/storageservices/Set-Container-ACL?redirectedfrom=MSDN
 exports.parseSignedIdentifiers = (body) => {
     body = body.toString('utf8');
     return parseStringAsync(body)
@@ -16,7 +17,37 @@ exports.parseSignedIdentifiers = (body) => {
             const model = new SignedIdentifiers();
             if (temp.SignedIdentifiers !== "") {
                 for (const si of temp.SignedIdentifiers.SignedIdentifier) {
-                    model.addSignedIdentifier(si.Id[0], si.AccessPolicy[0].Start[0], si.AccessPolicy[0].Expiry[0], si.AccessPolicy[0].Permission[0]);
+                    let start;
+                    let expiry;
+                    let permission;
+                    // for case where expiry not defined initially just avoiding a PANIC
+                    if(typeof si.AccessPolicy != 'undefined'){
+                        if(typeof si.AccessPolicy.Start != 'undefined'){
+                            start = si.AccessPolicy.Start[0];
+                        }
+                        else{
+                            console.error('WARN: ACCESS POLICY START UNDEFINED ' , si );
+                        }
+
+                        if(typeof si.AccessPolicy.Expiry != 'undefined'){
+                            expiry = si.AccessPolicy.Expiry[0];
+                        }
+                        else{
+                            // if you have no expiry set on your SAS Key, you are doing something wrong
+                            console.error('ERROR: ACCESS POLICY EXPIRY UNDEFINED ' , si );
+                        }
+
+                        if(typeof si.AccessPolicy.Permission != 'undefined'){
+                            expiry = si.AccessPolicy.Permission[0];
+                        }
+                        model.addSignedIdentifier(si.Id[0], start, expiry,permission);
+                    }
+                    else
+                    {
+                        // as Azurite is a tool to aid development, we should notify developers that a mistake has been made
+                        console.error('ERROR: ACCESS POLICY UNDEFINED ' , si );
+                    }
+                    
                 }
             }
             return model;


### PR DESCRIPTION
Changes to deal with cases where expiry or start times are not defined.

Script to test changes can be found in issue #12 

Need to validate what happens in the real case if we submit XML without required fields to create an access policy using a tool like postman.