### PR TITLE
Dockerfile: deterministic builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:alpine
+FROM node:10.6-alpine
 
 WORKDIR /opt/azurite
 
-COPY package.json /opt/azurite
+COPY package.json package-lock.json /opt/azurite/
 RUN npm install
 
 COPY bin /opt/azurite/bin


### PR DESCRIPTION
Use explicit version tag 10.6-alpine instead of alpine to ensure a known
version is used. Copy package-lock.json before npm install to ensure
known dependencies are installed.