### PR TITLE
Fix query single item incorrect behavior

### DIFF
--- a/lib/actions/table/QueryEntities.js
+++ b/lib/actions/table/QueryEntities.js
@@ -37,13 +37,7 @@ class QueryEntities {
         response["RowKey"] = item.rowKey;
         response = Object.assign({}, response, item.attribs(accept));
       }
-    } else if (payload.length === 1) {
-      response["PartitionKey"] = payload[0].partitionKey;
-      response["RowKey"] = payload[0].rowKey;
-      for (const attrib in payload[0].attribs(accept)) {
-        response[attrib] = payload[0]._.attribs[attrib];
-      }
-    } else if (payload.length > 1) {
+    } else {
       response.value = [];
       let i = 0;
       for (const item of payload) {


### PR DESCRIPTION
Appears to be from commit 9413bd7af4da7ffe24457180541ad1c6d2da8d10 for the 2.6.7 release, special behavior was introduced for single results. This breaks some clients as they are not expecting a structural change in the resulting payload, which appears to be inconsistent with the Microsoft official one.

I cannot find out exactly why this change was made as the history doesn't appear to be traceable beyond this, but I appreciate there might be a legitimate reason for this.

May be connected to #31.

I have a specific fake 5 F# test example I have attached below which will no longer explode after the change:

```
open System
open Microsoft.WindowsAzure.Storage
#load "./.fake/T1.fsx/intellisense.fsx"

#r "paket:
nuget FSharp.Azure.Storage //"

open FSharp.Azure.Storage.Table

type Thing = {
    [<PartitionKey>] PK: string
    [<RowKey>] Id: string
    string1: Option<string>
    string2: Option<string>
    string3: Option<string>
}

open Microsoft.WindowsAzure.Storage
open Microsoft.WindowsAzure.Storage.Table

let account = CloudStorageAccount.Parse "UseDevelopmentStorage=true;"
let tableClient = account.CreateCloudTableClient()
tableClient.GetTableReference("Thing").CreateIfNotExistsAsync().Result

let fromThingTable thing = fromTable tableClient "Thing" thing
let inThingTable thing = inTable tableClient "Thing" thing

let thing1 = {PK = "ONE"; Id = "THREE"; string1 = Some "hello world"; string2 = Some "test"; string3 = None}
printfn "before"
let result = thing1 |> InsertOrReplace |> inThingTable
let q2 = 
    Query.all<Thing>
    |> Query.where <@ fun g sf -> g.Id = "THREE" @>
    |> Query.take 1 
    |> fromThingTable 

printfn "%A" q2
```