### PR TITLE
Snapshot implementation for #190

### DIFF
--- a/src/blob/handlers/BlobHandler.ts
+++ b/src/blob/handlers/BlobHandler.ts
@@ -757,6 +757,7 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
 
   /**
    * create snapshot
+   * https://docs.microsoft.com/en-us/rest/api/storageservices/snapshot-blob
    *
    * @param {Models.BlobCreateSnapshotOptionalParams} options
    * @param {Context} context
@@ -767,7 +768,21 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
     options: Models.BlobCreateSnapshotOptionalParams,
     context: Context
   ): Promise<Models.BlobCreateSnapshotResponse> {
-    throw new NotImplementedError(context.contextID);
+    const blob = await this.getSimpleBlobFromStorage(context);
+
+    const snapshotResult = await this.dataStore.snapshotBlob(blob);
+
+    const response: Models.BlobCreateSnapshotResponse = {
+      statusCode: 201,
+      eTag: snapshotResult.properties.etag,
+      lastModified: snapshotResult.properties.lastModified,
+      requestId: context.contextID,
+      date: context.startTime!,
+      version: API_VERSION,
+      snapshot: snapshotResult.snapshot
+    };
+
+    return response;
   }
 
   /**

--- a/src/blob/handlers/ContainerHandler.ts
+++ b/src/blob/handlers/ContainerHandler.ts
@@ -686,13 +686,19 @@ export default class ContainerHandler extends BaseHandler
     const delimiter = "";
     options.prefix = ""; // we do not support a prefix for the flat list
     options.marker = options.marker || "";
-
+    let includeSnapshots: boolean = false;
+    if (options.include !== undefined) {
+      if (options.include.includes(Models.ListBlobsIncludeItem.Snapshots)) {
+        includeSnapshots = true;
+      }
+    }
     const [blobs, nextMarker] = await this.dataStore.listBlobs(
       accountName,
       containerName,
       options.prefix,
       options.maxresults,
-      marker
+      marker,
+      includeSnapshots
     );
 
     const blobItems: Models.BlobItem[] = [];

--- a/src/blob/handlers/ContainerHandler.ts
+++ b/src/blob/handlers/ContainerHandler.ts
@@ -756,13 +756,19 @@ export default class ContainerHandler extends BaseHandler
     const marker = parseInt(options.marker || "0", 10);
     options.prefix = options.prefix || "";
     options.marker = options.marker || "";
-
+    let includeSnapshots: boolean = false;
+    if (options.include !== undefined) {
+      if (options.include.includes(Models.ListBlobsIncludeItem.Snapshots)) {
+        includeSnapshots = true;
+      }
+    }
     const [blobs, nextMarker] = await this.dataStore.listBlobs(
       accountName,
       containerName,
       options.prefix,
       options.maxresults,
-      marker
+      marker,
+      includeSnapshots
     );
 
     const blobItems: Models.BlobItem[] = [];

--- a/src/blob/persistence/IBlobDataStore.ts
+++ b/src/blob/persistence/IBlobDataStore.ts
@@ -236,6 +236,7 @@ export interface IBlobDataStore extends IDataStore {
    * @param {string} [prefix]
    * @param {number} [maxResults]
    * @param {number} [marker]
+   * @param {boolean} [includeSnapshots]
    * @returns {(Promise<[T[], number | undefined]>)} A tuple including list blobs and next marker.
    * @memberof IBlobDataStore
    */
@@ -244,7 +245,8 @@ export interface IBlobDataStore extends IDataStore {
     container?: string,
     prefix?: string,
     maxResults?: number,
-    marker?: number
+    marker?: number,
+    includeSnapshots?: boolean
   ): Promise<[T[], number | undefined]>;
 
   /**
@@ -396,6 +398,17 @@ export interface IBlobDataStore extends IDataStore {
    * @memberof IBlobDataStore
    */
   iteratorReferredExtents(): AsyncIterator<IPersistencyChunk[]>;
+
+  /**
+   * Create a snapshot of a blob in the blobs collection
+   * Returned object will contain a snapshot property which can be used to find / get the snapshot
+   *
+   * @template T
+   * @param {T} blob
+   * @returns {Promise<T>}
+   * @memberof IBlobDataStore
+   */
+  snapshotBlob<T extends BlobModel>(blob: T): Promise<T>;
 }
 
 export default IBlobDataStore;

--- a/src/blob/persistence/LokiBlobDataStore.ts
+++ b/src/blob/persistence/LokiBlobDataStore.ts
@@ -415,8 +415,8 @@ export default class LokiBlobDataStore implements IBlobDataStore {
     clean_rec.snapshot = new Date().toISOString();
 
     // we need to remove these props to allow insert of new snapshot entry
-    delete clean_rec["meta"];
-    delete clean_rec["$loki"];
+    delete clean_rec.meta;
+    delete clean_rec.$loki;
 
     return coll.insert(clean_rec);
   }

--- a/src/blob/persistence/LokiBlobDataStore.ts
+++ b/src/blob/persistence/LokiBlobDataStore.ts
@@ -168,7 +168,7 @@ export default class LokiBlobDataStore implements IBlobDataStore {
     // Create containers collection if not exists
     if (this.db.getCollection(this.BLOBS_COLLECTION) === null) {
       this.db.addCollection(this.BLOBS_COLLECTION, {
-        indices: ["accountName", "containerName", "name"] // Optimize for find operation
+        indices: ["accountName", "containerName", "name", "snapshot"] // Optimize for find operation
       });
     }
 
@@ -389,7 +389,8 @@ export default class LokiBlobDataStore implements IBlobDataStore {
     const blobDoc = coll.findOne({
       accountName: blob.accountName,
       containerName: blob.containerName,
-      name: blob.name
+      name: blob.name,
+      snapshot: blob.snapshot
     });
     if (blobDoc) {
       coll.remove(blobDoc);
@@ -397,6 +398,27 @@ export default class LokiBlobDataStore implements IBlobDataStore {
 
     delete (blob as any).$loki;
     return coll.insert(blob);
+  }
+
+  /**
+   * Create a snapshot of a blob
+   *
+   * @template T
+   * @param {T} blob
+   * @returns {Promise<T>}
+   * @memberof LokiBlobDataStore
+   */
+  public async snapshotBlob<T extends BlobModel>(blob: T): Promise<T> {
+    const coll = this.db.getCollection(this.BLOBS_COLLECTION);
+
+    const clean_rec: any = Object.assign({}, blob);
+    clean_rec.snapshot = new Date().toISOString();
+
+    // we need to remove these props to allow insert of new snapshot entry
+    delete clean_rec["meta"];
+    delete clean_rec["$loki"];
+
+    return coll.insert(clean_rec);
   }
 
   /**
@@ -448,7 +470,8 @@ export default class LokiBlobDataStore implements IBlobDataStore {
     container?: string,
     prefix: string | undefined = "",
     maxResults: number | undefined = 5000,
-    marker?: number | undefined
+    marker?: number | undefined,
+    includeSnapshots?: boolean | undefined
   ): Promise<[T[], number | undefined]> {
     const query: any = {};
     if (prefix !== "") {
@@ -460,6 +483,10 @@ export default class LokiBlobDataStore implements IBlobDataStore {
     if (container !== undefined) {
       query.containerName = container;
     }
+    if (includeSnapshots === undefined || includeSnapshots === false) {
+      query.snapshot = { $ne: "" };
+    }
+
     query.$loki = { $gt: marker };
 
     const coll = this.db.getCollection(this.BLOBS_COLLECTION);

--- a/src/blob/persistence/LokiBlobDataStore.ts
+++ b/src/blob/persistence/LokiBlobDataStore.ts
@@ -483,8 +483,8 @@ export default class LokiBlobDataStore implements IBlobDataStore {
     if (container !== undefined) {
       query.containerName = container;
     }
-    if (includeSnapshots === undefined || includeSnapshots === false) {
-      query.snapshot = { $ne: "" };
+    if (includeSnapshots === true) {
+      query.snapshot = { $regex: /+/ };
     }
 
     query.$loki = { $gt: marker };

--- a/src/blob/persistence/LokiBlobDataStore.ts
+++ b/src/blob/persistence/LokiBlobDataStore.ts
@@ -484,12 +484,13 @@ export default class LokiBlobDataStore implements IBlobDataStore {
       query.containerName = container;
     }
     if (includeSnapshots === true) {
-      query.snapshot = { $regex: /+/ };
+      query.snapshot = { $regex: "+" };
     }
 
     query.$loki = { $gt: marker };
 
     const coll = this.db.getCollection(this.BLOBS_COLLECTION);
+
     const docs = coll
       .chain()
       .find(query)

--- a/tests/blob/apis/blob.test.ts
+++ b/tests/blob/apis/blob.test.ts
@@ -96,6 +96,42 @@ describe("BlobAPIs", () => {
     await blobURL.delete(Aborter.none);
   });
 
+  it("should create a snapshot from a blob", async () => {
+    const result = await blobURL.createSnapshot(Aborter.none);
+    assert.ok(result.snapshot);
+  });
+
+  it("should delete snapshot", async () => {
+    const result = await blobURL.createSnapshot(Aborter.none);
+    assert.ok(result.snapshot);
+    const blobSnapshotURL = blobURL.withSnapshot(result.snapshot!);
+    await blobSnapshotURL.getProperties(Aborter.none);
+    await blobSnapshotURL.delete(Aborter.none);
+    await blobURL.delete(Aborter.none);
+    const result2 = await containerURL.listBlobFlatSegment(
+      Aborter.none,
+      undefined,
+      {
+        include: ["snapshots"]
+      }
+    );
+    // Verify that the snapshot is deleted
+    assert.equal(result2.segment.blobItems!.length, 0);
+  });
+
+  it("should also list snapshots", async () => {
+    const result = await blobURL.createSnapshot(Aborter.none);
+    assert.ok(result.snapshot);
+    const result2 = await containerURL.listBlobFlatSegment(
+      Aborter.none,
+      undefined,
+      {
+        include: ["snapshots"]
+      }
+    );
+    assert.strictEqual(result2.segment.blobItems!.length, 2);
+  });
+
   it("should setMetadata with new metadata set", async () => {
     const metadata = {
       a: "a",

--- a/tests/blob/apis/container.test.ts
+++ b/tests/blob/apis/container.test.ts
@@ -182,7 +182,13 @@ describe("ContainerAPIs", () => {
       delimiter,
       undefined,
       {
-        include: ["metadata", "uncommittedblobs", "copy", "deleted"],
+        include: [
+          "metadata",
+          "uncommittedblobs",
+          "copy",
+          "deleted",
+          "snapshots"
+        ],
         maxresults: 1,
         prefix
       }
@@ -198,7 +204,13 @@ describe("ContainerAPIs", () => {
       delimiter,
       result.nextMarker,
       {
-        include: ["metadata", "uncommittedblobs", "copy", "deleted"],
+        include: [
+          "metadata",
+          "uncommittedblobs",
+          "copy",
+          "deleted",
+          "snapshots"
+        ],
         maxresults: 2,
         prefix
       }
@@ -214,7 +226,13 @@ describe("ContainerAPIs", () => {
       delimiter,
       undefined,
       {
-        include: ["metadata", "uncommittedblobs", "copy", "deleted"],
+        include: [
+          "metadata",
+          "uncommittedblobs",
+          "copy",
+          "deleted",
+          "snapshots"
+        ],
         maxresults: 2,
         prefix: `${prefix}0${delimiter}`
       }


### PR DESCRIPTION
Snapshot API has been implemented, and the DB schema updated.
#190 
There are now issues with the correctness of several APIs and tests which need to be corrected to account for snapshots in the blob collection.

1. collection indices extended by snapshot property.
1. listBlobs API on persitent storage extended to account for snapshots

### Open tasks:

1. All special naming tests now failing
1. Correctness of list blob tests needs to be checked.
Number of expected results no longer correct on flat and hierarchy tests.
1. Correctness of delete / undelete operations 
BlobDeleteMethodOptionalParams.deleteSnapshots
Required if the blob has associated snapshots. Specify one of the following two options:
 include: Delete the base blob and all of its snapshots. 
only: Delete only the blob's snapshots and not the blob itself. 
Possible values include: 'include', 'only'
Means that we need to check for snapshots and then process the options accordingly.
Need to check how the service API deals with missing required param at this stage.
