### PR TITLE
Add container lease feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -265,6 +265,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -991,7 +992,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.2",
@@ -1763,6 +1765,7 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3055,7 +3058,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "stack-trace": {
       "version": "0.0.10",

--- a/src/blob/errors/StorageError.ts
+++ b/src/blob/errors/StorageError.ts
@@ -29,7 +29,7 @@ export default class StorageError extends MiddlewareError {
   ) {
     const bodyInJSON: any = {
       Code: storageErrorCode,
-      Message: `${storageErrorMessage} RequestId:${storageRequestID} Time:${new Date().toISOString()}`,
+      Message: `${storageErrorMessage}\nRequestId:${storageRequestID}\nTime:${new Date().toISOString()}`
     };
 
     for (const key in storageAdditionalErrorMessages) {
@@ -47,7 +47,7 @@ export default class StorageError extends MiddlewareError {
       undefined,
       {
         "x-ms-error-code": storageErrorCode,
-        "x-ms-request-id": storageRequestID,
+        "x-ms-request-id": storageRequestID
       },
       bodyInXML,
       "application/xml"

--- a/src/blob/errors/StorageErrorFactory.ts
+++ b/src/blob/errors/StorageErrorFactory.ts
@@ -58,4 +58,90 @@ export default class StorageErrorFactory {
       contextID
     );
   }
+
+  public static getContainerInvalidLeaseDuration(
+    contextID: string
+  ): StorageError {
+    return new StorageError(
+      400,
+      "InvalidLeaseDuration",
+      "The LeaseDuration is invalid, it must between 15 and 60 seconds.",
+      contextID
+    );
+  }
+
+  public static getContainerLeaseAlreadyPresent(
+    contextID: string
+  ): StorageError {
+    return new StorageError(
+      409,
+      "LeaseAlreadyPresent",
+      "There is already a lease present.",
+      contextID
+    );
+  }
+
+  public static getContainerLeaseNotPresentWithLeaseOperation(
+    contextID: string
+  ): StorageError {
+    return new StorageError(
+      409,
+      "LeaseNotPresentWithLeaseOperation",
+      "There is currently no lease on the container.",
+      contextID
+    );
+  }
+
+  public static getContainerLeaseIdMismatchWithLeaseOperation(
+    contextID: string
+  ): StorageError {
+    return new StorageError(
+      409,
+      "LeaseIdMismatchWithLeaseOperation",
+      "The lease ID specified did not match the lease ID for the container.",
+      contextID
+    );
+  }
+
+  public static getContainerLeaseIsBrokenAndCannotBeRenewed(
+    contextID: string
+  ): StorageError {
+    return new StorageError(
+      409,
+      "LeaseIsBrokenAndCannotBeRenewed",
+      "The lease ID matched, but the lease has been broken explicitly and cannot be renewed.",
+      contextID
+    );
+  }
+
+  public static getContainerLeaseIsBreakingAndCannotBeChanged(
+    contextID: string
+  ): StorageError {
+    return new StorageError(
+      409,
+      "LeaseIsBreakingAndCannotBeChanged",
+      "The lease ID matched, but the lease is currently in breaking state and cannot be changed.",
+      contextID
+    );
+  }
+
+  public static getContainerLeaseIdMissing(contextID: string): StorageError {
+    return new StorageError(
+      412,
+      "LeaseIdMissing",
+      "There is currently a lease on the container and no lease ID was specified in the request.",
+      contextID
+    );
+  }
+
+  public static getContainerLeaseIdMismatchWithContainerOperation(
+    contextID: string
+  ): StorageError {
+    return new StorageError(
+      412,
+      "LeaseIdMismatchWithContainerOperation",
+      "The lease ID specified did not match the lease ID for the container.",
+      contextID
+    );
+  }
 }

--- a/src/blob/generated/utils/serializer.ts
+++ b/src/blob/generated/utils/serializer.ts
@@ -10,8 +10,8 @@ export declare type ParameterPath =
   | string
   | string[]
   | {
-      [propertyName: string]: ParameterPath;
-    };
+    [propertyName: string]: ParameterPath;
+  };
 
 export async function deserialize(
   req: IRequest,
@@ -66,7 +66,7 @@ export async function deserialize(
     const headerCollectionPrefix:
       | string
       | undefined = (headerParameter.mapper as msRest.DictionaryMapper)
-      .headerCollectionPrefix;
+        .headerCollectionPrefix;
     if (headerCollectionPrefix) {
       const dictionary: any = {};
       const headers = req.getHeaders();
@@ -263,7 +263,7 @@ export async function serialize(
             }
           }
         } else {
-          if (headerName && headerValueSerialized) {
+          if (headerName && headerValueSerialized !== undefined) {
             res.setHeader(headerName, headerValueSerialized);
           }
         }

--- a/src/blob/persistence/IBlobDataStore.ts
+++ b/src/blob/persistence/IBlobDataStore.ts
@@ -27,6 +27,10 @@ export type ServicePropertiesModel = Models.StorageServiceProperties &
 /** MODELS FOR CONTAINER */
 interface IContainerAdditionalProperties {
   accountName: string;
+  leaseduration?: number;
+  leaseId?: string;
+  leaseExpireTime?: Date;
+  leaseBreakExpireTime?: Date;
 }
 
 export type ContainerModel = Models.ContainerItem &

--- a/tests/testutils.ts
+++ b/tests/testutils.ts
@@ -88,6 +88,12 @@ export async function bodyToString(
   });
 }
 
+export async function sleep(time: number): Promise<void> {
+  return new Promise<void>(resolve => {
+    setTimeout(resolve, time);
+  });
+}
+
 export function base64encode(content: string): string {
   return Buffer.from(content).toString("base64");
 }


### PR DESCRIPTION
New Implemented APIs: 
•	ContainerHandler.acquireLease()
•	ContainerHandler.releaseLease()
•	ContainerHandler.renewLease()
•	ContainerHandler.breakLease()
•	ContainerHandler.changeLease()

Updated APIs:
•	ContainerHandler.Delete()
o	It will be blocked on a container which is in lease blocked status
•	ContainerHandler. getProperties()
o	Will return the correct lease status.

API pending update:
•	For all other API that will return container properties, like list container, need update the lease status. 
o	@XiaoningLiu , I have added a function to update the lease status of a container: ContainerHandler.updateLeaseAttributes(). As we talked, you will add it to related APIs.

Test:
•	Added all lease cases (5) from https://github.com/Azure/azure-storage-js/blob/master/blob/tests/containerurl.test.ts, all these cases passed. 	
