### PR TITLE
Fixes incorrect handling of table management URLs

### DIFF
--- a/lib/routes/table/EntityRoute.js
+++ b/lib/routes/table/EntityRoute.js
@@ -15,7 +15,7 @@ const env = require("./../../core/env"),
 module.exports = (app) => {
   app
     .route(
-      new RegExp(`\/${env.emulatedStorageAccountName}\/(?![Tt][Aa][Bb][Ll][Ee][Ss])([A-Za-z0-9]+)(.*)`)
+      new RegExp(`\/${env.emulatedStorageAccountName}\/([A-Za-z0-9]+)(.*)`)
     )
     .get((req, res, next) => {
       if (req.azuriteOperation === undefined) {
@@ -50,18 +50,22 @@ module.exports = (app) => {
       next();
     })
     .delete((req, res, next) => {
-      req.azuriteOperation = Operations.DELETE_ENTITY;
-      req.azuriteRequest = new AzuriteTableRequest({ req: req });
+      if (req.azuriteOperation === undefined) {
+        req.azuriteOperation = Operations.DELETE_ENTITY;
+        req.azuriteRequest = new AzuriteTableRequest({ req: req });
+      }
       next();
     })
     .merge((req, res, next) => {
-      req.azuriteRequest = new AzuriteTableRequest({
-        req: req,
-        payload: req.payload,
-      });
-      req.azuriteOperation = req.azuriteRequest.httpProps[N.IF_MATCH]
-        ? Operations.MERGE_ENTITY
-        : Operations.INSERT_OR_MERGE_ENTITY;
+      if (req.azuriteOperation === undefined) {
+        req.azuriteRequest = new AzuriteTableRequest({
+          req: req,
+          payload: req.payload,
+        });
+        req.azuriteOperation = req.azuriteRequest.httpProps[N.IF_MATCH]
+          ? Operations.MERGE_ENTITY
+          : Operations.INSERT_OR_MERGE_ENTITY;
+      }
       next();
     });
 };

--- a/lib/routes/table/EntityRoute.js
+++ b/lib/routes/table/EntityRoute.js
@@ -15,7 +15,7 @@ const env = require("./../../core/env"),
 module.exports = (app) => {
   app
     .route(
-      new RegExp(`\/${env.emulatedStorageAccountName}\/([A-Za-z0-9]+)(.*)`)
+      new RegExp(`\/${env.emulatedStorageAccountName}\/(?![Tt][Aa][Bb][Ll][Ee][Ss])([A-Za-z0-9]+)(.*)`)
     )
     .get((req, res, next) => {
       if (req.azuriteOperation === undefined) {

--- a/lib/routes/table/TableRoute.js
+++ b/lib/routes/table/TableRoute.js
@@ -15,8 +15,10 @@ module.exports = (app) => {
   app
     .route(new RegExp(`\/${env.emulatedStorageAccountName}\/Tables(.*)`))
     .get((req, res, next) => {
-      req.azuriteOperation = Operations.QUERY_TABLE;
-      req.azuriteRequest = new AzuriteTableRequest({ req: req });
+      if (req.azuriteOperation === undefined) {
+        req.azuriteOperation = Operations.QUERY_TABLE;
+        req.azuriteRequest = new AzuriteTableRequest({ req: req });
+      }
       next();
     })
     .head((req, res, next) => {
@@ -26,16 +28,20 @@ module.exports = (app) => {
       next();
     })
     .post((req, res, next) => {
-      req.azuriteOperation = Operations.CREATE_TABLE;
-      req.azuriteRequest = new AzuriteTableRequest({
-        req: req,
-        payload: req.payload,
-      });
+      if (req.azuriteOperation === undefined) {
+        req.azuriteOperation = Operations.CREATE_TABLE;
+        req.azuriteRequest = new AzuriteTableRequest({
+          req: req,
+          payload: req.payload,
+        });
+      }
       next();
     })
     .delete((req, res, next) => {
-      req.azuriteOperation = Operations.DELETE_TABLE;
-      req.azuriteRequest = new AzuriteTableRequest({ req: req });
+      if (req.azuriteOperation === undefined) {
+        req.azuriteOperation = Operations.DELETE_TABLE;
+        req.azuriteRequest = new AzuriteTableRequest({ req: req });
+      }
       next();
     });
 };


### PR DESCRIPTION
While debugging, I noticed that some table operations were being incorrectly handled by both the `TableRoute` and `EntityRoute` handlers. For example, I encountered problems deleting tables using Azure Storage Explorer.

```
DELETE /Tables('Example')
```

On the first pass, the `TableRoute` handler correctly parsed the request as a `DELETE_TABLE` operation with a `AzuriteTableRequest.tableName` equal to "Example". However, the call to express's `next()` caused the request to flow to `EntityRoute`. On this second pass, the `EntityRoute` handler incorrectly parsed the request as a `DELETE_ENTITY` operation with a `AzuriteTableRequest.tableName` equal to "Tables". It was this second, incorrect request that was actually processed and resulted in an error (because a table named "Tables" didn't exist).

The issue stems from the overlap of RegExp matching of these two different URL patterns. (I noticed that the Blob and Queue endpoints don't have this same issue.) I'm was able to quickly fix and test this solution with Azure Storage Explorer and a C# client. I'm not well versed in express, feedback welcome if there's a better approach!