### PR TITLE
Refactored error handling

### DIFF
--- a/lib/core/AzuriteError.js
+++ b/lib/core/AzuriteError.js
@@ -7,12 +7,13 @@ function generateErrorMessage(errorCode, userMessage) {
 }
 
 class AzuriteError extends Error {
-  constructor(e) {
-    super(e.errorCode);
-    this.message = generateErrorMessage(e.errorCode, e.userMessage || "");
-    this.statusCode = e.httpErrorCode;
-    Error.captureStackTrace(this, this.constructor);
-  }
+    constructor(e) {
+        super(generateErrorMessage(e.errorCode, e.userMessage || ""));
+        this.errorCode = e.errorCode;
+        this.statusCode = e.httpErrorCode;
+        this.messageContentType = 'application/xml';
+        Error.captureStackTrace(this, this.constructor);
+    }
 }
 
 module.exports = AzuriteError;

--- a/lib/core/HttpHeaderNames.js
+++ b/lib/core/HttpHeaderNames.js
@@ -55,6 +55,7 @@ module.exports = {
   ACCESS_CONTROL_MAX_AGE: "access-control-max-age",
   ACCESS_CONTROL_ALLOW_CREDENTIALS: "access-control-allow-credentials",
   ACCESS_CONTROL_EXPOSE_HEADERS: "access-control-expose-headers",
+  ERROR_CODE: 'x-ms-error-code',
   // Append Blob specific attributes
   BLOB_CONDITION_MAX_SIZE: "x-ms-blob-condition-maxsize",
   BLOB_COMMITTED_BLOCK_COUNT: "x-ms-blob-committed-block-count",

--- a/lib/model/blob/AzuriteErrorResponse.js
+++ b/lib/model/blob/AzuriteErrorResponse.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const AzuriteResponse = require('./AzuriteResponse'),
+    N = require('./../../core/HttpHeaderNames');
+
+class AzuriteErrorResponse extends AzuriteResponse {
+    constructor({ proxy = undefined, error = undefined, cors = undefined} = {}) {
+        super({proxy, payload: error.message, cors});
+        
+        this.httpProps[N.ERROR_CODE] = error.errorCode;
+        this.httpProps[N.CONTENT_TYPE] = error.messageContentType;
+        this.status = error.statusCode;
+    }
+}
+
+module.exports = AzuriteErrorResponse;

--- a/lib/model/blob/AzuriteResponse.js
+++ b/lib/model/blob/AzuriteResponse.js
@@ -12,9 +12,12 @@ class AzuriteResponse {
     payload = undefined,
     query = {},
     cors = undefined,
+    status = 200
   } = {}) {
     this.httpProps = {};
     this.proxy = proxy;
+    this.status = status;
+
     if (this.proxy) {
       this.httpProps[N.ETAG] = `\"${this.proxy.original.etag}\"`;
       this.httpProps[N.LAST_MODIFIED] = this.proxy.lastModified();
@@ -32,7 +35,7 @@ class AzuriteResponse {
         this.httpProps[N.SEQUENCE_NUMBER] = proxy.original.sequenceNumber;
       }
     }
-    this.httpProps[N.VERSION] = "2016-05-31";
+    this.httpProps[N.VERSION] = "2017-07-29";
     this.httpProps[N.DATE] = new Date().toGMTString();
     this.httpProps[N.CONTENT_LENGTH] = 0;
     this.httpProps[N.REQUEST_ID] = uuidV1();
@@ -58,6 +61,13 @@ class AzuriteResponse {
     this.addHttpProperty(N.CONTENT_ENCODING, query.rsce);
     this.addHttpProperty(N.CONTENT_LANGUAGE, query.rscl);
     this.addHttpProperty(N.CONTENT_TYPE, query.rsct);
+  }
+
+  send(res) {
+      this.httpProps[N.CONTENT_LENGTH] = this.payload ? this.payload.length : 0;
+      res.set(this.httpProps);
+      res.status(this.status);
+      res.send(this.payload);
   }
 }
 


### PR DESCRIPTION
Introduces a new AzuriteErrorRespone, subclassed from AzuriteResponse, that can correctly package and send errors back to the client.

Also sets the x-ms-error-code header and adjusts the API version accordingly to improve compatibility with newer clients.

Finally, the AzuriteResponse class gains a send method, which will apply all headers, set status code, calculate content-length and send the data over the wire via an express `res` object. Over time, all Azurite actions can migrate to use this pattern, instead of manually applying all properties from the AzuriteResponse.