### PR TITLE
Fix listblobs order when filtering by prefix

### DIFF
--- a/src/blob/handlers/ContainerHandler.ts
+++ b/src/blob/handlers/ContainerHandler.ts
@@ -757,7 +757,7 @@ export default class ContainerHandler extends BaseHandler
     const request = context.request!;
     const accountName = container.accountName;
     const containerName = container.name;
-    const marker = parseInt(options.marker || "0", 10);
+    const marker = options.marker;
     const delimiter = "";
     options.marker = options.marker || "";
     let includeSnapshots: boolean = false;
@@ -828,7 +828,7 @@ export default class ContainerHandler extends BaseHandler
     const request = context.request!;
     const accountName = container.accountName;
     const containerName = container.name;
-    const marker = parseInt(options.marker || "0", 10);
+    const marker = options.marker;
     delimiter = delimiter === "" ? "/" : delimiter;
     options.prefix = options.prefix || "";
     options.marker = options.marker || "";

--- a/src/blob/persistence/IBlobDataStore.ts
+++ b/src/blob/persistence/IBlobDataStore.ts
@@ -250,9 +250,9 @@ export interface IBlobDataStore extends IDataStore {
     blob?: string,
     prefix?: string,
     maxResults?: number,
-    marker?: number,
+    marker?: string,
     includeSnapshots?: boolean
-  ): Promise<[T[], number | undefined]>;
+  ): Promise<[T[], string | undefined]>;
 
   /**
    * Delete blob item from persistency layer.

--- a/src/blob/persistence/LokiBlobDataStore.ts
+++ b/src/blob/persistence/LokiBlobDataStore.ts
@@ -447,7 +447,7 @@ export default class LokiBlobDataStore implements IBlobDataStore {
     blob?: string,
     prefix: string | undefined = "",
     maxResults: number | undefined = 5000,
-    marker?: string,
+    marker: string = "",
     includeSnapshots?: boolean | undefined
   ): Promise<[T[], string | undefined]> {
     const query: any = {};
@@ -462,10 +462,6 @@ export default class LokiBlobDataStore implements IBlobDataStore {
     }
     if (container !== undefined) {
       query.containerName = container;
-    }
-
-    if (marker === undefined) {
-      marker = "";
     }
 
     const coll = this.db.getCollection(this.BLOBS_COLLECTION);

--- a/src/blob/persistence/LokiBlobDataStore.ts
+++ b/src/blob/persistence/LokiBlobDataStore.ts
@@ -502,7 +502,7 @@ export default class LokiBlobDataStore implements IBlobDataStore {
     if (docs.length < maxResults) {
       return [docs, undefined];
     } else {
-      const nextMarker = docs.length;
+      const nextMarker = docs.length + marker;
       return [docs, nextMarker];
     }
   }

--- a/src/blob/persistence/LokiBlobDataStore.ts
+++ b/src/blob/persistence/LokiBlobDataStore.ts
@@ -464,7 +464,9 @@ export default class LokiBlobDataStore implements IBlobDataStore {
       query.containerName = container;
     }
 
-    query.$loki = { $gt: marker };
+    if (marker === undefined) {
+      marker = 0;
+    }
 
     const coll = this.db.getCollection(this.BLOBS_COLLECTION);
 
@@ -474,6 +476,7 @@ export default class LokiBlobDataStore implements IBlobDataStore {
         .chain()
         .find(query)
         .simplesort("name")
+        .offset(marker)
         .limit(maxResults)
         .data();
     } else {
@@ -484,6 +487,7 @@ export default class LokiBlobDataStore implements IBlobDataStore {
           return obj.snapshot.length === 0;
         })
         .simplesort("name")
+        .offset(marker)
         .limit(maxResults)
         .data();
     }
@@ -498,7 +502,7 @@ export default class LokiBlobDataStore implements IBlobDataStore {
     if (docs.length < maxResults) {
       return [docs, undefined];
     } else {
-      const nextMarker = docs[docs.length - 1].$loki;
+      const nextMarker = docs.length;
       return [docs, nextMarker];
     }
   }

--- a/src/blob/persistence/LokiBlobDataStore.ts
+++ b/src/blob/persistence/LokiBlobDataStore.ts
@@ -473,6 +473,7 @@ export default class LokiBlobDataStore implements IBlobDataStore {
       docs = await coll
         .chain()
         .find(query)
+        .simplesort("name")
         .limit(maxResults)
         .data();
     } else {
@@ -482,6 +483,7 @@ export default class LokiBlobDataStore implements IBlobDataStore {
         .where(obj => {
           return obj.snapshot.length === 0;
         })
+        .simplesort("name")
         .limit(maxResults)
         .data();
     }

--- a/src/blob/persistence/LokiReferredExtentsAsyncIterator.ts
+++ b/src/blob/persistence/LokiReferredExtentsAsyncIterator.ts
@@ -21,7 +21,7 @@ export default class LokiReferredExtentsAsyncIterator
   implements AsyncIterator<IPersistencyChunk[]> {
   private state: State = State.LISTING_EXTENTS_IN_BLOBS;
 
-  private blobListingMarker: number | undefined;
+  private blobListingMarker: string | undefined;
 
   constructor(
     private readonly blobDataStore: LokiBlobDataStore,

--- a/tests/blob/apis/container.test.ts
+++ b/tests/blob/apis/container.test.ts
@@ -476,7 +476,7 @@ describe("ContainerAPIs", () => {
     );
     assert.ok(result.serviceEndpoint.length > 0);
     assert.ok(containerURL.url.indexOf(result.containerName));
-    assert.ok(result.nextMarker);
+    assert.equal(result.nextMarker, "blockblob/abc-003");
     assert.equal(result.segment.blobItems.length, 4);
 
     const gotNames: Array<string> = [];
@@ -494,7 +494,7 @@ describe("ContainerAPIs", () => {
     );
     assert.ok(result.serviceEndpoint.length > 0);
     assert.ok(containerURL.url.indexOf(result.containerName));
-    assert.ok(result.nextMarker);
+    assert.equal(result.nextMarker, "blockblob/abc-007");
     assert.equal(result.segment.blobItems.length, 4);
 
     for (const item of result.segment.blobItems) {

--- a/tests/blob/apis/container.test.ts
+++ b/tests/blob/apis/container.test.ts
@@ -471,12 +471,13 @@ describe("ContainerAPIs", () => {
       Aborter.none,
       inputmarker,
       {
-        maxresults: 7
+        maxresults: 4
       }
     );
     assert.ok(result.serviceEndpoint.length > 0);
     assert.ok(containerURL.url.indexOf(result.containerName));
     assert.ok(result.nextMarker);
+    assert.equal(result.segment.blobItems.length, 4);
 
     const gotNames: Array<string> = [];
 
@@ -484,19 +485,33 @@ describe("ContainerAPIs", () => {
       gotNames.push(item.name);
     }
 
-    assert.equal(result.segment.blobItems.length, 7);
+    result = await containerURL.listBlobFlatSegment(
+      Aborter.none,
+      result.nextMarker,
+      {
+        maxresults: 4
+      }
+    );
+    assert.ok(result.serviceEndpoint.length > 0);
+    assert.ok(containerURL.url.indexOf(result.containerName));
+    assert.ok(result.nextMarker);
+    assert.equal(result.segment.blobItems.length, 4);
+
+    for (const item of result.segment.blobItems) {
+      gotNames.push(item.name);
+    }
 
     result = await containerURL.listBlobFlatSegment(
       Aborter.none,
       result.nextMarker,
       {
-        maxresults: 7
+        maxresults: 4
       }
     );
     assert.ok(result.serviceEndpoint.length > 0);
     assert.ok(containerURL.url.indexOf(result.containerName));
     assert.strictEqual(result.nextMarker, "");
-    assert.equal(result.segment.blobItems.length, 3);
+    assert.equal(result.segment.blobItems.length, 2);
 
     for (const item of result.segment.blobItems) {
       gotNames.push(item.name);

--- a/tests/blob/apis/container.test.ts
+++ b/tests/blob/apis/container.test.ts
@@ -443,23 +443,34 @@ describe("ContainerAPIs", () => {
 
   it("returns a valid, correct nextMarker", async () => {
     const blobURLs = [];
-    const blobNames: Array<string> = [];
+    var blobNames: Array<string> = [
+      "blockblob/abc-001",
+      "blockblob/abc-004",
+      "blockblob/abc-009",
+      "blockblob/abc-003",
+      "blockblob/abc-006",
+      "blockblob/abc-000",
+      "blockblob/abc-007",
+      "blockblob/abc-002",
+      "blockblob/abc-005",
+      "blockblob/abc-008"
+    ];
 
     for (let i = 0; i < 10; i++) {
-      var name = `blockblob${i}/abc-00${i}`;
-      const blobURL = BlobURL.fromContainerURL(containerURL, name);
+      const blobURL = BlobURL.fromContainerURL(containerURL, blobNames[i]);
       const blockBlobURL = BlockBlobURL.fromBlobURL(blobURL);
       await blockBlobURL.upload(Aborter.none, "", 0);
       blobURLs.push(blobURL);
-      blobNames.push(name);
     }
+
+    //Sort blobnames for comparison
+    blobNames = blobNames.sort();
 
     const inputmarker = undefined;
     var result = await containerURL.listBlobFlatSegment(
       Aborter.none,
       inputmarker,
       {
-        prefix: "blockblob",
         maxresults: 7
       }
     );
@@ -479,7 +490,6 @@ describe("ContainerAPIs", () => {
       Aborter.none,
       result.nextMarker,
       {
-        prefix: "blockblob",
         maxresults: 7
       }
     );


### PR DESCRIPTION
In the Azure docs for List Blobs it specifies

> Blobs are listed in alphabetical order in the response body, with upper-case letters listed first.

(via: https://docs.microsoft.com/en-us/rest/api/storageservices/list-blobs search for "alphabetical")

However we have found that Azurite does not guarantee that ordering when listing blobs with a `prefix` option. This PR simply adds a test that exposes that behavior and adds a lokijs `simplesort` call to the `listBlobs` function.

We found this bug by trying to use Azurite for testing when implementing a client app for Azure Blob storage. When we went to write paging using the `Marker` functionality we noticed that when the prefix option is sent to Azurite the results are returned in reverse create order, not alphabetical order. When tested against `<account>.blob.core.microsoft.net` the order is correct in all scenarios.
