### PR TITLE
Add .gitattributes and .dockerignore; replace "npm install" with "npm ci"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.vscode/**
+node_modules/**
+swagger/**
+__blobstorage__/**
+__queuestorage__/**

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -15,14 +15,14 @@ In the root of the repository, we have provided pre-defined debugging scripts. T
 Manually follow following steps to build and run all services in Azurite:
 
 ```bash
-npm install
+npm ci
 npm run azurite
 ```
 
 Or build and run a certain service like Blob service:
 
 ```bash
-npm install
+npm ci
 npm run blob
 ```
 
@@ -57,7 +57,7 @@ We also provide a predefined Visual Studio Code debug configuration "Current Moc
 Or manually execute all test cases:
 
 ```bash
-npm install
+npm ci
 npm run test
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ VOLUME [ "/data" ]
 COPY . .
 
 RUN npm config set unsafe-perm=true
-RUN npm install
+RUN npm ci
 RUN npm run build
 RUN npm install -g
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Try with any of following ways to start an Azurite V3 instance.
 After cloning source code, execute following commands to install and start Azurite V3.
 
 ```bash
-npm install
+npm ci
 npm run build
 npm install -g
 azurite


### PR DESCRIPTION
Add .gitattributes to assist people using different host operating systems. Add .dockerignore to minimise the amount of files sent to docker machine when creating the docker image. Replaced "npm install" with "npm ci" in various places, in particular in Dockerfile to make container image builds repeatable.

Thanks for contribution! Please go through following checklist before sending PR.

### PR Branch Destination

- For Azurite V3, please send PR to `dev` branch.
- For legacy Azurite V2, please send PR to `legacy-dev` branch.

=> intended to go to branch "dev"

### Always Add Test Cases

=> Can't think of reasonable automated tests

### Development Guideline

Please go to CONTRIBUTION.md for steps about setting up development environment and recommended Visual Studio Code extensions.

=> Done
