### PR TITLE
Update etag generation and matching in Table Service

### DIFF
--- a/lib/AzuriteTable.js
+++ b/lib/AzuriteTable.js
@@ -54,6 +54,7 @@ class AzuriteTable {
         require("./routes/table/EntityRoute")(app);
         app.use(require("./middleware/table/validation"));
         app.use(require("./middleware/table/actions"));
+        app.set('etag', false); // turn generated etag off
         this.server = app.listen(env.tableStoragePort, () => {
           if (!env.silent) {
             cli.tableStorageStatus();

--- a/lib/actions/table/InsertEntity.js
+++ b/lib/actions/table/InsertEntity.js
@@ -21,6 +21,8 @@ class InsertEntity {
             etag: response.proxy.etag,
           },
         });
+        response.addHttpProperty(N.ETAG, response.proxy.etag);
+        res.set(response.httpProps);
         res.status(204).send(payload);
       } else {
         const payload = Object.assign(

--- a/lib/actions/table/UpdateEntity.js
+++ b/lib/actions/table/UpdateEntity.js
@@ -12,6 +12,7 @@ class UpdateEntity {
 
   process(request, res) {
     tableStorageManager.updateEntity(request).then((response) => {
+      response.addHttpProperty(N.ETAG, response.proxy.etag);
       res.set(response.httpProps);
       res.status(204).send();
     });

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -2,12 +2,6 @@
 
 "use strict";
 
-const crypto = require("crypto");
-
 exports.computeEtag = (templateString) => {
-  return crypto
-    .createHash("sha1")
-    .update(templateString, "utf8")
-    .digest("base64")
-    .replace(/=+$/, "");
+  return `W/\"datetime'${encodeURIComponent(templateString)}'\"`;
 };

--- a/lib/model/table/EntityGenerator.js
+++ b/lib/model/table/EntityGenerator.js
@@ -60,7 +60,7 @@ class EntityGenerator {
     entity.odata.editLink = `${tableName}(PartitionKey='${
       rawEntity.PartitionKey
     }',RowKey='${rawEntity.RowKey}')`;
-    entity.odata.etag = etag(JSON.stringify(rawEntity));
+    entity.odata.etag = etag(entity.attribs.Timestamp);
     return entity;
   }
 }

--- a/lib/model/table/EntityProxy.js
+++ b/lib/model/table/EntityProxy.js
@@ -11,7 +11,7 @@ class EntityProxy extends BaseProxy {
     super(entity);
     this.partitionKey = entity.partitionKey;
     this.rowKey = entity.rowKey;
-    this.etag = `\"${entity.odata.etag}\"`;
+    this.etag = `${entity.odata.etag}`;
   }
 
   /**

--- a/lib/validation/table/EntityIfMatch.js
+++ b/lib/validation/table/EntityIfMatch.js
@@ -16,6 +16,22 @@ class EntityIfMatch {
     if (request.httpProps[N.IF_MATCH] === "*") {
       return;
     }
+    var etag = request.httpProps[N.IF_MATCH];
+    if (etag.includes("datetime")) {
+      // Clients use the entity's timestamp as etag when entities are queried
+      // with no or minimal metadata. If that's the case match against the 
+      // Timestamp attribute.
+      var match = /W\/"datetime'(.*)'"/.exec(etag);
+      if (match !== null) {
+        var etagTimestamp = Date.parse(decodeURIComponent(match[1]));
+        var entityTimestamp = Date.parse(entity._.attribs.Timestamp);
+        if (etagTimestamp == entityTimestamp) {
+          return;
+        }
+
+        throw new AError(ErrorCodes.UpdateConditionNotSatisfied);
+      }
+    }
     if (request.httpProps[N.IF_MATCH] !== entity._.etag) {
       throw new AError(ErrorCodes.UpdateConditionNotSatisfied);
     }

--- a/test/01_Basic_table_Tests.js
+++ b/test/01_Basic_table_Tests.js
@@ -64,15 +64,15 @@ describe("Table HTTP Api tests", () => {
       //.then(() => tableService.createTableIfNotExists(tableName, function (error, result, response) {
       // would be better to use "createTableIfNotExists" but we may need to make changes server side for this to work
       .then(() =>
-        tableService.createTable(tableName, function(error, result, response) {
-          tableService.insertEntity(tableName, tableEntity1, function(
+        tableService.createTable(tableName, function (error, result, response) {
+          tableService.insertEntity(tableName, tableEntity1, function (
             error,
             result,
             response
           ) {
             if (error === null) {
               entity1Created = true;
-              tableService.insertEntity(tableName, tableEntity2, function(
+              tableService.insertEntity(tableName, tableEntity2, function (
                 error,
                 result,
                 response
@@ -126,7 +126,7 @@ describe("Table HTTP Api tests", () => {
         tableName,
         partitionKeyForTest,
         rowKeyForTestEntity1,
-        function(error, result, response) {
+        function (error, result, response) {
           expect(error).to.equal(null);
           expect(result).to.not.equal(undefined);
           expect(result).to.not.equal(null);
@@ -146,7 +146,7 @@ describe("Table HTTP Api tests", () => {
       const retrievalTableService = azureStorage.createTableService(
         "UseDevelopmentStorage=true"
       );
-      retrievalTableService.queryEntities(tableName, query, null, function(
+      retrievalTableService.queryEntities(tableName, query, null, function (
         error,
         results,
         response
@@ -188,7 +188,7 @@ describe("Table HTTP Api tests", () => {
         tableName,
         partitionKeyForTest,
         "unknownRowKey",
-        function(error, result, response) {
+        function (error, result, response) {
           expect(error.message).to.equal(EntityNotFoundErrorMessage);
           expect(response.statusCode).to.equal(404);
           cb();
@@ -215,7 +215,7 @@ describe("Table HTTP Api tests", () => {
       const faillingFindTableService = azureStorage.createTableService(
         "UseDevelopmentStorage=true"
       );
-      faillingFindTableService.queryEntities(tableName, query, null, function(
+      faillingFindTableService.queryEntities(tableName, query, null, function (
         error,
         result,
         response
@@ -225,10 +225,32 @@ describe("Table HTTP Api tests", () => {
         cb();
       });
     }
+
+    it("should not have an ETag header", (done) => {
+      const retrievalTableService = azureStorage.createTableService(
+        "UseDevelopmentStorage=true"
+      );
+      retrievalTableService.retrieveEntity(
+        tableName,
+        partitionKeyForTest,
+        rowKeyForTestEntity1,
+        function (error, result, response) {
+          expect(response.headers).not.to.have.property("etag");
+          const query = new azureStorage.TableQuery();
+          retrievalTableService.queryEntities(tableName, query, null, function (
+            error,
+            results,
+            response
+          ) {
+            expect(response.headers).not.to.have.property("etag");
+            done();
+          });
+        });
+    });
   });
 
   describe("PUT and Insert Table Entites", () => {
-    it("should return a valid object in the result object when creating an Entity in TableStorage using return no content", (done) => {
+    it("should have an ETag response header", (done) => {
       const insertEntityTableService = azureStorage.createTableService(
         "UseDevelopmentStorage=true"
       );
@@ -246,12 +268,222 @@ describe("Table HTTP Api tests", () => {
         {
           echoContent: false,
         },
-        function(error, result, response) {
+        function (error, result, response) {
+          expect(response.headers).to.have.property("etag");
+          done();
+        }
+      );
+    });
+
+    it("should return a valid object in the result object when creating an Entity in TableStorage using return no content", (done) => {
+      const insertEntityTableService = azureStorage.createTableService(
+        "UseDevelopmentStorage=true"
+      );
+      const insertionEntity = {
+        PartitionKey: entGen.String(partitionKeyForTest),
+        RowKey: entGen.String("5"),
+        description: entGen.String("qux"),
+        dueDate: entGen.DateTime(new Date(Date.UTC(2018, 12, 26))),
+      };
+
+      // Request is made by default with "return-no-content" when using the storage-sdk
+      insertEntityTableService.insertEntity(
+        tableName,
+        insertionEntity,
+        {
+          echoContent: false,
+        },
+        function (error, result, response) {
+          if (error !== null) {
+            throw error;
+          }
           // etag format is currently different to that returned from Azure and x-ms-version 2018-03-28
           expect(response.statusCode).to.equal(204);
           expect(result).to.not.equal(undefined);
-          expect(result[".metadata"].etag).to.not.equal(undefined);
+          expect(result).to.have.property(".metadata");
+          expect(result[".metadata"]).to.have.property("etag");
           done();
+        }
+      );
+    });
+  });
+
+  describe("PUT and Replace Entity operations", (done) => {
+    it("should have an ETag response header", (done) => {
+      const retrievalTableService = azureStorage.createTableService(
+        "UseDevelopmentStorage=true"
+      );
+      retrievalTableService.retrieveEntity(
+        tableName,
+        partitionKeyForTest,
+        rowKeyForTestEntity1,
+        function (error, result, response) {
+          if (error !== null) {
+            throw error;
+          }
+          retrievalTableService.replaceEntity(
+            tableName,
+            result,
+            function (error, result, response) {
+              if (error !== null) {
+                throw error;
+              }
+              expect(response.statusCode).to.be.equal(204);
+              expect(response.headers).to.have.property("etag");
+              done();
+            }
+          );
+        });
+    });
+    it("should fail if If-Match header doesn't match entity's etag", (done) => {
+      const updateEntityTableService = azureStorage.createTableService(
+        "UseDevelopmentStorage=true"
+      );
+
+      updateEntityTableService.retrieveEntity(
+        tableName,
+        partitionKeyForTest,
+        rowKeyForTestEntity1,
+        function (error, result, response) {
+          expect(error).to.equal(null);
+
+          result[".metadata"].etag = "W/\"newvalue\"";
+
+          updateEntityTableService.replaceEntity(
+            tableName,
+            result,
+            function (error, result, response) {
+              expect(response.statusCode).to.equal(412); // invalid pre-condition
+              done();
+            }
+          )
+        }
+      )
+    });
+    it("should return 204 if If-Match header matches entity's etag", (done) => {
+      const updateEntityTableService = azureStorage.createTableService(
+        "UseDevelopmentStorage=true"
+      );
+
+      updateEntityTableService.retrieveEntity(
+        tableName,
+        partitionKeyForTest,
+        rowKeyForTestEntity1,
+        function (error, result, response) {
+          expect(error).to.equal(null);
+          updateEntityTableService.replaceEntity(
+            tableName,
+            result,
+            function (error, result, response) {
+              expect(response.statusCode).to.equal(204); // no-content
+              done();
+            }
+          )
+        }
+      )
+    });
+  });
+
+  describe("PUT and Insert Or Replace Entity", (done) => {
+    it("should have an ETag response header", (done) => {
+      const retrievalTableService = azureStorage.createTableService(
+        "UseDevelopmentStorage=true"
+      );
+      retrievalTableService.retrieveEntity(
+        tableName,
+        partitionKeyForTest,
+        rowKeyForTestEntity1,
+        function (error, result, response) {
+          retrievalTableService.insertOrReplaceEntity(
+            tableName,
+            result,
+            function (error, result, response) {
+              expect(response.headers).to.have.property("etag");
+              done();
+            }
+          );
+        });
+    });
+  });
+
+  describe("MERGE and Merge Entity operations", (done) => {
+    it("should have an ETag response header", (done) => {
+      const mergeTableService = azureStorage.createTableService(
+        "UseDevelopmentStorage=true"
+      );
+      mergeTableService.retrieveEntity(
+        tableName,
+        partitionKeyForTest,
+        rowKeyForTestEntity1,
+        function (error, result, response) {
+          mergeTableService.mergeEntity(
+            tableName,
+            result,
+            function (error, result, response) {
+              expect(response.headers).to.have.property("etag");
+              done();
+            }
+          );
+        });
+    });
+  });
+
+  describe("MERGE and Merge Or Replace Entity", (done) => {
+    it("should have an ETag response header", (done) => {
+      const mergeTableService = azureStorage.createTableService(
+        "UseDevelopmentStorage=true"
+      );
+      mergeTableService.retrieveEntity(
+        tableName,
+        partitionKeyForTest,
+        rowKeyForTestEntity1,
+        function (error, result, response) {
+          mergeTableService.insertOrMergeEntity(
+            tableName,
+            result,
+            function (error, result, response) {
+              expect(response.headers).to.have.property("etag");
+              done();
+            }
+          );
+        });
+    });
+  });
+
+  describe("DELETE and Delete Entity operations", (done) => {
+    it("should not have an ETag response header", (done) => {
+      const deleteTableService = azureStorage.createTableService(
+        "UseDevelopmentStorage=true"
+      );
+
+      const tempEntity = {
+        PartitionKey: entGen.String(partitionKeyForTest),
+        RowKey: entGen.String("4"),
+        description: entGen.String("qux"),
+        dueDate: entGen.DateTime(new Date(Date.UTC(2018, 12, 26))),
+      };
+
+      // Request is made by default with "return-no-content" when using the storage-sdk
+      deleteTableService.insertEntity(
+        tableName,
+        tempEntity,
+        {
+          echoContent: false,
+        },
+        function (error, result, response) {
+          if (error !== null) {
+            throw error;
+          }
+          deleteTableService.deleteEntity(
+            tableName,
+            tempEntity,
+            function (error, response) {
+              if (error !== null) {
+                throw error;
+              }
+              expect(response.headers).to.not.have.property("etag");
+              done();
+            });
         }
       );
     });


### PR DESCRIPTION
Picks up changes from @michaelkruglos, but extends those in the following way:

* Disable express' etag generation
* Update entity operations to emit etag according to spec
* Update `EntityIfMatch` to match timestamp instead of etag
* Add tests
* Fixes #95