### PR TITLE
[NewArch] Account SAS & .Net SDK Sample Support

### DIFF
--- a/src/blob/BlobRequestListenerFactory.ts
+++ b/src/blob/BlobRequestListenerFactory.ts
@@ -5,6 +5,7 @@ import IAccountDataStore from "../common/IAccountDataStore";
 import IRequestListenerFactory from "../common/IRequestListenerFactory";
 import logger from "../common/Logger";
 import { RequestListener } from "../common/ServerBase";
+import AccountSASAuthenticator from "./authentication/AccountSASAuthenticator";
 import AuthenticationMiddlewareFactory from "./authentication/AuthenticationMiddlewareFactory";
 import BlobSharedKeyAuthenticator from "./authentication/BlobSharedKeyAuthenticator";
 import blobStorageContextMiddleware from "./context/blobStorageContext.middleware";
@@ -89,7 +90,12 @@ export default class BlobRequestListenerFactory
     );
     app.use(
       authenticationMiddlewareFactory.createAuthenticationMiddleware([
-        new BlobSharedKeyAuthenticator(this.accountDataStore, logger)
+        new BlobSharedKeyAuthenticator(this.accountDataStore, logger),
+        new AccountSASAuthenticator(
+          this.accountDataStore,
+          this.dataStore,
+          logger
+        )
       ])
     );
 

--- a/src/blob/authentication/AccountSASAuthenticator.ts
+++ b/src/blob/authentication/AccountSASAuthenticator.ts
@@ -67,7 +67,7 @@ export default class AccountSASAuthenticator implements IAuthenticator {
     const values = this.getAccountSASSignatureValuesFromRequest(req);
     if (values === undefined) {
       this.logger.info(
-        `AccountSASAuthenticator:validate() failed to get valid account SAS values from request.`,
+        `AccountSASAuthenticator:validate() Failed to get valid account SAS values from request.`,
         context.contextID
       );
       return false;

--- a/src/blob/authentication/AccountSASAuthenticator.ts
+++ b/src/blob/authentication/AccountSASAuthenticator.ts
@@ -1,0 +1,270 @@
+import IAccountDataStore from "../../common/IAccountDataStore";
+import ILogger from "../../common/ILogger";
+import StorageErrorFactory from "../errors/StorageErrorFactory";
+import { BlobType } from "../generated/artifacts/models";
+import Operation from "../generated/artifacts/operation";
+import Context from "../generated/Context";
+import IRequest from "../generated/IRequest";
+import IBlobDataStore from "../persistence/IBlobDataStore";
+import { AccountSASPermission } from "./AccountSASPermissions";
+import {
+  generateAccountSASSignature,
+  IAccountSASSignatureValues
+} from "./IAccountSASSignatureValues";
+import IAuthenticator from "./IAuthenticator";
+import OPERATION_ACCOUNT_SAS_PERMISSIONS from "./OperationAccountSASPermission";
+
+export default class AccountSASAuthenticator implements IAuthenticator {
+  public constructor(
+    private readonly accountDataStore: IAccountDataStore,
+    private readonly blobDataStore: IBlobDataStore,
+    private readonly logger: ILogger
+  ) {}
+
+  public async validate(
+    req: IRequest,
+    context: Context
+  ): Promise<boolean | undefined> {
+    this.logger.info(
+      `AccountSASAuthenticator:validate() Start validation against account Shared Key Signature pattern.`,
+      context.contextID
+    );
+
+    this.logger.debug(
+      "AccountSASAuthenticator:validate() Getting account properties...",
+      context.contextID
+    );
+
+    // Doesn't create a BlobContext here because wants to move this class into common
+    const account: string = context.context.account;
+    const containerName: string | undefined = context.context.container;
+    const blobName: string | undefined = context.context.blob;
+    this.logger.debug(
+      // tslint:disable-next-line:max-line-length
+      `AccountSASAuthenticator:validate() Retrieved account name from context: ${account}, container: ${containerName}, blob: ${blobName}`,
+      context.contextID
+    );
+
+    // TODO: Make following async
+    const accountProperties = this.accountDataStore.getAccount(account);
+    if (accountProperties === undefined) {
+      throw StorageErrorFactory.getInvalidOperation(
+        context.contextID!,
+        "Invalid storage account."
+      );
+    }
+    this.logger.debug(
+      "AccountSASAuthenticator:validate() Got account properties successfully.",
+      context.contextID
+    );
+
+    const signature = this.decodeIfExist(req.getQuery("sig"));
+    this.logger.debug(
+      `AccountSASAuthenticator:validate() Retrieved signature from URL parameter sig: ${signature}`,
+      context.contextID
+    );
+
+    const values = this.getAccountSASSignatureValuesFromRequest(req);
+    if (values === undefined) {
+      this.logger.info(
+        `AccountSASAuthenticator:validate() failed to get valid account SAS values from request.`,
+        context.contextID
+      );
+      return false;
+    }
+    this.logger.info(
+      `AccountSASAuthenticator:validate() Successfully got valid account SAS values from request. ${JSON.stringify(
+        values
+      )}`,
+      context.contextID
+    );
+
+    this.logger.info(
+      `AccountSASAuthenticator:validate() Validate signature based account key1.`,
+      context.contextID
+    );
+    const sig1 = generateAccountSASSignature(
+      values,
+      account,
+      accountProperties.key1
+    );
+
+    const sig1Pass = sig1 === signature;
+    this.logger.info(
+      `AccountSASAuthenticator:validate() Signature based on key1 validation ${
+        sig1Pass ? "passed" : "failed"
+      }.`,
+      context.contextID
+    );
+
+    if (accountProperties.key2 !== undefined) {
+      this.logger.info(
+        `AccountSASAuthenticator:validate() Account key2 is not empty, validate signature based account key2.`,
+        context.contextID
+      );
+      const sig2 = generateAccountSASSignature(
+        values,
+        account,
+        accountProperties.key2
+      );
+
+      const sig2Pass = sig2 !== signature;
+      this.logger.info(
+        `AccountSASAuthenticator:validate() Signature based on key2 validation ${
+          sig2Pass ? "passed" : "failed"
+        }.`,
+        context.contextID
+      );
+
+      if (!sig2Pass && !sig1Pass) {
+        this.logger.info(
+          `AccountSASAuthenticator:validate() Validate signature based account key1 and key2 failed.`,
+          context.contextID
+        );
+        return false;
+      }
+    }
+
+    const operation = context.operation;
+    if (operation === undefined) {
+      throw new Error(
+        // tslint:disable-next-line:max-line-length
+        `AccountSASAuthenticator:validate() operation shouldn't be undefined. Please make sure DispatchMiddleware is hooked before authentication related middleware.`
+      );
+    }
+
+    const accountSASPermission = OPERATION_ACCOUNT_SAS_PERMISSIONS.get(
+      operation
+    );
+    this.logger.debug(
+      `AccountSASAuthenticator:validate() Got permission requirements for operation ${
+        Operation[operation]
+      } - ${JSON.stringify(accountSASPermission)}`,
+      context.contextID
+    );
+    if (accountSASPermission === undefined) {
+      throw new Error(
+        // tslint:disable-next-line:max-line-length
+        `AccountSASAuthenticator:validate() OPERATION_ACCOUNT_SAS_PERMISSIONS doesn't have configuration for operation ${
+          Operation[operation]
+        }'s account SAS permission.`
+      );
+    }
+
+    if (
+      accountSASPermission.validate(
+        values.services,
+        values.resourceTypes,
+        values.permissions
+      )
+    ) {
+      this.logger.info(
+        `AccountSASAuthenticator:validate() Account SAS validation successfully.`,
+        context.contextID
+      );
+
+      // Check 3 special permission requirements
+      // If block blob exists, then permission must be Write only
+      // If page blob exists, then permission must be Write only
+      // If destination blob exists, then permission must be Write only
+      if (
+        operation === Operation.BlockBlob_Upload ||
+        operation === Operation.PageBlob_Create ||
+        operation === Operation.Blob_StartCopyFromURL
+      ) {
+        this.logger.info(
+          `AccountSASAuthenticator:validate() For ${
+            Operation[operation]
+          }, if blob exists, then permission must be Write.`,
+          context.contextID
+        );
+
+        if (
+          (await this.blobExist(account, containerName!, blobName!)) &&
+          accountSASPermission.permission !== AccountSASPermission.Write
+        ) {
+          this.logger.info(
+            `AccountSASAuthenticator:validate() Account SAS validation failed for special requirement.`,
+            context.contextID
+          );
+          return false;
+        }
+        return true;
+      }
+
+      return true;
+    }
+
+    this.logger.info(
+      `AccountSASAuthenticator:validate() Account SAS validation failed.`,
+      context.contextID
+    );
+    return false;
+  }
+
+  private getAccountSASSignatureValuesFromRequest(
+    req: IRequest
+  ): IAccountSASSignatureValues | undefined {
+    const version = this.decodeIfExist(req.getQuery("sv"));
+    const services = this.decodeIfExist(req.getQuery("ss"));
+    const resourceTypes = this.decodeIfExist(req.getQuery("srt"));
+    const protocol = this.decodeIfExist(req.getQuery("spr"));
+    const startTime = this.decodeIfExist(req.getQuery("st"));
+    const expiryTime = this.decodeIfExist(req.getQuery("se"));
+    const ipRange = this.decodeIfExist(req.getQuery("sip"));
+    const permissions = this.decodeIfExist(req.getQuery("sp"));
+    const signature = this.decodeIfExist(req.getQuery("sig"));
+
+    if (
+      version === undefined ||
+      expiryTime === undefined ||
+      permissions === undefined ||
+      services === undefined ||
+      resourceTypes === undefined ||
+      signature === undefined
+    ) {
+      return undefined;
+    }
+
+    const accountSASValues: IAccountSASSignatureValues = {
+      version,
+      protocol,
+      startTime,
+      expiryTime,
+      permissions,
+      ipRange,
+      services,
+      resourceTypes
+    };
+
+    return accountSASValues;
+  }
+
+  private decodeIfExist(value?: string): string | undefined {
+    return value === undefined ? value : decodeURIComponent(value);
+  }
+
+  private async blobExist(
+    account: string,
+    container: string,
+    blob: string
+  ): Promise<boolean> {
+    const blobModel = await this.blobDataStore.getBlob(
+      account,
+      container,
+      blob
+    );
+    if (blobModel === undefined) {
+      return false;
+    }
+
+    if (
+      blobModel.properties.blobType === BlobType.BlockBlob &&
+      blobModel.isCommitted === false
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/blob/authentication/AccountSASPermissions.ts
+++ b/src/blob/authentication/AccountSASPermissions.ts
@@ -1,0 +1,199 @@
+export enum AccountSASPermission {
+  Read = "r",
+  Write = "w",
+  Delete = "d",
+  List = "l",
+  Add = "a",
+  Create = "c",
+  Update = "u",
+  Process = "p"
+}
+
+/**
+ * This is a helper class to construct a string representing the permissions granted by an AccountSAS. Setting a value
+ * to true means that any SAS which uses these permissions will grant permissions for that operation. Once all the
+ * values are set, this should be serialized with toString and set as the permissions field on an
+ * {@link AccountSASSignatureValues} object. It is possible to construct the permissions string without this class, but
+ * the order of the permissions is particular and this class guarantees correctness.
+ *
+ * @export
+ * @class AccountSASPermissions
+ */
+export default class AccountSASPermissions {
+  /**
+   * Parse initializes the AccountSASPermissions fields from a string.
+   *
+   * @static
+   * @param {string} permissions
+   * @returns {AccountSASPermissions}
+   * @memberof AccountSASPermissions
+   */
+  public static parse(permissions: string): AccountSASPermissions {
+    const accountSASPermissions = new AccountSASPermissions();
+
+    for (const c of permissions) {
+      switch (c) {
+        case AccountSASPermission.Read:
+          if (accountSASPermissions.read) {
+            throw new RangeError(`Duplicated permission character: ${c}`);
+          }
+          accountSASPermissions.read = true;
+          break;
+        case AccountSASPermission.Write:
+          if (accountSASPermissions.write) {
+            throw new RangeError(`Duplicated permission character: ${c}`);
+          }
+          accountSASPermissions.write = true;
+          break;
+        case AccountSASPermission.Delete:
+          if (accountSASPermissions.delete) {
+            throw new RangeError(`Duplicated permission character: ${c}`);
+          }
+          accountSASPermissions.delete = true;
+          break;
+        case AccountSASPermission.List:
+          if (accountSASPermissions.list) {
+            throw new RangeError(`Duplicated permission character: ${c}`);
+          }
+          accountSASPermissions.list = true;
+          break;
+        case AccountSASPermission.Add:
+          if (accountSASPermissions.add) {
+            throw new RangeError(`Duplicated permission character: ${c}`);
+          }
+          accountSASPermissions.add = true;
+          break;
+        case AccountSASPermission.Create:
+          if (accountSASPermissions.create) {
+            throw new RangeError(`Duplicated permission character: ${c}`);
+          }
+          accountSASPermissions.create = true;
+          break;
+        case AccountSASPermission.Update:
+          if (accountSASPermissions.update) {
+            throw new RangeError(`Duplicated permission character: ${c}`);
+          }
+          accountSASPermissions.update = true;
+          break;
+        case AccountSASPermission.Process:
+          if (accountSASPermissions.process) {
+            throw new RangeError(`Duplicated permission character: ${c}`);
+          }
+          accountSASPermissions.process = true;
+          break;
+        default:
+          throw new RangeError(`Invalid permission character: ${c}`);
+      }
+    }
+
+    return accountSASPermissions;
+  }
+
+  /**
+   * Permission to read resources and list queues and tables granted.
+   *
+   * @type {boolean}
+   * @memberof AccountSASPermissions
+   */
+  public read: boolean = false;
+
+  /**
+   * Permission to write resources granted.
+   *
+   * @type {boolean}
+   * @memberof AccountSASPermissions
+   */
+  public write: boolean = false;
+
+  /**
+   * Permission to create blobs and files granted.
+   *
+   * @type {boolean}
+   * @memberof AccountSASPermissions
+   */
+  public delete: boolean = false;
+
+  /**
+   * Permission to list blob containers, blobs, shares, directories, and files granted.
+   *
+   * @type {boolean}
+   * @memberof AccountSASPermissions
+   */
+  public list: boolean = false;
+
+  /**
+   * Permission to add messages, table entities, and append to blobs granted.
+   *
+   * @type {boolean}
+   * @memberof AccountSASPermissions
+   */
+  public add: boolean = false;
+
+  /**
+   * Permission to create blobs and files granted.
+   *
+   * @type {boolean}
+   * @memberof AccountSASPermissions
+   */
+  public create: boolean = false;
+
+  /**
+   * Permissions to update messages and table entities granted.
+   *
+   * @type {boolean}
+   * @memberof AccountSASPermissions
+   */
+  public update: boolean = false;
+
+  /**
+   * Permission to get and delete messages granted.
+   *
+   * @type {boolean}
+   * @memberof AccountSASPermissions
+   */
+  public process: boolean = false;
+
+  /**
+   * Produces the SAS permissions string for an Azure Storage account.
+   * Call this method to set AccountSASSignatureValues Permissions field.
+   *
+   * Using this method will guarantee the resource types are in
+   * an order accepted by the service.
+   *
+   * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
+   *
+   * @returns {string}
+   * @memberof AccountSASPermissions
+   */
+  public toString(): string {
+    // The order of the characters should be as specified here to ensure correctness:
+    // https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
+    // Use a string array instead of string concatenating += operator for performance
+    const permissions: string[] = [];
+    if (this.read) {
+      permissions.push(AccountSASPermission.Read);
+    }
+    if (this.write) {
+      permissions.push(AccountSASPermission.Write);
+    }
+    if (this.delete) {
+      permissions.push(AccountSASPermission.Delete);
+    }
+    if (this.list) {
+      permissions.push(AccountSASPermission.List);
+    }
+    if (this.add) {
+      permissions.push(AccountSASPermission.Add);
+    }
+    if (this.create) {
+      permissions.push(AccountSASPermission.Create);
+    }
+    if (this.update) {
+      permissions.push(AccountSASPermission.Update);
+    }
+    if (this.process) {
+      permissions.push(AccountSASPermission.Process);
+    }
+    return permissions.join("");
+  }
+}

--- a/src/blob/authentication/AccountSASResourceTypes.ts
+++ b/src/blob/authentication/AccountSASResourceTypes.ts
@@ -1,0 +1,103 @@
+export enum AccountSASResourceType {
+  Service = "s",
+  Container = "c",
+  Object = "o"
+}
+
+/**
+ * This is a helper class to construct a string representing the resources accessible by an AccountSAS. Setting a value
+ * to true means that any SAS which uses these permissions will grant access to that resource type. Once all the
+ * values are set, this should be serialized with toString and set as the resources field on an
+ * {@link AccountSASSignatureValues} object. It is possible to construct the resources string without this class, but
+ * the order of the resources is particular and this class guarantees correctness.
+ *
+ * @export
+ * @class AccountSASResourceTypes
+ */
+export default class AccountSASResourceTypes {
+  /**
+   * Creates an {@link AccountSASResourceType} from the specified resource types string. This method will throw an
+   * Error if it encounters a character that does not correspond to a valid resource type.
+   *
+   * @static
+   * @param {string} resourceTypes
+   * @returns {AccountSASResourceTypes}
+   * @memberof AccountSASResourceTypes
+   */
+  public static parse(resourceTypes: string): AccountSASResourceTypes {
+    const accountSASResourceTypes = new AccountSASResourceTypes();
+
+    for (const c of resourceTypes) {
+      switch (c) {
+        case AccountSASResourceType.Service:
+          if (accountSASResourceTypes.service) {
+            throw new RangeError(`Duplicated permission character: ${c}`);
+          }
+          accountSASResourceTypes.service = true;
+          break;
+        case AccountSASResourceType.Container:
+          if (accountSASResourceTypes.container) {
+            throw new RangeError(`Duplicated permission character: ${c}`);
+          }
+          accountSASResourceTypes.container = true;
+          break;
+        case AccountSASResourceType.Object:
+          if (accountSASResourceTypes.object) {
+            throw new RangeError(`Duplicated permission character: ${c}`);
+          }
+          accountSASResourceTypes.object = true;
+          break;
+        default:
+          throw new RangeError(`Invalid resource type: ${c}`);
+      }
+    }
+
+    return accountSASResourceTypes;
+  }
+
+  /**
+   * Permission to access service level APIs granted.
+   *
+   * @type {boolean}
+   * @memberof AccountSASResourceTypes
+   */
+  public service: boolean = false;
+
+  /**
+   * Permission to access container level APIs (Blob Containers, Tables, Queues, File Shares) granted.
+   *
+   * @type {boolean}
+   * @memberof AccountSASResourceTypes
+   */
+  public container: boolean = false;
+
+  /**
+   * Permission to access object level APIs (Blobs, Table Entities, Queue Messages, Files) granted.
+   *
+   * @type {boolean}
+   * @memberof AccountSASResourceTypes
+   */
+  public object: boolean = false;
+
+  /**
+   * Converts the given resource types to a string.
+   *
+   * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
+   *
+   * @returns {string}
+   * @memberof AccountSASResourceTypes
+   */
+  public toString(): string {
+    const resourceTypes: string[] = [];
+    if (this.service) {
+      resourceTypes.push(AccountSASResourceType.Service);
+    }
+    if (this.container) {
+      resourceTypes.push(AccountSASResourceType.Container);
+    }
+    if (this.object) {
+      resourceTypes.push(AccountSASResourceType.Object);
+    }
+    return resourceTypes.join("");
+  }
+}

--- a/src/blob/authentication/AccountSASServices.ts
+++ b/src/blob/authentication/AccountSASServices.ts
@@ -1,0 +1,121 @@
+export enum AccountSASService {
+  Blob = "b",
+  File = "f",
+  Queue = "q",
+  Table = "t"
+}
+
+/**
+ * ONLY AVAILABLE IN NODE.JS RUNTIME.
+ *
+ * This is a helper class to construct a string representing the services accessible by an AccountSAS. Setting a value
+ * to true means that any SAS which uses these permissions will grant access to that service. Once all the
+ * values are set, this should be serialized with toString and set as the services field on an
+ * {@link AccountSASSignatureValues} object. It is possible to construct the services string without this class, but
+ * the order of the services is particular and this class guarantees correctness.
+ *
+ * @export
+ * @class AccountSASServices
+ */
+export default class AccountSASServices {
+  /**
+   * Creates an {@link AccountSASServices} from the specified services string. This method will throw an
+   * Error if it encounters a character that does not correspond to a valid service.
+   *
+   * @static
+   * @param {string} services
+   * @returns {AccountSASServices}
+   * @memberof AccountSASServices
+   */
+  public static parse(services: string): AccountSASServices {
+    const accountSASServices = new AccountSASServices();
+
+    for (const c of services) {
+      switch (c) {
+        case AccountSASService.Blob:
+          if (accountSASServices.blob) {
+            throw new RangeError(`Duplicated permission character: ${c}`);
+          }
+          accountSASServices.blob = true;
+          break;
+        case AccountSASService.File:
+          if (accountSASServices.file) {
+            throw new RangeError(`Duplicated permission character: ${c}`);
+          }
+          accountSASServices.file = true;
+          break;
+        case AccountSASService.Queue:
+          if (accountSASServices.queue) {
+            throw new RangeError(`Duplicated permission character: ${c}`);
+          }
+          accountSASServices.queue = true;
+          break;
+        case AccountSASService.Table:
+          if (accountSASServices.table) {
+            throw new RangeError(`Duplicated permission character: ${c}`);
+          }
+          accountSASServices.table = true;
+          break;
+        default:
+          throw new RangeError(`Invalid service character: ${c}`);
+      }
+    }
+
+    return accountSASServices;
+  }
+
+  /**
+   * Permission to access blob resources granted.
+   *
+   * @type {boolean}
+   * @memberof AccountSASServices
+   */
+  public blob: boolean = false;
+
+  /**
+   * Permission to access file resources granted.
+   *
+   * @type {boolean}
+   * @memberof AccountSASServices
+   */
+  public file: boolean = false;
+
+  /**
+   * Permission to access queue resources granted.
+   *
+   * @type {boolean}
+   * @memberof AccountSASServices
+   */
+  public queue: boolean = false;
+
+  /**
+   * Permission to access table resources granted.
+   *
+   * @type {boolean}
+   * @memberof AccountSASServices
+   */
+  public table: boolean = false;
+
+  /**
+   * Converts the given services to a string.
+   *
+   * @returns {string}
+   * @memberof AccountSASServices
+   */
+  public toString(): string {
+    const services: string[] = [];
+    if (this.blob) {
+      services.push(AccountSASService.Blob);
+    }
+    if (this.table) {
+      services.push(AccountSASService.Table);
+    }
+    if (this.queue) {
+      services.push(AccountSASService.Queue);
+    }
+    if (this.file) {
+      services.push(AccountSASService.File);
+    }
+    return services.join("");
+  }
+}

--- a/src/blob/authentication/AuthenticationMiddlewareFactory.ts
+++ b/src/blob/authentication/AuthenticationMiddlewareFactory.ts
@@ -18,11 +18,11 @@ export default class AuthenticationMiddlewareFactory {
       this.authenticate(req, res, authenticators)
         .then(pass => {
           // TODO: To support public access, we need to modify here to reject request later in handler
-          if (pass === true) {
+          if (pass) {
             next();
           } else {
             next(
-              StorageErrorFactory.getAuthenticationFailed(context.contextID!)
+              StorageErrorFactory.getAuthorizationFailure(context.contextID!)
             );
           }
         })

--- a/src/blob/authentication/AuthenticationMiddlewareFactory.ts
+++ b/src/blob/authentication/AuthenticationMiddlewareFactory.ts
@@ -14,28 +14,42 @@ export default class AuthenticationMiddlewareFactory {
     authenticators: IAuthenticator[]
   ): RequestHandler {
     return (req: Request, res: Response, next: NextFunction) => {
-      const request = new ExpressRequestAdapter(req);
       const context = new BlobStorageContext(res.locals, DEFAULT_CONTEXT_PATH);
-
-      this.logger.verbose(
-        `AuthenticationMiddlewareFactory:createAuthenticationMiddleware() Validating authentications.`,
-        context.contextID
-      );
-
-      let pass: boolean | undefined = false;
-      for (const authenticator of authenticators) {
-        pass = authenticator.validate(request, context);
-        if (pass === true) {
-          break;
-        }
-      }
-
-      // TODO: To support public access, we need to modify here to reject request later in handler
-      if (pass === true) {
-        next();
-      } else {
-        next(StorageErrorFactory.getAuthenticationFailed(context.contextID!));
-      }
+      this.authenticate(req, res, authenticators)
+        .then(pass => {
+          // TODO: To support public access, we need to modify here to reject request later in handler
+          if (pass === true) {
+            next();
+          } else {
+            next(
+              StorageErrorFactory.getAuthenticationFailed(context.contextID!)
+            );
+          }
+        })
+        .catch(next);
     };
+  }
+
+  private async authenticate(
+    req: Request,
+    res: Response,
+    authenticators: IAuthenticator[]
+  ): Promise<boolean> {
+    const request = new ExpressRequestAdapter(req);
+    const context = new BlobStorageContext(res.locals, DEFAULT_CONTEXT_PATH);
+
+    this.logger.verbose(
+      `AuthenticationMiddlewareFactory:createAuthenticationMiddleware() Validating authentications.`,
+      context.contextID
+    );
+
+    let pass: boolean | undefined = false;
+    for (const authenticator of authenticators) {
+      pass = await authenticator.validate(request, context);
+      if (pass === true) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/blob/authentication/BlobSharedKeyAuthenticator.ts
+++ b/src/blob/authentication/BlobSharedKeyAuthenticator.ts
@@ -21,15 +21,16 @@ export default class BlobSharedKeyAuthenticator implements IAuthenticator {
     const blobContext = new BlobStorageContext(context);
     const account = blobContext.account!;
 
-    this.logger.verbose(
-      `BlobSharedKeyAuthenticator:validate()`,
+    this.logger.info(
+      `BlobSharedKeyAuthenticator:validate() Start validation against account shared key authentication.`,
       blobContext.contextID
     );
 
     const authHeaderValue = req.getHeader(HeaderConstants.AUTHORIZATION);
     if (authHeaderValue === undefined) {
-      this.logger.verbose(
-        `BlobSharedKeyAuthenticator:validate() Request doesn't include valid authentication header.`,
+      this.logger.info(
+        // tslint:disable-next-line:max-line-length
+        `BlobSharedKeyAuthenticator:validate() Request doesn't include valid authentication header. Skip shared key authentication.`,
         blobContext.contextID
       );
       return undefined;
@@ -86,7 +87,7 @@ export default class BlobSharedKeyAuthenticator implements IAuthenticator {
     // this.logger.info(`[HEADERS]:${req.getHeaders().toString()}`);
     // this.logger.info(`[KEY]: ${request.headers.get(HeaderConstants.AUTHORIZATION)}`);
 
-    this.logger.verbose(
+    this.logger.info(
       `BlobSharedKeyAuthenticator:validate() Validation failed.`,
       blobContext.contextID
     );

--- a/src/blob/authentication/IAccountSASSignatureValues.ts
+++ b/src/blob/authentication/IAccountSASSignatureValues.ts
@@ -1,0 +1,162 @@
+import { IIPRange } from "@azure/storage-blob";
+
+import { computeHMACSHA256, truncatedISO8061Date } from "../utils/utils";
+import AccountSASPermissions from "./AccountSASPermissions";
+import AccountSASResourceTypes from "./AccountSASResourceTypes";
+import AccountSASServices from "./AccountSASServices";
+import { ipRangeToString } from "./IIPRange";
+
+/**
+ * Protocols for generated SAS.
+ *
+ * @export
+ * @enum {number}
+ */
+export enum SASProtocol {
+  /**
+   * Protocol that allows HTTPS only
+   */
+  HTTPS = "https",
+
+  /**
+   * Protocol that allows both HTTPS and HTTP
+   */
+  HTTPSandHTTP = "https,http"
+}
+
+/**
+ * IAccountSASSignatureValues is used to generate a Shared Access Signature (SAS) for an Azure Storage account.
+ *
+ * @see https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1
+ * for more conceptual information on SAS
+ *
+ * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
+ * for descriptions of the parameters, including which are required
+ *
+ * @export
+ * @class IAccountSASSignatureValues
+ */
+export interface IAccountSASSignatureValues {
+  /**
+   * If not provided, this defaults to the service version targeted by this version of the library.
+   *
+   * @type {string}
+   * @memberof IAccountSASSignatureValues
+   */
+  version: string;
+
+  /**
+   * Optional. SAS protocols allowed.
+   *
+   * @type {SASProtocol | string}
+   * @memberof IAccountSASSignatureValues
+   */
+  protocol?: SASProtocol | string;
+
+  /**
+   * Optional. When the SAS will take effect.
+   *
+   * @type {Date | string}
+   * @memberof IAccountSASSignatureValues
+   */
+  startTime?: Date | string;
+
+  /**
+   * The time after which the SAS will no longer work.
+   *
+   * @type {Date | string}
+   * @memberof IAccountSASSignatureValues
+   */
+  expiryTime: Date | string;
+
+  /**
+   * Specifies which operations the SAS user may perform. Please refer to {@link AccountSASPermissions} for help
+   * constructing the permissions string.
+   *
+   * @type {AccountSASPermissions | string}
+   * @memberof IAccountSASSignatureValues
+   */
+  permissions: AccountSASPermissions | string;
+
+  /**
+   * Optional. IP range allowed.
+   *
+   * @type {IIPRange | string}
+   * @memberof IAccountSASSignatureValues
+   */
+  ipRange?: IIPRange | string;
+
+  /**
+   * The values that indicate the services accessible with this SAS. Please refer to {@link AccountSASServices} to
+   * construct this value.
+   *
+   * @type {AccountSASServices | string}
+   * @memberof IAccountSASSignatureValues
+   */
+  services: AccountSASServices | string;
+
+  /**
+   * The values that indicate the resource types accessible with this SAS. Please refer
+   * to {@link AccountSASResourceTypes} to construct this value.
+   *
+   * @type {AccountSASResourceType | string}
+   * @memberof IAccountSASSignatureValues
+   */
+  resourceTypes: AccountSASResourceTypes | string;
+}
+
+/**
+ * Generates signature string from account SAS parameters.
+ *
+ * @see https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
+ *
+ * @param {SharedKeyCredential} sharedKeyCredential
+ * @returns {string}
+ * @memberof IAccountSASSignatureValues
+ */
+export function generateAccountSASSignature(
+  accountSASSignatureValues: IAccountSASSignatureValues,
+  accountName: string,
+  sharedKey: Buffer
+): string {
+  const parsedPermissions = accountSASSignatureValues.permissions.toString();
+  const parsedServices = accountSASSignatureValues.services.toString();
+  const parsedResourceTypes = accountSASSignatureValues.resourceTypes.toString();
+  const parsedStartTime =
+    accountSASSignatureValues.startTime === undefined
+      ? ""
+      : typeof accountSASSignatureValues.startTime === "string"
+      ? accountSASSignatureValues.startTime
+      : truncatedISO8061Date(accountSASSignatureValues.startTime, false);
+  const parsedExpiryTime =
+    typeof accountSASSignatureValues.expiryTime === "string"
+      ? accountSASSignatureValues.expiryTime
+      : truncatedISO8061Date(accountSASSignatureValues.expiryTime, false);
+  const parsedIPRange =
+    accountSASSignatureValues.ipRange === undefined
+      ? ""
+      : typeof accountSASSignatureValues.ipRange === "string"
+      ? accountSASSignatureValues.ipRange
+      : ipRangeToString(accountSASSignatureValues.ipRange);
+  const parsedProtocol =
+    accountSASSignatureValues.protocol === undefined
+      ? ""
+      : accountSASSignatureValues.protocol;
+  const version = accountSASSignatureValues.version;
+
+  const stringToSign = [
+    accountName,
+    parsedPermissions,
+    parsedServices,
+    parsedResourceTypes,
+    parsedStartTime,
+    parsedExpiryTime,
+    parsedIPRange,
+    parsedProtocol,
+    version,
+    "" // Account SAS requires an additional newline character
+  ].join("\n");
+
+  const signature: string = computeHMACSHA256(stringToSign, sharedKey);
+  return signature;
+}

--- a/src/blob/authentication/IAuthenticationContext.ts
+++ b/src/blob/authentication/IAuthenticationContext.ts
@@ -1,0 +1,3 @@
+export default interface IAuthenticationContext {
+  account?: string;
+}

--- a/src/blob/authentication/IAuthenticator.ts
+++ b/src/blob/authentication/IAuthenticator.ts
@@ -2,5 +2,5 @@ import Context from "../generated/Context";
 import IRequest from "../generated/IRequest";
 
 export default interface IAuthenticator {
-  validate(req: IRequest, content: Context): boolean | undefined;
+  validate(req: IRequest, content: Context): Promise<boolean | undefined>;
 }

--- a/src/blob/authentication/IIPRange.ts
+++ b/src/blob/authentication/IIPRange.ts
@@ -1,0 +1,37 @@
+/**
+ * Allowed IP range for a SAS.
+ *
+ * @export
+ * @interface IIPRange
+ */
+export interface IIPRange {
+  /**
+   * Starting IP address in the IP range.
+   * If end IP doesn't provide, start IP will the only IP allowed.
+   *
+   * @type {string}
+   * @memberof IPRange
+   */
+  start: string;
+  /**
+   * Optional. IP address that ends the IP range.
+   * If not provided, start IP will the only IP allowed.
+   *
+   * @type {string}
+   * @memberof IPRange
+   */
+  end?: string;
+}
+
+/**
+ * Generate IPRange format string. For example:
+ *
+ * "8.8.8.8" or "1.1.1.1-255.255.255.255"
+ *
+ * @export
+ * @param {IIPRange} ipRange
+ * @returns {string}
+ */
+export function ipRangeToString(ipRange: IIPRange): string {
+  return ipRange.end ? `${ipRange.start}-${ipRange.end}` : ipRange.start;
+}

--- a/src/blob/authentication/IRange.ts
+++ b/src/blob/authentication/IRange.ts
@@ -1,0 +1,48 @@
+// tslint:disable:max-line-length
+/**
+ * Range for Blob Service Operations.
+ * @see https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-the-range-header-for-blob-service-operations
+ *
+ * @export
+ * @interface IRange
+ */
+export interface IRange {
+  /**
+   * StartByte, larger than or equal 0.
+   *
+   * @type {string}
+   * @memberof IRange
+   */
+  offset: number;
+  /**
+   * Optional. Count of bytes, larger than 0.
+   * If not provided, will return bytes from offset to the end.
+   *
+   * @type {string}
+   * @memberof IRange
+   */
+  count?: number;
+}
+
+/**
+ * Generate a range string. For example:
+ *
+ * "bytes=255-" or "bytes=0-511"
+ *
+ * @export
+ * @param {IRange} iRange
+ * @returns {string}
+ */
+export function rangeToString(iRange: IRange): string {
+  if (iRange.offset < 0) {
+    throw new RangeError(`IRange.offset cannot be smaller than 0.`);
+  }
+  if (iRange.count && iRange.count <= 0) {
+    throw new RangeError(
+      `IRange.count must be larger than 0. Leave it undefined if you want a range from offset to the end.`
+    );
+  }
+  return iRange.count
+    ? `bytes=${iRange.offset}-${iRange.offset + iRange.count - 1}`
+    : `bytes=${iRange.offset}-`;
+}

--- a/src/blob/authentication/OperationAccountSASPermission.ts
+++ b/src/blob/authentication/OperationAccountSASPermission.ts
@@ -1,0 +1,451 @@
+import {
+  AccountSASPermissions,
+  AccountSASResourceTypes,
+  AccountSASServices
+} from "@azure/storage-blob";
+
+import Operation from "../generated/artifacts/operation";
+import { AccountSASPermission } from "./AccountSASPermissions";
+import { AccountSASResourceType } from "./AccountSASResourceTypes";
+import { AccountSASService } from "./AccountSASServices";
+
+export class OperationAccountSASPermission {
+  constructor(
+    public readonly service: string,
+    public readonly resourceType: string,
+    public readonly permission: string
+  ) {}
+
+  public validate(
+    services: AccountSASServices | string,
+    resourceTypes: AccountSASResourceTypes | string,
+    permissions: AccountSASPermissions | string
+  ) {
+    if (!services.toString().includes(this.service)) {
+      return false;
+    }
+
+    if (!resourceTypes.toString().includes(this.resourceType)) {
+      return false;
+    }
+
+    for (const p of this.permission) {
+      if (permissions.toString().includes(p)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}
+
+// See https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas
+const OPERATION_ACCOUNT_SAS_PERMISSIONS = new Map<
+  Operation,
+  OperationAccountSASPermission
+>();
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Service_GetAccountInfo, // Not sure about this permission
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Service,
+    AccountSASPermission.Read
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Container_GetAccountInfo, // Not sure about this permission
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Service,
+    AccountSASPermission.Read
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Blob_GetAccountInfo, // Not sure about this permission
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Service,
+    AccountSASPermission.Read
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Service_ListContainersSegment,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Service,
+    AccountSASPermission.List
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Service_GetProperties,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Service,
+    AccountSASPermission.Read
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Service_SetProperties,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Service,
+    AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Service_GetStatistics,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Service,
+    AccountSASPermission.Read
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Container_Create,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Container,
+    AccountSASPermission.Create + AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Container_GetProperties,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Container,
+    AccountSASPermission.Read
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Container_GetPropertiesWithHead,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Container,
+    AccountSASPermission.Read
+  )
+);
+
+// TODO: Get container metadata is missing in swagger
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Container_SetMetadata,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Container,
+    AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Container_BreakLease,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Container,
+    AccountSASPermission.Write + AccountSASPermission.Delete
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Container_RenewLease,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Container,
+    AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Container_ChangeLease,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Container,
+    AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Container_AcquireLease,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Container,
+    AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Container_ReleaseLease,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Container,
+    AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Container_Delete,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Container,
+    AccountSASPermission.Delete
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Container_ListBlobHierarchySegment,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Container,
+    AccountSASPermission.List
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Container_ListBlobFlatSegment,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Container,
+    AccountSASPermission.List
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.BlockBlob_Upload,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    // TODO: Create permission is only available for non existing block blob. Handle this scenario separately
+    AccountSASPermission.Write + AccountSASPermission.Create
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.PageBlob_Create,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    // TODO: Create permission is only available for non existing page blob. Handle this scenario separately
+    AccountSASPermission.Write + AccountSASPermission.Create
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Blob_Download,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Read
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Blob_GetProperties,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Read
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Blob_SetHTTPHeaders,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Write
+  )
+);
+
+// TODO: Get blob metadata is missing in swagger
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Blob_GetProperties,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Read
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Blob_SetMetadata,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Blob_Delete,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Delete
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Blob_BreakLease,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Delete + AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Blob_RenewLease,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Blob_ChangeLease,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Blob_AcquireLease,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Blob_ReleaseLease,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Blob_CreateSnapshot,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Write + AccountSASPermission.Create
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Blob_StartCopyFromURL,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    // TODO: If destination is an existing blob, create permission is not enough
+    AccountSASPermission.Write + AccountSASPermission.Create
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.PageBlob_CopyIncremental,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Write + AccountSASPermission.Create
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.Blob_AbortCopyFromURL,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.BlockBlob_StageBlock,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.BlockBlob_CommitBlockList,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.BlockBlob_GetBlockList,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Read
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.PageBlob_UploadPages,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.PageBlob_GetPageRanges,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Read
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.PageBlob_GetPageRangesDiff,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Read
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.AppendBlob_AppendBlock,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Add + AccountSASPermission.Write
+  )
+);
+
+OPERATION_ACCOUNT_SAS_PERMISSIONS.set(
+  Operation.PageBlob_ClearPages,
+  new OperationAccountSASPermission(
+    AccountSASService.Blob,
+    AccountSASResourceType.Object,
+    AccountSASPermission.Write
+  )
+);
+
+export default OPERATION_ACCOUNT_SAS_PERMISSIONS;

--- a/src/blob/authentication/OperationAccountSASPermission.ts
+++ b/src/blob/authentication/OperationAccountSASPermission.ts
@@ -20,21 +20,32 @@ export class OperationAccountSASPermission {
     services: AccountSASServices | string,
     resourceTypes: AccountSASResourceTypes | string,
     permissions: AccountSASPermissions | string
-  ) {
-    if (!services.toString().includes(this.service)) {
-      return false;
-    }
+  ): boolean {
+    return (
+      this.validateServices(services) &&
+      this.validateResourceTypes(resourceTypes) &&
+      this.validatePermissions(permissions)
+    );
+  }
 
-    if (!resourceTypes.toString().includes(this.resourceType)) {
-      return false;
-    }
+  public validateServices(services: AccountSASServices | string): boolean {
+    return services.toString().includes(this.service);
+  }
 
+  public validateResourceTypes(
+    resourceTypes: AccountSASResourceTypes | string
+  ): boolean {
+    return resourceTypes.toString().includes(this.resourceType);
+  }
+
+  public validatePermissions(
+    permissions: AccountSASPermissions | string
+  ): boolean {
     for (const p of this.permission) {
       if (permissions.toString().includes(p)) {
         return true;
       }
     }
-
     return false;
   }
 }

--- a/src/blob/context/BlobStorageContext.ts
+++ b/src/blob/context/BlobStorageContext.ts
@@ -15,6 +15,14 @@ export default class BlobStorageContext extends Context
     this.context.account = account;
   }
 
+  public set isSecondary(isSecondary: boolean | undefined) {
+    this.context.isSecondary = isSecondary;
+  }
+
+  public get isSecondary(): boolean | undefined {
+    return this.context.isSecondary;
+  }
+
   public get container(): string | undefined {
     return this.context.container;
   }
@@ -29,6 +37,14 @@ export default class BlobStorageContext extends Context
 
   public set blob(blob: string | undefined) {
     this.context.blob = blob;
+  }
+
+  public get authenticationPath(): string | undefined {
+    return this.context.authenticationPath;
+  }
+
+  public set authenticationPath(path: string | undefined) {
+    this.context.authenticationPath = path;
   }
 
   public get xMsRequestID(): string | undefined {

--- a/src/blob/context/BlobStorageContext.ts
+++ b/src/blob/context/BlobStorageContext.ts
@@ -1,6 +1,8 @@
+import IAuthenticationContext from "../authentication/IAuthenticationContext";
 import Context from "../generated/Context";
 
-export default class BlobStorageContext extends Context {
+export default class BlobStorageContext extends Context
+  implements IAuthenticationContext {
   public getContainer(): string | undefined {
     return this.context.container;
   }

--- a/src/blob/context/blobStorageContext.middleware.ts
+++ b/src/blob/context/blobStorageContext.middleware.ts
@@ -3,7 +3,7 @@ import uuid from "uuid/v4";
 
 import logger from "../../common/Logger";
 import StorageErrorFactory from "../errors/StorageErrorFactory";
-import { DEFAULT_CONTEXT_PATH } from "../utils/constants";
+import { DEFAULT_CONTEXT_PATH, SECONDARY_SUFFIX } from "../utils/constants";
 import BlobStorageContext from "./BlobStorageContext";
 
 /**
@@ -36,23 +36,31 @@ export default function blobStorageContextMiddleware(
     requestID
   );
 
-  const parts = extractStoragePartsFromPath(req.path);
-  const account = parts[0];
-  const container = parts[1];
-  const blob = parts[2];
+  const [account, container, blob, isSecondary] = extractStoragePartsFromPath(
+    req.path
+  );
 
   blobContext.account = account;
   blobContext.container = container;
   blobContext.blob = blob;
+  blobContext.isSecondary = isSecondary;
 
   // Emulator's URL pattern is like http://hostname:port/account/container
   // Create a router to exclude account name from req.path, as url path in swagger doesn't include account
   // Exclude account name from req.path for dispatchMiddleware
-  blobContext.dispatchPath = container
+  blobContext.dispatchPattern = container
     ? blob
       ? `/container/blob`
       : `/container`
     : "/";
+
+  blobContext.authenticationPath = req.path;
+  if (isSecondary) {
+    const pos = blobContext.authenticationPath.search(SECONDARY_SUFFIX);
+    blobContext.authenticationPath =
+      blobContext.authenticationPath.substr(0, pos) +
+      blobContext.authenticationPath.substr(pos + SECONDARY_SUFFIX.length);
+  }
 
   if (!account) {
     const handlerError = StorageErrorFactory.getInvalidQueryParameterValue(
@@ -80,14 +88,20 @@ export default function blobStorageContextMiddleware(
  * Extract storage account, container, and blob from URL path.
  *
  * @param {string} path
- * @returns {([string | undefined, string | undefined, string | undefined])}
+ * @returns {([string | undefined, string | undefined, string | undefined, boolean | undefined])}
  */
 function extractStoragePartsFromPath(
   path: string
-): [string | undefined, string | undefined, string | undefined] {
+): [
+  string | undefined,
+  string | undefined,
+  string | undefined,
+  boolean | undefined
+] {
   let account;
   let container;
   let blob;
+  let isSecondary = false;
 
   const decodedPath = decodeURIComponent(path);
   const normalizedPath = decodedPath.startsWith("/")
@@ -103,5 +117,10 @@ function extractStoragePartsFromPath(
     .join("/")
     .replace(/\\/g, "/"); // Azure Storage Server will replace "\" with "/" in the blob names
 
-  return [account, container, blob];
+  if (account.endsWith(SECONDARY_SUFFIX)) {
+    account = account.substr(0, account.length - SECONDARY_SUFFIX.length);
+    isSecondary = true;
+  }
+
+  return [account, container, blob, isSecondary];
 }

--- a/src/blob/context/blobStorageContext.middleware.ts
+++ b/src/blob/context/blobStorageContext.middleware.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from "express";
+import uuid from "uuid/v4";
 
 import logger from "../../common/Logger";
 import StorageErrorFactory from "../errors/StorageErrorFactory";
@@ -21,8 +22,7 @@ export default function blobStorageContextMiddleware(
   const blobContext = new BlobStorageContext(res.locals, DEFAULT_CONTEXT_PATH);
   blobContext.startTime = new Date();
 
-  // TODO: Use GUID for a server request ID
-  const requestID = blobContext.startTime.getTime().toString();
+  const requestID = uuid();
   blobContext.xMsRequestID = requestID;
 
   logger.info(

--- a/src/blob/errors/StorageErrorFactory.ts
+++ b/src/blob/errors/StorageErrorFactory.ts
@@ -229,10 +229,10 @@ export default class StorageErrorFactory {
     );
   }
 
-  public static getAuthenticationFailed(contextID: string): StorageError {
+  public static getAuthorizationFailure(contextID: string): StorageError {
     return new StorageError(
       403,
-      "AuthenticationFailed",
+      "AuthorizationFailure",
       // tslint:disable-next-line:max-line-length
       "Server failed to authenticate the request. Make sure the value of the Authorization header is formed correctly including the signature.",
       contextID
@@ -277,6 +277,70 @@ export default class StorageErrorFactory {
       409,
       "BlobTierInadequateForContentLength",
       "Specified blob tier size limit cannot be less than content length.",
+      contextID
+    );
+  }
+
+  public static getAuthorizationSourceIPMismatch(
+    contextID: string
+  ): StorageError {
+    return new StorageError(
+      403,
+      "AuthorizationSourceIPMismatch",
+      "This request is not authorized to perform this operation using this source IP {SourceIP}.",
+      contextID
+    );
+  }
+
+  public static getAuthorizationProtocolMismatch(
+    contextID: string
+  ): StorageError {
+    return new StorageError(
+      403,
+      "AuthorizationProtocolMismatch",
+      "This request is not authorized to perform this operation using this protocol.",
+      contextID
+    );
+  }
+
+  public static getAuthorizationPermissionMismatch(
+    contextID: string
+  ): StorageError {
+    return new StorageError(
+      403,
+      "AuthorizationPermissionMismatch",
+      "This request is not authorized to perform this operation using this permission.",
+      contextID
+    );
+  }
+
+  public static getAuthorizationServiceMismatch(
+    contextID: string
+  ): StorageError {
+    return new StorageError(
+      403,
+      "AuthorizationServiceMismatch",
+      "This request is not authorized to perform this operation using this service.",
+      contextID
+    );
+  }
+
+  public static getAuthorizationResourceTypeMismatch(
+    contextID: string
+  ): StorageError {
+    return new StorageError(
+      403,
+      "AuthorizationResourceTypeMismatch",
+      "This request is not authorized to perform this operation using this resource type.",
+      contextID
+    );
+  }
+
+  public static getFeatureVersionMismatch(contextID: string): StorageError {
+    return new StorageError(
+      409,
+      "FeatureVersionMismatch",
+      "Stored access policy contains a permission that is not supported by this version.",
       contextID
     );
   }

--- a/src/blob/generated/Context.ts
+++ b/src/blob/generated/Context.ts
@@ -93,12 +93,12 @@ export default class Context {
     return this.context.request;
   }
 
-  public get dispatchPath(): string | undefined {
-    return this.context.dispatchPath;
+  public get dispatchPattern(): string | undefined {
+    return this.context.dispatchPattern;
   }
 
-  public set dispatchPath(path: string | undefined) {
-    this.context.dispatchPath = path;
+  public set dispatchPattern(path: string | undefined) {
+    this.context.dispatchPattern = path;
   }
 
   public set response(response: IResponse | undefined) {

--- a/src/blob/generated/ExpressRequestAdapter.ts
+++ b/src/blob/generated/ExpressRequestAdapter.ts
@@ -46,4 +46,8 @@ export default class ExpressRequestAdapter implements IRequest {
   public getQuery(key: string): string | undefined {
     return this.req.query[key];
   }
+
+  public getProtocol(): string {
+    return this.req.protocol;
+  }
 }

--- a/src/blob/generated/IRequest.ts
+++ b/src/blob/generated/IRequest.ts
@@ -20,4 +20,5 @@ export default interface IRequest {
   getHeader(field: string): string | undefined;
   getHeaders(): { [header: string]: string | string[] | undefined };
   getQuery(key: string): string | undefined;
+  getProtocol(): string;
 }

--- a/src/blob/generated/artifacts/specifications.ts
+++ b/src/blob/generated/artifacts/specifications.ts
@@ -345,7 +345,7 @@ const containerGetAccessPolicyOperationSpec: msRest.OperationSpec = {
     200: {
       bodyMapper: {
         xmlElementName: "SignedIdentifier",
-        serializedName: "parsedResponse",
+        serializedName: "SignedIdentifiers",
         type: {
           name: "Sequence",
           element: {
@@ -715,7 +715,7 @@ const blobDownloadOperationSpec: msRest.OperationSpec = {
   responses: {
     200: {
       bodyMapper: {
-        serializedName: "parsedResponse",
+        serializedName: "Stream",
         type: {
           name: "Stream"
         }
@@ -724,7 +724,7 @@ const blobDownloadOperationSpec: msRest.OperationSpec = {
     },
     206: {
       bodyMapper: {
-        serializedName: "parsedResponse",
+        serializedName: "Stream",
         type: {
           name: "Stream"
         }

--- a/src/blob/generated/middleware/deserializer.middleware.ts
+++ b/src/blob/generated/middleware/deserializer.middleware.ts
@@ -22,7 +22,7 @@ export default function deserializerMiddleware(
   context: Context,
   req: IRequest,
   next: NextFunction,
-  logger: ILogger,
+  logger: ILogger
 ): void {
   logger.verbose(
     `DeserializerMiddleware: Start deserializing...`,
@@ -40,18 +40,18 @@ export default function deserializerMiddleware(
 
   if (Specifications[context.operation] === undefined) {
     logger.warn(
-      `DeserializerMiddleware: cannot find deserializer for operation ${
+      `DeserializerMiddleware: Cannot find deserializer for operation ${
         Operation[context.operation]
       }`
     );
   }
 
-  deserialize(req, Specifications[context.operation])
-    .then((parameters) => {
+  deserialize(context, req, Specifications[context.operation], logger)
+    .then(parameters => {
       context.handlerParameters = parameters;
     })
     .then(next)
-    .catch((err) => {
+    .catch(err => {
       const deserializationError = new DeserializationError(err.message);
       deserializationError.stack = err.stack;
       next(deserializationError);

--- a/src/blob/generated/middleware/dispatch.middleware.ts
+++ b/src/blob/generated/middleware/dispatch.middleware.ts
@@ -47,7 +47,7 @@ export default function dispatchMiddleware(
       const res = isRequestAgainstOperation(
         req,
         Specifications[operation],
-        context.dispatchPath
+        context.dispatchPattern
       );
       if (res[0] && res[1] > conditionsMet) {
         context.operation = operation;
@@ -83,7 +83,7 @@ export default function dispatchMiddleware(
 function isRequestAgainstOperation(
   req: IRequest,
   spec: msRest.OperationSpec,
-  dispatchPath?: string
+  dispatchPathPattern?: string
 ): [boolean, number] {
   let metConditionsNum = 0;
   if (req === undefined || spec === undefined) {
@@ -104,7 +104,7 @@ function isRequestAgainstOperation(
   if (
     !isURITemplateMatch(
       // Use dispatch path with priority
-      dispatchPath !== undefined ? dispatchPath : req.getPath(),
+      dispatchPathPattern !== undefined ? dispatchPathPattern : req.getPath(),
       path
     )
   ) {
@@ -162,7 +162,8 @@ function isRequestAgainstOperation(
 
       if (
         headerParameter.mapper.isConstant &&
-        headerParameter.mapper.defaultValue !== headerValue
+        `${headerParameter.mapper.defaultValue || ""}`.toLowerCase() !==
+          headerValue.toLowerCase()
       ) {
         return [false, metConditionsNum];
       }

--- a/src/blob/generated/middleware/error.middleware.ts
+++ b/src/blob/generated/middleware/error.middleware.ts
@@ -41,7 +41,7 @@ export default function errorMiddleware(
   // other error handlers.
   if (err instanceof MiddlewareError) {
     logger.error(
-      `ErrorMiddleware: received a MiddlewareError, fill error information to HTTP response`,
+      `ErrorMiddleware: Received a MiddlewareError, fill error information to HTTP response`,
       context.contextID
     );
 
@@ -104,7 +104,7 @@ export default function errorMiddleware(
     }
   } else if (err instanceof Error) {
     logger.error(
-      `ErrorMiddleware: received an Error, fill error information to HTTP response`,
+      `ErrorMiddleware: Received an error, fill error information to HTTP response`,
       context.contextID
     );
     logger.error(
@@ -123,7 +123,7 @@ export default function errorMiddleware(
     // res.getBodyStream().write(err.message);
   } else {
     logger.warn(
-      `ErrorMiddleware: received unhandled error object`,
+      `ErrorMiddleware: Received unhandled error object`,
       context.contextID
     );
   }

--- a/src/blob/generated/middleware/serializer.middleware.ts
+++ b/src/blob/generated/middleware/serializer.middleware.ts
@@ -20,7 +20,7 @@ export default function serializerMiddleware(
   context: Context,
   res: IResponse,
   next: NextFunction,
-  logger: ILogger,
+  logger: ILogger
 ): void {
   logger.verbose(
     `SerializerMiddleware: Start serializing...`,
@@ -38,13 +38,20 @@ export default function serializerMiddleware(
 
   if (Specifications[context.operation] === undefined) {
     logger.warn(
-      `SerializerMiddleware: cannot find serializer for operation ${
+      `SerializerMiddleware: Cannot find serializer for operation ${
         Operation[context.operation]
-      }`
+      }`,
+      context.contextID
     );
   }
 
-  serialize(res, Specifications[context.operation], context.handlerResponses)
+  serialize(
+    context,
+    res,
+    Specifications[context.operation],
+    context.handlerResponses,
+    logger
+  )
     .then(next)
     .catch(next);
 }

--- a/src/blob/generated/utils/xml.ts
+++ b/src/blob/generated/utils/xml.ts
@@ -21,7 +21,8 @@ export function parseXML(
     explicitCharkey: false,
     explicitRoot: false,
     preserveChildrenOrder: explicitChildrenWithOrder,
-    explicitChildren: explicitChildrenWithOrder
+    explicitChildren: explicitChildrenWithOrder,
+    emptyTag: undefined
   });
   return new Promise((resolve, reject) => {
     xmlParser.parseString(str, (err?: Error, res?: any) => {

--- a/src/blob/handlers/BlobHandler.ts
+++ b/src/blob/handlers/BlobHandler.ts
@@ -11,9 +11,9 @@ import IBlobDataStore, { BlobModel } from "../persistence/IBlobDataStore";
 import { API_VERSION } from "../utils/constants";
 import {
   deserializePageBlobRangeHeader,
-  deserializeRangeHeader
+  deserializeRangeHeader,
+  getContainerGetAccountInfoResponse
 } from "../utils/utils";
-import { getContainerGetAccountInfoResponse } from "../utils/utils";
 import BaseHandler from "./BaseHandler";
 import IPageBlobRangesManager from "./IPageBlobRangesManager";
 
@@ -1202,7 +1202,7 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
     // }
 
     const response: Models.BlobDownloadResponse = {
-      statusCode: 200,
+      statusCode: rangesParts[1] === Infinity ? 200 : 206,
       body,
       metadata: blob.metadata,
       eTag: blob.properties.etag,

--- a/src/blob/handlers/ServiceHandler.ts
+++ b/src/blob/handlers/ServiceHandler.ts
@@ -1,5 +1,4 @@
 import BlobStorageContext from "../context/BlobStorageContext";
-import NotImplementedError from "../errors/NotImplementedError";
 import * as Models from "../generated/artifacts/models";
 import Context from "../generated/Context";
 import IServiceHandler from "../generated/handlers/IServiceHandler";
@@ -146,7 +145,17 @@ export default class ServiceHandler extends BaseHandler
     options: Models.ServiceGetStatisticsOptionalParams,
     context: Context
   ): Promise<Models.ServiceGetStatisticsResponse> {
-    throw new NotImplementedError(context.contextID);
+    const response: Models.ServiceGetStatisticsResponse = {
+      statusCode: 200,
+      requestId: context.contextID,
+      version: API_VERSION,
+      date: context.startTime,
+      geoReplication: {
+        status: Models.GeoReplicationStatusType.Live,
+        lastSyncTime: context.startTime!
+      }
+    };
+    return response;
   }
 
   /**

--- a/src/blob/persistence/IBlobDataStore.ts
+++ b/src/blob/persistence/IBlobDataStore.ts
@@ -219,13 +219,15 @@ export interface IBlobDataStore extends IDataStore {
    * @param {string} account
    * @param {string} container
    * @param {string} blob
+   * @param {string} [snapshot]
    * @returns {(Promise<T | undefined>)}
    * @memberof IBlobDataStore
    */
   getBlob<T extends BlobModel>(
     account: string,
     container: string,
-    blob: string
+    blob: string,
+    snapshot?: string
   ): Promise<T | undefined>;
 
   /**

--- a/src/blob/persistence/LokiBlobDataStore.ts
+++ b/src/blob/persistence/LokiBlobDataStore.ts
@@ -448,9 +448,9 @@ export default class LokiBlobDataStore implements IBlobDataStore {
       blobModel.properties.contentMD5 = this.restoreUint8Array(
         blobModel.properties.contentMD5
       );
+    } else {
+      return undefined;
     }
-
-    return blobDoc;
   }
 
   /**

--- a/src/blob/persistence/LokiBlobDataStore.ts
+++ b/src/blob/persistence/LokiBlobDataStore.ts
@@ -78,7 +78,7 @@ interface IExtentModel {
  * -- BLOBS_COLLECTION       // Collection contains all blobs
  *                           // Default collection name is $BLOBS_COLLECTION$
  *                           // Each document maps to a blob
- *                           // Unique document properties: accountName, containerName, (blob)name
+ *                           // Unique document properties: accountName, containerName, (blob)name, snapshot
  * -- BLOCKS_COLLECTION      // Block blob blocks collection includes all UNCOMMITTED blocks
  *                           // Unique document properties: accountName, containerName, blobName, name, isCommitted
  * -- EXTENTS_COLLECTION     // Collections maintain extents information, including extentID, mapped local file path
@@ -428,19 +428,22 @@ export default class LokiBlobDataStore implements IBlobDataStore {
    * @param {string} account
    * @param {string} container
    * @param {string} blob
+   * @param {string} [snapshot=""]
    * @returns {(Promise<T | undefined>)}
-   * @memberof IBlobDataStore
+   * @memberof LokiBlobDataStore
    */
   public async getBlob<T extends BlobModel>(
     account: string,
     container: string,
-    blob: string
+    blob: string,
+    snapshot: string = ""
   ): Promise<T | undefined> {
     const coll = this.db.getCollection(this.BLOBS_COLLECTION);
     const blobDoc = coll.findOne({
       accountName: account,
       containerName: container,
-      name: blob
+      name: blob,
+      snapshot
     });
 
     if (blobDoc) {
@@ -448,6 +451,7 @@ export default class LokiBlobDataStore implements IBlobDataStore {
       blobModel.properties.contentMD5 = this.restoreUint8Array(
         blobModel.properties.contentMD5
       );
+      return blobDoc;
     } else {
       return undefined;
     }

--- a/src/blob/utils/constants.ts
+++ b/src/blob/utils/constants.ts
@@ -57,3 +57,5 @@ export const HeaderConstants = {
   X_MS_CLIENT_REQUEST_ID: "x-ms-client-request-id",
   X_MS_DATE: "x-ms-date"
 };
+
+export const SECONDARY_SUFFIX = "-secondary";

--- a/src/blob/utils/utils.ts
+++ b/src/blob/utils/utils.ts
@@ -2,6 +2,7 @@ import { createHash, createHmac } from "crypto";
 import etag from "etag";
 import { createWriteStream, PathLike } from "fs";
 import { parse } from "url";
+
 import * as Models from "../generated/artifacts/models";
 import Context from "../generated/Context";
 import {
@@ -100,11 +101,7 @@ export function getURLQueries(url: string): { [key: string]: string } {
   querySubStrings = querySubStrings.filter((value: string) => {
     const indexOfEqual = value.indexOf("=");
     const lastIndexOfEqual = value.lastIndexOf("=");
-    return (
-      indexOfEqual > 0 &&
-      indexOfEqual === lastIndexOfEqual &&
-      lastIndexOfEqual < value.length - 1
-    );
+    return indexOfEqual > 0 && indexOfEqual === lastIndexOfEqual;
   });
 
   const queries: { [key: string]: string } = {};

--- a/src/blob/utils/utils.ts
+++ b/src/blob/utils/utils.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash, createHmac } from "crypto";
 import etag from "etag";
 import { createWriteStream, PathLike } from "fs";
 import { parse } from "url";
@@ -9,6 +9,40 @@ import {
   EMULATOR_ACCOUNT_KIND,
   EMULATOR_ACCOUNT_SKUNAME
 } from "../utils/constants";
+
+/**
+ * Generates a hash signature for an HTTP request or for a SAS.
+ *
+ * @param {string} stringToSign
+ * @param {key} key
+ * @returns {string}
+ */
+export function computeHMACSHA256(stringToSign: string, key: Buffer): string {
+  return createHmac("sha256", key)
+    .update(stringToSign, "utf8")
+    .digest("base64");
+}
+
+/**
+ * Rounds a date off to seconds.
+ *
+ * @export
+ * @param {Date} date
+ * @param {boolean} [withMilliseconds=true] If true, YYYY-MM-DDThh:mm:ss.fffffffZ will be returned;
+ *                                          If false, YYYY-MM-DDThh:mm:ssZ will be returned.
+ * @returns {string} Date string in ISO8061 format, with or without 7 milliseconds component
+ */
+export function truncatedISO8061Date(
+  date: Date,
+  withMilliseconds: boolean = true
+): string {
+  // Date.toISOString() will return like "2018-10-29T06:34:36.139Z"
+  const dateString = date.toISOString();
+
+  return withMilliseconds
+    ? dateString.substring(0, dateString.length - 1) + "0000" + "Z"
+    : dateString.substring(0, dateString.length - 5) + "Z";
+}
 
 // TODO: Align eTag with Azure Storage Service
 export function newEtag(): string {

--- a/tests/blob/apis/container.test.ts
+++ b/tests/blob/apis/container.test.ts
@@ -11,6 +11,7 @@ import assert = require("assert");
 
 import BlobConfiguration from "../../../src/blob/BlobConfiguration";
 import Server from "../../../src/blob/BlobServer";
+import { configLogger } from "../../../src/common/Logger";
 import {
   EMULATOR_ACCOUNT_KEY,
   EMULATOR_ACCOUNT_NAME,
@@ -18,6 +19,9 @@ import {
   rmRecursive,
   sleep
 } from "../../testutils";
+
+// Set to true enable debug log
+configLogger(false);
 
 describe("ContainerAPIs", () => {
   // TODO: Create a server factory as tests utils
@@ -380,7 +384,7 @@ describe("ContainerAPIs", () => {
       blobURLs.push(blobURL);
     }
 
-    const inputmarker = "";
+    const inputmarker = undefined;
     const result = await containerURL.listBlobFlatSegment(
       Aborter.none,
       inputmarker

--- a/tests/blob/sas.test.ts
+++ b/tests/blob/sas.test.ts
@@ -1,0 +1,416 @@
+import {
+  Aborter,
+  AccountSASPermissions,
+  AccountSASResourceTypes,
+  AccountSASServices,
+  AnonymousCredential,
+  BlobSASPermissions,
+  ContainerSASPermissions,
+  ContainerURL,
+  generateAccountSASQueryParameters,
+  generateBlobSASQueryParameters,
+  PageBlobURL,
+  SASProtocol,
+  ServiceURL,
+  SharedKeyCredential,
+  StorageURL
+} from "@azure/storage-blob";
+import * as assert from "assert";
+
+import BlobConfiguration from "../../src/blob/BlobConfiguration";
+import Server from "../../src/blob/BlobServer";
+import { configLogger } from "../../src/common/Logger";
+import {
+  EMULATOR_ACCOUNT_KEY,
+  EMULATOR_ACCOUNT_NAME,
+  getUniqueName,
+  rmRecursive
+} from "../testutils";
+
+configLogger(true);
+
+describe("Shared Access Signature (SAS) generation Node.js only", () => {
+  // TODO: Create a server factory as tests utils
+  const host = "127.0.0.1";
+  const port = 11000;
+  const dbPath = "__testsstorage__";
+  const persistencePath = "__testspersistence__";
+  const config = new BlobConfiguration(
+    host,
+    port,
+    dbPath,
+    persistencePath,
+    false
+  );
+
+  // TODO: Create serviceURL factory as tests utils
+  const baseURL = `http://${host}:${port}/devstoreaccount1`;
+  const serviceURL = new ServiceURL(
+    baseURL,
+    StorageURL.newPipeline(
+      new SharedKeyCredential(EMULATOR_ACCOUNT_NAME, EMULATOR_ACCOUNT_KEY),
+      {
+        retryOptions: { maxTries: 1 }
+      }
+    )
+  );
+
+  let server: Server;
+
+  before(async () => {
+    server = new Server(config);
+    await server.start();
+  });
+
+  after(async () => {
+    await server.close();
+    await rmRecursive(dbPath);
+    await rmRecursive(persistencePath);
+  });
+
+  it("generateAccountSASQueryParameters should work", async () => {
+    const now = new Date();
+    now.setMinutes(now.getMinutes() - 5); // Skip clock skew with server
+
+    const tmr = new Date();
+    tmr.setDate(tmr.getDate() + 1);
+
+    // By default, credential is always the last element of pipeline factories
+    const factories = serviceURL.pipeline.factories;
+    const sharedKeyCredential = factories[factories.length - 1];
+
+    const sas = generateAccountSASQueryParameters(
+      {
+        expiryTime: tmr,
+        ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
+        permissions: AccountSASPermissions.parse("rwdlacup").toString(),
+        protocol: SASProtocol.HTTPSandHTTP,
+        resourceTypes: AccountSASResourceTypes.parse("sco").toString(),
+        services: AccountSASServices.parse("btqf").toString(),
+        startTime: now,
+        version: "2016-05-31"
+      },
+      sharedKeyCredential as SharedKeyCredential
+    ).toString();
+
+    const sasURL = `${serviceURL.url}?${sas}`;
+    const serviceURLWithSAS = new ServiceURL(
+      sasURL,
+      StorageURL.newPipeline(new AnonymousCredential())
+    );
+
+    await serviceURLWithSAS.getAccountInfo(Aborter.none);
+  });
+
+  it("generateAccountSASQueryParameters should not work with invalid permission", async () => {
+    const tmr = new Date();
+    tmr.setDate(tmr.getDate() + 1);
+
+    // By default, credential is always the last element of pipeline factories
+    const factories = serviceURL.pipeline.factories;
+    const sharedKeyCredential = factories[factories.length - 1];
+
+    const sas = generateAccountSASQueryParameters(
+      {
+        expiryTime: tmr,
+        permissions: AccountSASPermissions.parse("wdlcup").toString(),
+        resourceTypes: AccountSASResourceTypes.parse("sco").toString(),
+        services: AccountSASServices.parse("btqf").toString()
+      },
+      sharedKeyCredential as SharedKeyCredential
+    ).toString();
+
+    const sasURL = `${serviceURL.url}?${sas}`;
+    const serviceURLWithSAS = new ServiceURL(
+      sasURL,
+      StorageURL.newPipeline(new AnonymousCredential())
+    );
+
+    let error;
+    try {
+      await serviceURLWithSAS.getProperties(Aborter.none);
+    } catch (err) {
+      error = err;
+    }
+
+    assert.ok(error);
+  });
+
+  it("generateAccountSASQueryParameters should not work with invalid service", async () => {
+    const tmr = new Date();
+    tmr.setDate(tmr.getDate() + 1);
+
+    // By default, credential is always the last element of pipeline factories
+    const factories = serviceURL.pipeline.factories;
+    const sharedKeyCredential = factories[factories.length - 1];
+
+    const sas = generateAccountSASQueryParameters(
+      {
+        expiryTime: tmr,
+        permissions: AccountSASPermissions.parse("rwdlacup").toString(),
+        resourceTypes: AccountSASResourceTypes.parse("sco").toString(),
+        services: AccountSASServices.parse("tqf").toString()
+      },
+      sharedKeyCredential as SharedKeyCredential
+    ).toString();
+
+    const sasURL = `${serviceURL.url}?${sas}`;
+    const serviceURLWithSAS = new ServiceURL(
+      sasURL,
+      StorageURL.newPipeline(new AnonymousCredential())
+    );
+
+    let error;
+    try {
+      await serviceURLWithSAS.getProperties(Aborter.none);
+    } catch (err) {
+      error = err;
+    }
+
+    assert.ok(error);
+  });
+
+  it("generateAccountSASQueryParameters should not work with invalid resource type", async () => {
+    const tmr = new Date();
+    tmr.setDate(tmr.getDate() + 1);
+
+    // By default, credential is always the last element of pipeline factories
+    const factories = serviceURL.pipeline.factories;
+    const sharedKeyCredential = factories[factories.length - 1];
+
+    const sas = generateAccountSASQueryParameters(
+      {
+        expiryTime: tmr,
+        ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
+        permissions: AccountSASPermissions.parse("rwdlacup").toString(),
+        protocol: SASProtocol.HTTPSandHTTP,
+        resourceTypes: AccountSASResourceTypes.parse("co").toString(),
+        services: AccountSASServices.parse("btqf").toString(),
+        version: "2016-05-31"
+      },
+      sharedKeyCredential as SharedKeyCredential
+    ).toString();
+
+    const sasURL = `${serviceURL.url}?${sas}`;
+    const serviceURLWithSAS = new ServiceURL(
+      sasURL,
+      StorageURL.newPipeline(new AnonymousCredential())
+    );
+
+    let error;
+    try {
+      await serviceURLWithSAS.getProperties(Aborter.none);
+    } catch (err) {
+      error = err;
+    }
+
+    assert.ok(error);
+  });
+
+  it.skip("generateBlobSASQueryParameters should work for container", async () => {
+    const now = new Date();
+    now.setMinutes(now.getMinutes() - 5); // Skip clock skew with server
+
+    const tmr = new Date();
+    tmr.setDate(tmr.getDate() + 1);
+
+    // By default, credential is always the last element of pipeline factories
+    const factories = serviceURL.pipeline.factories;
+    const sharedKeyCredential = factories[factories.length - 1];
+
+    const containerName = getUniqueName("container");
+    const containerURL = ContainerURL.fromServiceURL(serviceURL, containerName);
+    await containerURL.create(Aborter.none);
+
+    const containerSAS = generateBlobSASQueryParameters(
+      {
+        containerName,
+        expiryTime: tmr,
+        ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
+        permissions: ContainerSASPermissions.parse("racwdl").toString(),
+        protocol: SASProtocol.HTTPSandHTTP,
+        startTime: now,
+        version: "2016-05-31"
+      },
+      sharedKeyCredential as SharedKeyCredential
+    );
+
+    const sasURL = `${containerURL.url}?${containerSAS}`;
+    const containerURLwithSAS = new ContainerURL(
+      sasURL,
+      StorageURL.newPipeline(new AnonymousCredential())
+    );
+
+    await containerURLwithSAS.listBlobFlatSegment(Aborter.none);
+    await containerURL.delete(Aborter.none);
+  });
+
+  it.skip("generateBlobSASQueryParameters should work for blob", async () => {
+    const now = new Date();
+    now.setMinutes(now.getMinutes() - 5); // Skip clock skew with server
+
+    const tmr = new Date();
+    tmr.setDate(tmr.getDate() + 1);
+
+    // By default, credential is always the last element of pipeline factories
+    const factories = serviceURL.pipeline.factories;
+    const sharedKeyCredential = factories[factories.length - 1];
+
+    const containerName = getUniqueName("container");
+    const containerURL = ContainerURL.fromServiceURL(serviceURL, containerName);
+    await containerURL.create(Aborter.none);
+
+    const blobName = getUniqueName("blob");
+    const blobURL = PageBlobURL.fromContainerURL(containerURL, blobName);
+    await blobURL.create(Aborter.none, 1024, {
+      blobHTTPHeaders: {
+        blobContentType: "content-type-original"
+      }
+    });
+
+    const blobSAS = generateBlobSASQueryParameters(
+      {
+        blobName,
+        cacheControl: "cache-control-override",
+        containerName,
+        contentDisposition: "content-disposition-override",
+        contentEncoding: "content-encoding-override",
+        contentLanguage: "content-language-override",
+        contentType: "content-type-override",
+        expiryTime: tmr,
+        ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
+        permissions: BlobSASPermissions.parse("racwd").toString(),
+        protocol: SASProtocol.HTTPSandHTTP,
+        startTime: now,
+        version: "2016-05-31"
+      },
+      sharedKeyCredential as SharedKeyCredential
+    );
+
+    const sasURL = `${blobURL.url}?${blobSAS}`;
+    const blobURLwithSAS = new PageBlobURL(
+      sasURL,
+      StorageURL.newPipeline(new AnonymousCredential())
+    );
+
+    const properties = await blobURLwithSAS.getProperties(Aborter.none);
+    assert.equal(properties.cacheControl, "cache-control-override");
+    assert.equal(properties.contentDisposition, "content-disposition-override");
+    assert.equal(properties.contentEncoding, "content-encoding-override");
+    assert.equal(properties.contentLanguage, "content-language-override");
+    assert.equal(properties.contentType, "content-type-override");
+
+    await containerURL.delete(Aborter.none);
+  });
+
+  it.skip("generateBlobSASQueryParameters should work for blob with special namings", async () => {
+    const now = new Date();
+    now.setMinutes(now.getMinutes() - 5); // Skip clock skew with server
+
+    const tmr = new Date();
+    tmr.setDate(tmr.getDate() + 1);
+
+    // By default, credential is always the last element of pipeline factories
+    const factories = serviceURL.pipeline.factories;
+    const sharedKeyCredential = factories[factories.length - 1];
+
+    const containerName = getUniqueName("container-with-dash");
+    const containerURL = ContainerURL.fromServiceURL(serviceURL, containerName);
+    await containerURL.create(Aborter.none);
+
+    const blobName = getUniqueName(
+      // tslint:disable-next-line:max-line-length
+      "////Upper/blob/empty /another 汉字 ру́сский язы́к ру́сский язы́к عربي/عربى にっぽんご/にほんご . special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'"
+    );
+    const blobURL = PageBlobURL.fromContainerURL(containerURL, blobName);
+    await blobURL.create(Aborter.none, 1024, {
+      blobHTTPHeaders: {
+        blobContentType: "content-type-original"
+      }
+    });
+
+    const blobSAS = generateBlobSASQueryParameters(
+      {
+        // NOTICE: Azure Storage Server will replace "\" with "/" in the blob names
+        blobName: blobName.replace(/\\/g, "/"),
+        cacheControl: "cache-control-override",
+        containerName,
+        contentDisposition: "content-disposition-override",
+        contentEncoding: "content-encoding-override",
+        contentLanguage: "content-language-override",
+        contentType: "content-type-override",
+        expiryTime: tmr,
+        ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
+        permissions: BlobSASPermissions.parse("racwd").toString(),
+        protocol: SASProtocol.HTTPSandHTTP,
+        startTime: now,
+        version: "2016-05-31"
+      },
+      sharedKeyCredential as SharedKeyCredential
+    );
+
+    const sasURL = `${blobURL.url}?${blobSAS}`;
+    const blobURLwithSAS = new PageBlobURL(
+      sasURL,
+      StorageURL.newPipeline(new AnonymousCredential())
+    );
+
+    const properties = await blobURLwithSAS.getProperties(Aborter.none);
+    assert.equal(properties.cacheControl, "cache-control-override");
+    assert.equal(properties.contentDisposition, "content-disposition-override");
+    assert.equal(properties.contentEncoding, "content-encoding-override");
+    assert.equal(properties.contentLanguage, "content-language-override");
+    assert.equal(properties.contentType, "content-type-override");
+
+    await containerURL.delete(Aborter.none);
+  });
+
+  it.skip("generateBlobSASQueryParameters should work for blob with access policy", async () => {
+    const now = new Date();
+    now.setMinutes(now.getMinutes() - 5); // Skip clock skew with server
+
+    const tmr = new Date();
+    tmr.setDate(tmr.getDate() + 1);
+
+    // By default, credential is always the last element of pipeline factories
+    const factories = serviceURL.pipeline.factories;
+    const sharedKeyCredential = factories[factories.length - 1];
+
+    const containerName = getUniqueName("container");
+    const containerURL = ContainerURL.fromServiceURL(serviceURL, containerName);
+    await containerURL.create(Aborter.none);
+
+    const blobName = getUniqueName("blob");
+    const blobURL = PageBlobURL.fromContainerURL(containerURL, blobName);
+    await blobURL.create(Aborter.none, 1024);
+
+    const id = "unique-id";
+    await containerURL.setAccessPolicy(Aborter.none, undefined, [
+      {
+        accessPolicy: {
+          expiry: tmr,
+          permission: ContainerSASPermissions.parse("racwdl").toString(),
+          start: now
+        },
+        id
+      }
+    ]);
+
+    const blobSAS = generateBlobSASQueryParameters(
+      {
+        containerName,
+        identifier: id
+      },
+      sharedKeyCredential as SharedKeyCredential
+    );
+
+    const sasURL = `${blobURL.url}?${blobSAS}`;
+    const blobURLwithSAS = new PageBlobURL(
+      sasURL,
+      StorageURL.newPipeline(new AnonymousCredential())
+    );
+
+    await blobURLwithSAS.getProperties(Aborter.none);
+    await containerURL.delete(Aborter.none);
+  });
+});

--- a/tests/blob/sas.test.ts
+++ b/tests/blob/sas.test.ts
@@ -27,7 +27,7 @@ import {
   rmRecursive
 } from "../testutils";
 
-configLogger(false);
+configLogger(true);
 
 describe("Shared Access Signature (SAS) generation Node.js only", () => {
   // TODO: Create a server factory as tests utils

--- a/tests/blob/sas.test.ts
+++ b/tests/blob/sas.test.ts
@@ -27,7 +27,7 @@ import {
   rmRecursive
 } from "../testutils";
 
-configLogger(true);
+configLogger(false);
 
 describe("Shared Access Signature (SAS) generation Node.js only", () => {
   // TODO: Create a server factory as tests utils


### PR DESCRIPTION
Now AzuriteV3 works with most of .net sample besides blob service SAS and CopyBlob.

Supported Account SAS, and fixed several bugs and improvements:

* Fixed a poential shared key auth error due to missing empty url query parameter; 
* Added support for secondary account url; 
* Fixed a getBlob bug in persistency layer which cannot return proper blob model; 
* Implemented getStatistics; Updated download page blob 206 status code; 
* Added logging for serialize and deserialize methods;