### PR TITLE
Adjust logging to have Standard Apache common log output.

### DIFF
--- a/lib/AzuriteBlob.js
+++ b/lib/AzuriteBlob.js
@@ -35,7 +35,7 @@ class AzuriteBlob {
             .then(() => {
                 const app = express();
                 if (!env.silent) {
-                    app.use(morgan('dev'));
+                    app.use(morgan('common'));
                 }
                 // According to RFC 7231:
                 // An origin server MAY respond with a status code of 415 (Unsupported

--- a/lib/AzuriteQueue.js
+++ b/lib/AzuriteQueue.js
@@ -31,7 +31,7 @@ class AzuriteQueue {
             .then(() => {
                 const app = express();
                 if (!env.silent) {
-                    app.use(morgan('dev'));
+                    app.use(morgan('common'));
                 }
                 app.use(bodyParser.raw({
                     inflate: true,

--- a/lib/AzuriteTable.js
+++ b/lib/AzuriteTable.js
@@ -34,7 +34,7 @@ class AzuriteTable {
             .then(() => {
                 const app = express();
                 if (!env.silent) {
-                    app.use(morgan('dev'));
+                    app.use(morgan('common'));
                 }
                 app.use(bodyParser.raw({
                     inflate: true,


### PR DESCRIPTION
I worked on Issue #27 and changed from dev to apache common logging format. Now color is gone and logs shouldn't cause problems.