### PR TITLE
Updated documentation for Azure storage testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,15 @@ If you are interested in making a code contribution and would like to learn more
 - Azurite makes heavy use of [Bluebird](http://bluebirdjs.com/docs/getting-started.html) which is a fully featured promises library with unmatched performance.  
 
 ## What TODOs are there?
-The current status of Azurite's support of the [Official Blob Storage REST API Specification](https://docs.microsoft.com/rest/api/storageservices/blob-service-rest-api) is listed in below section [API Support](https://github.com/arafato/azurite/#api-support). Features that are still unimplemented are marked with `[TODO]`. Features that are currently being worked on are marked with `[IN-PROGRESS]`.
+We are using a combination of community feedback, and the Azure Storage Node package tests to validate  Azurite's support of the [Official Blob Storage REST API Specification](https://docs.microsoft.com/rest/api/storageservices/blob-service-rest-api).  
+We shall create issues based on failing tests to help direct and prioritize our development efforts.  
+See also section below: [API Support](https://github.com/Azure/Azurite/#api-support).
 
 Current bugs that need to be fixed are listed at our [issues site on Github](https://github.com/Azure/Azurite/issues) and tagged with a red label `bug`.
+
+Issues which we think might  be a good place for newcomers to start, are tagged with [**"good first issue"**](https://github.com/Azure/Azurite/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+
+Details on how to setup tests with the Azure Storage submodule, can be found under [Testing with Azure Storage Node](./doc/azure-storage-node_tdd.md).  
 
 ## Need Help?
 Be sure to check out the Microsoft Azure Developer Forums on MSDN or the Developer Forums on Stack Overflow if you have trouble with the provided code.
@@ -115,6 +121,8 @@ If you encounter any bugs with the library please file an issue in the [Issues](
 
 When sending pull requests, please send **non-breaking PRs** to the dev branch and breaking changes to the **dev_breaking** branch. Please do not make PRs against master.
 
+- **Please include a Unit or Integration test with any code submission, this is a significant help when validating changes and helps reduce the time we need to spend on pull requests.**  
+
 ## Where can I go for help?
 
 If you need help, you can ask questions directly at our [issues site on Github](https://github.com/Azure/Azurite/issues).  
@@ -125,7 +133,8 @@ Alternatively, check out the following links:
 [Azure Storage Team Blog](https://blogs.msdn.com/b/windowsazurestorage/)  
 
 # API Support
-Currently, Azurite only supports the [Blob Storage APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/blob-service-rest-api), the [Queue Storage API](https://docs.microsoft.com/en-us/rest/api/storageservices/queue-service-rest-api), and the [Table Storage API](https://docs.microsoft.com/en-us/rest/api/storageservices/table-service-rest-api). Support for Azure Storage Files is planned, but currently not available. 
+Currently, Azurite only supports the [Blob Storage APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/blob-service-rest-api), the [Queue Storage API](https://docs.microsoft.com/en-us/rest/api/storageservices/queue-service-rest-api), and the [Table Storage API](https://docs.microsoft.com/en-us/rest/api/storageservices/table-service-rest-api).  
+Support for Azure Storage Files is planned, but currently not available. 
 
 The Standard Emulator Connection String is the same as required by [Microsoft's Official Storage Emulator](https://go.microsoft.com/fwlink/?LinkId=717179):
 

--- a/doc/azure-storage-node_tdd.md
+++ b/doc/azure-storage-node_tdd.md
@@ -1,0 +1,67 @@
+# Testing with Azure Storage Node
+
+We have added the Azure Storage Node package as a submodule under ./externaltests
+
+To run these tests, you need to open your git console and run the following command in your Azurite repo:
+
+```shell
+git submodule update
+```
+
+Once the submodule has been cloned, you need to change to the **./externaltests/azure-storage-node** folder and run 
+
+```shell
+npm install
+```
+
+This will install the dependencies, and allow you to run the tests.
+
+To debug test cases, you can use the following addition to your VS Code launch.json:
+
+```json
+        {
+            "type": "node",
+            "request": "launch",
+            "env": {
+                "AZURITE_LOCATION" :"azurite-storage-testdrive",
+                "NOCK_OFF": "true",
+                "AZURE_STORAGE_CONNECTION_STRING": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;",
+                "AZURE_STORAGE_CONNECTION_STRING_BLOB_ACCOUNT" : "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+            },
+            "name": "Azure Storage Tests",
+            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+            "args": [
+                "-u",
+                "tdd",
+                "--timeout",
+                "999999",
+                "--colors",
+                "${workspaceRoot}/externaltests"
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "protocol": "inspector"
+        },
+```
+
+The tests are currently run by ./externaltests/azure-storage-shim.js , and we are looking at making this more comfortable for developers at the early stages of feature implementation.  
+Currently, we are just commenting out those test scripts which we do not want to run.
+i.e:
+
+```javascript
+describe('azure-storage-node tests', () => {
+    const azurite = new Azurite();
+    before(() => {
+        const location = path.join(process.env.AZURITE_LOCATION, 'AZURE-STORAGE');
+        return azurite.init({ l: location, silent: 'true', overwrite: 'true' });
+    });
+
+    //requireTestDir('');
+    // Currently runs azure-storage tests individually, until we implement a playlist definition
+    // require('./azure-storage-node/test/services/blob/blobservice-archive-tests');
+    require('./azure-storage-node/test/services/blob/blobservice-container-tests');
+    // require('./azure-storage-node/test/services/blob/blobservice-lease-tests');
+    // require('./azure-storage-node/test/services/blob/blobservice-sse-tests'); 
+    // require('./azure-storage-node/test/services/blob/blobservice-tests');
+    // require('./azure-storage-node/test/services/blob/blobservice-uploaddownload-tests');
+    // require('./azure-storage-node/test/services/blob/blobservice-uploaddownload-scale-tests');
+```


### PR DESCRIPTION
This is the  documentation updates for using Azure-Storage-Node to test Azurite...

I accidentally pushed my branch to Azurite directly, rather than my own fork...
The actual changes which deliver the testing will be submitted separately.