### PR TITLE
Implement Blob Lease

### DIFF
--- a/src/blob/errors/StorageErrorFactory.ts
+++ b/src/blob/errors/StorageErrorFactory.ts
@@ -59,20 +59,34 @@ export default class StorageErrorFactory {
     );
   }
 
-  public static getContainerInvalidLeaseDuration(
-    contextID: string
-  ): StorageError {
+  public static getInvalidLeaseDuration(contextID: string): StorageError {
     return new StorageError(
       400,
-      "InvalidLeaseDuration",
-      "The LeaseDuration is invalid, it must between 15 and 60 seconds.",
+      "InvalidHeaderValue",
+      "The value for one of the HTTP headers is not in the correct format.",
       contextID
     );
   }
 
-  public static getContainerLeaseAlreadyPresent(
-    contextID: string
-  ): StorageError {
+  public static getInvalidLeaseBreakPeriod(contextID: string): StorageError {
+    return new StorageError(
+      400,
+      "InvalidHeaderValue",
+      "The value for one of the HTTP headers is not in the correct format.",
+      contextID
+    );
+  }
+
+  public static getInvalidId(contextID: string): StorageError {
+    return new StorageError(
+      400,
+      "InvalidHeaderValue",
+      "The value for one of the HTTP headers is not in the correct format.",
+      contextID
+    );
+  }
+
+  public static getLeaseAlreadyPresent(contextID: string): StorageError {
     return new StorageError(
       409,
       "LeaseAlreadyPresent",
@@ -103,7 +117,7 @@ export default class StorageErrorFactory {
     );
   }
 
-  public static getContainerLeaseIsBrokenAndCannotBeRenewed(
+  public static getLeaseIsBrokenAndCannotBeRenewed(
     contextID: string
   ): StorageError {
     return new StorageError(
@@ -114,7 +128,7 @@ export default class StorageErrorFactory {
     );
   }
 
-  public static getContainerLeaseIsBreakingAndCannotBeChanged(
+  public static getLeaseIsBreakingAndCannotBeChanged(
     contextID: string
   ): StorageError {
     return new StorageError(
@@ -141,6 +155,76 @@ export default class StorageErrorFactory {
       412,
       "LeaseIdMismatchWithContainerOperation",
       "The lease ID specified did not match the lease ID for the container.",
+      contextID
+    );
+  }
+
+  public static getContainerLeaseLost(contextID: string): StorageError {
+    return new StorageError(
+      412,
+      "LeaseLost",
+      "A lease ID was specified, but the lease for the container has expired.",
+      contextID
+    );
+  }
+
+  public static getBlobLeaseIdMismatchWithLeaseOperation(
+    contextID: string
+  ): StorageError {
+    return new StorageError(
+      409,
+      "LeaseIdMismatchWithLeaseOperation",
+      "The lease ID specified did not match the lease ID for the blob.",
+      contextID
+    );
+  }
+
+  public static getBlobLeaseNotPresentWithLeaseOperation(
+    contextID: string
+  ): StorageError {
+    return new StorageError(
+      409,
+      "LeaseNotPresentWithLeaseOperation",
+      "There is currently no lease on the blob.",
+      contextID
+    );
+  }
+
+  // The error code/message need check with server
+  public static getBlobLeaseOnSnapshot(contextID: string): StorageError {
+    return new StorageError(
+      400,
+      "SnapshotsPresent",
+      "This operation is not permitted because the blob is snapshot.",
+      contextID
+    );
+  }
+
+  public static getBlobLeaseIdMissing(contextID: string): StorageError {
+    return new StorageError(
+      412,
+      "LeaseIdMissing",
+      "There is currently a lease on the blob and no lease ID was specified in the request.",
+      contextID
+    );
+  }
+
+  public static getBlobLeaseIdMismatchWithBlobOperation(
+    contextID: string
+  ): StorageError {
+    return new StorageError(
+      412,
+      "LeaseIdMismatchWithBlobOperation ",
+      "The lease ID specified did not match the lease ID for the blob.",
+      contextID
+    );
+  }
+
+  public static getBlobLeaseLost(contextID: string): StorageError {
+    return new StorageError(
+      412,
+      "LeaseLost ",
+      "A lease ID was specified, but the lease for the blob has expired.",
       contextID
     );
   }

--- a/src/blob/handlers/AppendBlobHandler.ts
+++ b/src/blob/handlers/AppendBlobHandler.ts
@@ -20,6 +20,7 @@ export default class AppendBlobHandler extends BaseHandler
     options: Models.AppendBlobAppendBlockOptionalParams,
     context: Context
   ): Promise<Models.AppendBlobAppendBlockResponse> {
+    // TODO: Check Lease status, and set to available if it's expired, see sample in BlobHandler.setMetadata()
     throw new NotImplementedError(context.contextID);
   }
 }

--- a/src/blob/handlers/ServiceHandler.ts
+++ b/src/blob/handlers/ServiceHandler.ts
@@ -177,6 +177,7 @@ export default class ServiceHandler extends BaseHandler
       marker
     );
 
+    // TODO: Need update list out container lease properties with ContainerHandler.updateLeaseAttributes()
     const serviceEndpoint = `${request.getEndpoint()}/${accountName}`;
     const res: Models.ServiceListContainersSegmentResponse = {
       containerItems: containers[0],

--- a/src/blob/persistence/IBlobDataStore.ts
+++ b/src/blob/persistence/IBlobDataStore.ts
@@ -65,6 +65,10 @@ interface IBlockBlobAdditionalProperties {
    * @memberof IBlobAdditionalProperties
    */
   isCommitted: boolean;
+  leaseduration?: number;
+  leaseId?: string;
+  leaseExpireTime?: Date;
+  leaseBreakExpireTime?: Date;
 
   /**
    * Committed blocks for block blob.

--- a/tests/blob/apis/blob.test.ts
+++ b/tests/blob/apis/blob.test.ts
@@ -16,7 +16,8 @@ import {
   EMULATOR_ACCOUNT_KEY,
   EMULATOR_ACCOUNT_NAME,
   getUniqueName,
-  rmRecursive
+  rmRecursive,
+  sleep
 } from "../../testutils";
 
 describe("BlobAPIs", () => {
@@ -103,5 +104,128 @@ describe("BlobAPIs", () => {
     await blobURL.setMetadata(Aborter.none, metadata);
     const result = await blobURL.getProperties(Aborter.none);
     assert.deepStrictEqual(result.metadata, metadata);
+  });
+
+  it("acquireLease_available_proposedLeaseId_fixed", async () => {
+    const guid = "ca761232ed4211cebacd00aa0057b223";
+    const duration = 30;
+    await blobURL.acquireLease(Aborter.none, guid, duration);
+
+    const result = await blobURL.getProperties(Aborter.none);
+    assert.equal(result.leaseDuration, "fixed");
+    assert.equal(result.leaseState, "leased");
+    assert.equal(result.leaseStatus, "locked");
+
+    await blobURL.releaseLease(Aborter.none, guid);
+  });
+
+  it("acquireLease_available_NoproposedLeaseId_infinite", async () => {
+    const leaseResult = await blobURL.acquireLease(Aborter.none, "", -1);
+    const leaseId = leaseResult.leaseId;
+    assert.ok(leaseId);
+
+    const result = await blobURL.getProperties(Aborter.none);
+    assert.equal(result.leaseDuration, "infinite");
+    assert.equal(result.leaseState, "leased");
+    assert.equal(result.leaseStatus, "locked");
+
+    await blobURL.releaseLease(Aborter.none, leaseId!);
+  });
+
+  it("releaseLease", async () => {
+    const guid = "ca761232ed4211cebacd00aa0057b223";
+    const duration = -1;
+    await blobURL.acquireLease(Aborter.none, guid, duration);
+
+    let result = await blobURL.getProperties(Aborter.none);
+    assert.equal(result.leaseDuration, "infinite");
+    assert.equal(result.leaseState, "leased");
+    assert.equal(result.leaseStatus, "locked");
+
+    await blobURL.releaseLease(Aborter.none, guid);
+    result = await blobURL.getProperties(Aborter.none);
+    assert.equal(result.leaseDuration, undefined);
+    assert.equal(result.leaseState, "available");
+    assert.equal(result.leaseStatus, "unlocked");
+  });
+
+  it("renewLease", async () => {
+    const guid = "ca761232ed4211cebacd00aa0057b223";
+    const duration = 15;
+    await blobURL.acquireLease(Aborter.none, guid, duration);
+
+    const result = await blobURL.getProperties(Aborter.none);
+    assert.equal(result.leaseDuration, "fixed");
+    assert.equal(result.leaseState, "leased");
+    assert.equal(result.leaseStatus, "locked");
+
+    await sleep(16 * 1000);
+    const result2 = await blobURL.getProperties(Aborter.none);
+    assert.ok(!result2.leaseDuration);
+    assert.equal(result2.leaseState, "expired");
+    assert.equal(result2.leaseStatus, "unlocked");
+
+    await blobURL.renewLease(Aborter.none, guid);
+    const result3 = await blobURL.getProperties(Aborter.none);
+    assert.equal(result3.leaseDuration, "fixed");
+    assert.equal(result3.leaseState, "leased");
+    assert.equal(result3.leaseStatus, "locked");
+
+    await blobURL.releaseLease(Aborter.none, guid);
+  });
+
+  it("changeLease", async () => {
+    const guid = "ca761232ed4211cebacd00aa0057b223";
+    const duration = 15;
+    await blobURL.acquireLease(Aborter.none, guid, duration);
+
+    const result = await blobURL.getProperties(Aborter.none);
+    assert.equal(result.leaseDuration, "fixed");
+    assert.equal(result.leaseState, "leased");
+    assert.equal(result.leaseStatus, "locked");
+
+    const newGuid = "3c7e72ebb4304526bc53d8ecef03798f";
+    await blobURL.changeLease(Aborter.none, guid, newGuid);
+
+    await blobURL.getProperties(Aborter.none);
+    await blobURL.releaseLease(Aborter.none, newGuid);
+  });
+
+  it("breakLease", async () => {
+    const guid = "ca761232ed4211cebacd00aa0057b223";
+    const duration = 15;
+    await blobURL.acquireLease(Aborter.none, guid, duration);
+
+    const result = await blobURL.getProperties(Aborter.none);
+    assert.equal(result.leaseDuration, "fixed");
+    assert.equal(result.leaseState, "leased");
+    assert.equal(result.leaseStatus, "locked");
+
+    const breakDuration = 3;
+    let breaklefttime = breakDuration;
+    while (breaklefttime > 0) {
+      const breakResult = await blobURL.breakLease(Aborter.none, breakDuration);
+
+      assert.equal(breakResult.leaseTime! <= breaklefttime, true);
+      breaklefttime = breakResult.leaseTime!;
+
+      const result2 = await blobURL.getProperties(Aborter.none);
+      assert.ok(!result2.leaseDuration);
+      assert.equal(result2.leaseState, "breaking");
+      assert.equal(result2.leaseStatus, "locked");
+
+      await sleep(500);
+    }
+
+    const result3 = await blobURL.getProperties(Aborter.none);
+    assert.ok(!result3.leaseDuration);
+    assert.equal(result3.leaseState, "broken");
+    assert.equal(result3.leaseStatus, "unlocked");
+
+    await blobURL.releaseLease(Aborter.none, guid);
+    const result4 = await blobURL.getProperties(Aborter.none);
+    assert.equal(result4.leaseDuration, undefined);
+    assert.equal(result4.leaseState, "available");
+    assert.equal(result4.leaseStatus, "unlocked");
   });
 });


### PR DESCRIPTION
Please note, it’s still not well tested (only unit test pass), so the PR is only for code review. 
**Please don’t merge.**
I will continue test and refine it.

New Implemented APIs: 
•	BlobHandler.acquireLease()
•	BlobHandler.releaseLease()
•	BlobHandler.renewLease()
•	BlobHandler.breakLease()
•	BlobHandler.changeLease()

Updated APIs:
•	BlobHandler. getProperties()
o	Will return the correct lease status.

•	Per the doc, we need to check lease ID (and set lease state to available on lease expired blob), when write blob. Related Blob APIs:
o	(Updated)Has add code to do lease check and lease status change:
	SetBlobMetadata (BlobHandler.setMetadata)
	DeleteBlob(BlobHandler,delete)
	PutBlockList (BlockBlobHandler.commitBlockList)
	PutPage(uploadPages)
o	(Add comment)Add comments TODO the lease work
	SetBlobProperties (BlobHandler.setHTTPHeaders)
	CopyBlob (BlobHandler.startCopyFromURL)
o	(Pending Update)Don’t find which API should be change:
	PutBlob
	PutBlock
	AppendBlock 


API pending update:
•	Many of the write blob API need update for check blob lease and update blob lease state
o	I have added 2 functions: BlobHandler.checkBlobLeaseOnWriteBlob (), BlobHandler.UpdateBlobLeaseStateOnWriteBlob()
•	For all API that will return blob properties (except getproperties which already implemented), like list blob, need update the lease status. 
o	I have added a function : BlobHandler.updateLeaseAttributes()

Test:
•	Added all lease cases (5) from https://raw.githubusercontent.com/Azure/azure-storage-js/master/blob/tests/bloburl.test.ts , all these cases passed.    
•	Per my understanding of lease, to test the lease status change, we might need to add another ~30 cases besides the current ones. 