### PR TITLE
Run install as root in docker so that vscode module installs correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ VOLUME [ "/data" ]
 
 COPY . .
 
+RUN npm config set unsafe-perm=true
 RUN npm install
 RUN npm run build
 RUN npm install -g


### PR DESCRIPTION
Module vscode was not being installed when building Docker image - running `npm config set unsafe-perm=true` before install allows this module to be installed within the container correctly.