### PR TITLE
Fixed errors when querying tables with a $filter argument

### DIFF
--- a/lib/actions/table/QueryEntities.js
+++ b/lib/actions/table/QueryEntities.js
@@ -43,7 +43,7 @@ class QueryEntities {
       for (const attrib in payload[0].attribs(accept)) {
         response[attrib] = payload[0]._.attribs[attrib];
       }
-    } else if (payload.length > 1) {
+    } else {
       response.value = [];
       let i = 0;
       for (const item of payload) {

--- a/lib/core/table/TableStorageManager.js
+++ b/lib/core/table/TableStorageManager.js
@@ -145,7 +145,7 @@ class TableStorageManager {
         .data();
     }
 
-    if (find.length == 0) {
+    if (request.partitionKey && request.rowKey && find.length == 0) {
       throw new AError(ErrorCodes.EntityNotFound);
     }
 

--- a/lib/model/table/AzuriteTableRequest.js
+++ b/lib/model/table/AzuriteTableRequest.js
@@ -99,6 +99,8 @@ class AzuriteTableRequest {
       // ignoring these query keywords since we compare simply on a string-level
       .replace(/\bdatetime\b/g, "")
       .replace(/\bguid\b/g, "")
+      // Escape a single backtick to prevent interpreting the start of a template literal.
+      .replace(/`/g, '\\`')
       // A simple quotation mark is escaped with another one (i.e. '').
       // Since we will evaluate this string we replace simple quotation marks indictaing strings with template quotation marks
       .replace(/''/g, "@")

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "externaltests": "env-cmd ./externaltests/.env mocha externaltests",
     "start": "node bin/azurite -l azurite-testdrive",
     "blob": "node bin/blob -l azurite-testdrive",
-    "queue": "node bin/queue",
-    "table": "node bin/table",
+    "queue": "node bin/queue -l azurite-testdrive",
+    "table": "node bin/table -l azurite-testdrive",
     "clean": "rimraf azurite-testdrive *.nupkg blob.exe queue.exe table.exe",
     "nuget": "cross-var \"npm run clean && pkg -t node6-win --output blob bin/blob && pkg -t node6-win --output queue bin/queue && pkg -t node6-win --output table bin/table && nuget pack -Version $npm_package_version && nuget push *.nupkg  -Source https://www.nuget.org/api/v2/package\"",
     "docker": "cross-var \"docker build -t arafato/azurite:$npm_package_version . && docker build -t arafato/azurite:latest . && docker push arafato/azurite:$npm_package_version && docker push arafato/azurite:latest\""

--- a/test/01_Basic_table_Tests.js
+++ b/test/01_Basic_table_Tests.js
@@ -196,9 +196,8 @@ describe("Table HTTP Api tests", () => {
       );
     }
 
-    // this test performs a query, rather than a retrieve (which is just a different implementation via
-    // the SDK, but currently lands in the same place in our implementation which is using LokiJs)
-    it("should fail to find a non-existing entity with 404 EntityNotFound", (done) => {
+    // This test performs a query, rather than a retrieve.
+    it("should fail to find a non-existing entity with an empty result", (done) => {
       if (entity1Created === false) {
         const getE1 = setTimeout(() => {
           missingEntityFindTest(done);
@@ -217,11 +216,12 @@ describe("Table HTTP Api tests", () => {
       );
       faillingFindTableService.queryEntities(tableName, query, null, function(
         error,
-        result,
+        results,
         response
       ) {
-        expect(error.message).to.equal(EntityNotFoundErrorMessage);
-        expect(response.statusCode).to.equal(404);
+        expect(error).to.equal(null);
+        expect(results.entries.length).to.equal(0);
+        expect(response.statusCode).to.equal(200);
         cb();
       });
     }

--- a/test/01_Basic_table_Tests.js
+++ b/test/01_Basic_table_Tests.js
@@ -225,6 +225,34 @@ describe("Table HTTP Api tests", () => {
         cb();
       });
     }
+
+    it("should not fail when a query contains a backtick", (done) => {
+      if (entity1Created === false) {
+        setTimeout(() => {
+          backtickEntityFindTest(done);
+        }, 500);
+      } else {
+        backtickEntityFindTest(done);
+      }
+    });
+
+    function backtickEntityFindTest(cb) {
+      const query = new azureStorage.TableQuery()
+        .where("RowKey eq ?", "`");
+      const retrievalTableService = azureStorage.createTableService(
+        "UseDevelopmentStorage=true"
+      );
+      retrievalTableService.queryEntities(tableName, query, null, function(
+        error,
+        results,
+        response
+      ) {
+        expect(error).to.equal(null);
+        expect(results.entries.length).to.equal(0);
+        expect(response.statusCode).to.equal(200);
+        cb();
+      });
+    }
   });
 
   describe("PUT and Insert Table Entites", () => {


### PR DESCRIPTION
Fixes #117 and #120. For #117, I tested by manually querying using the following two URL patterns:

```
/TableName(PartitionKey='pk',RowKey='rk')
/TableName?$select=&$filter=PartitionKey eq 'pk' and RowKey eq 'rk'&$top=1000
```

This is my first time looking at both Azurite and the Azure Storage API. This is my best guess as to how the Azure Storage API behaves based purely on Fiddler traffic captures of the Azure Storage Explorer. Guidance is appreciated if there's a better method to debugging and fixing an issue like this.

I haven't yet looked at the Azurite test suite, but I'm guessing the second URL pattern isn't covered given it isn't working on the latest release. I'll try to amend this PR to include an additional test.

EDIT: I updated this PR to include a fix for #120 as the unit test behavior is also dependent on this specific response. The fix for #120 is to simply escape backticks.