### PR TITLE
Entity generator now accepts optional partition and row key

### DIFF
--- a/lib/core/table/TableStorageManager.js
+++ b/lib/core/table/TableStorageManager.js
@@ -190,7 +190,7 @@ class TableStorageManager {
 
     _createOrUpdateEntity(partitionKey, rowKey, tableName, rawEntity) {
         const coll = this.db.getCollection(tableName),
-            entity = EntityGenerator.generateEntity(rawEntity, tableName),
+            entity = EntityGenerator.generateEntity(rawEntity, tableName, partitionKey, rowKey),
             res = coll.findOne({ partitionKey: partitionKey, rowKey: rowKey });
 
         if (res !== null) {
@@ -205,7 +205,7 @@ class TableStorageManager {
 
     _insertOrMergeEntity(partitionKey, rowKey, tableName, rawEntity) {
         const coll = this.db.getCollection(tableName),
-            entity = EntityGenerator.generateEntity(rawEntity, tableName),
+            entity = EntityGenerator.generateEntity(rawEntity, tableName, partitionKey, rowKey),
             res = coll.findOne({ partitionKey: partitionKey, rowKey: rowKey });
 
         if (res !== null) {

--- a/lib/model/table/EntityGenerator.js
+++ b/lib/model/table/EntityGenerator.js
@@ -31,11 +31,11 @@ class EntityGenerator {
         return entity;
     }
 
-    generateEntity(rawEntity, tableName) {
+    generateEntity(rawEntity, tableName, partitionKey = undefined, rowKey = undefined) {
         // Enriching raw entity from payload with odata attributes
         const entity = { attribs: {} };
-        entity.partitionKey = rawEntity.PartitionKey;
-        entity.rowKey = rawEntity.RowKey;
+        entity.partitionKey = partitionKey || rawEntity.PartitionKey;
+        entity.rowKey = rowKey || rawEntity.RowKey;
         entity.attribs.Timestamp = new Date().toISOString();
         entity.attribs['Timestamp@odata.type'] = "Edm.DateTime";  
         for (const key of Object.keys(rawEntity)) {


### PR DESCRIPTION
When the raw entity does not have a partition key or row key use the ones from the request params.

The C# azure storage sdk does not necessarily send the partition key and row key in the raw entity. Azure Storage apparently does not read it from the raw entity because code that works on it does not work on Azurite without these changes.