### PR TITLE
Support production-style URLs (e.g. http://account.localhost/container)

### DIFF
--- a/src/blob/handlers/BlobHandler.ts
+++ b/src/blob/handlers/BlobHandler.ts
@@ -576,7 +576,7 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
       sourceAccount,
       sourceContainer,
       sourceBlob
-    ] = extractStoragePartsFromPath(url.pathname);
+    ] = extractStoragePartsFromPath(url.hostname, url.pathname);
     const snapshot = url.searchParams.get("snapshot") || "";
 
     if (

--- a/src/blob/middlewares/blobStorageContext.middleware.ts
+++ b/src/blob/middlewares/blobStorageContext.middleware.ts
@@ -2,10 +2,10 @@ import { NextFunction, Request, Response } from "express";
 import uuid from "uuid/v4";
 
 import logger from "../../common/Logger";
+import { PRODUCTION_STYLE_URL_HOSTNAME } from "../../common/utils/constants";
 import { checkApiVersion } from "../../common/utils/utils";
 import BlobStorageContext from "../context/BlobStorageContext";
 import StorageErrorFactory from "../errors/StorageErrorFactory";
-import { PRODUCTION_STYLE_URL_HOSTNAME } from "../../common/utils/constants";
 import {
   DEFAULT_CONTEXT_PATH,
   HeaderConstants,
@@ -62,7 +62,8 @@ export default function blobStorageContextMiddleware(
   blobContext.blob = blob;
   blobContext.isSecondary = isSecondary;
 
-  // Emulator's URL pattern is like http://hostname[:port]/account/container (or, alternatively, http[s]://account.localhost[:port]/container)
+  // Emulator's URL pattern is like http://hostname[:port]/account/container
+  // (or, alternatively, http[s]://account.localhost[:port]/container)
   // Create a router to exclude account name from req.path, as url path in swagger doesn't include account
   // Exclude account name from req.path for dispatchMiddleware
   blobContext.dispatchPattern = container
@@ -126,7 +127,7 @@ export function extractStoragePartsFromPath(
 
   const parts = normalizedPath.split("/");
 
-  var urlPartIndex = 0;
+  let urlPartIndex = 0;
   if (hostname.endsWith(PRODUCTION_STYLE_URL_HOSTNAME)) {
     account = hostname.substring(
       0,

--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -25,7 +25,8 @@ export const DEFAULT_SQL_OPTIONS = {
   }
 };
 
-// In some scenarios, users want to test with production-style URLs like http[s]://devstoreaccount1.localhost[:port]/container/path/blob.dat
+// In some scenarios, users want to test with production-style URLs like
+// http[s]://devstoreaccount1.localhost[:port]/container/path/blob.dat
 // (as opposed to default emulator style http[s]://hostname[:port]/devstoreaccount1/container/path/blob.dat
 // When URL's hostname ends with .localhost, we assume user wants to use production-style URL format.
 export const PRODUCTION_STYLE_URL_HOSTNAME = ".localhost";

--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -24,3 +24,8 @@ export const DEFAULT_SQL_OPTIONS = {
     timezone: "+00:00"
   }
 };
+
+// In some scenarios, users want to test with production-style URLs like http[s]://devstoreaccount1.localhost[:port]/container/path/blob.dat
+// (as opposed to default emulator style http[s]://hostname[:port]/devstoreaccount1/container/path/blob.dat
+// When URL's hostname ends with .localhost, we assume user wants to use production-style URL format.
+export const PRODUCTION_STYLE_URL_HOSTNAME = ".localhost";

--- a/src/queue/middlewares/queueStorageContext.middleware.ts
+++ b/src/queue/middlewares/queueStorageContext.middleware.ts
@@ -2,10 +2,10 @@ import { NextFunction, Request, Response } from "express";
 import uuid from "uuid/v4";
 
 import logger from "../../common/Logger";
+import { PRODUCTION_STYLE_URL_HOSTNAME } from "../../common/utils/constants";
 import { checkApiVersion } from "../../common/utils/utils";
 import QueueStorageContext from "../context/QueueStorageContext";
 import StorageErrorFactory from "../errors/StorageErrorFactory";
-import { PRODUCTION_STYLE_URL_HOSTNAME } from "../../common/utils/constants";
 import {
   DEFAULT_QUEUE_CONTEXT_PATH,
   HeaderConstants,
@@ -71,7 +71,8 @@ export default function queueStorageContextMiddleware(
   queueContext.messageId = messageId;
   queueContext.isSecondary = isSecondary;
 
-  // Emulator's URL pattern is like http://hostname[:port]/account/queue/messages (or, alternatively, http[s]://account.localhost[:port]/queue/messages)
+  // Emulator's URL pattern is like http://hostname[:port]/account/queue/messages
+  // (or, alternatively, http[s]://account.localhost[:port]/queue/messages)
   // Create a router to exclude account name from req.path, as url path in swagger doesn't include account
   // Exclude account name from req.path for dispatchMiddleware
   queueContext.dispatchPattern =
@@ -172,7 +173,7 @@ export function extractStoragePartsFromPath(
 
   const parts = normalizedPath.split("/");
 
-  var urlPartIndex = 0;
+  let urlPartIndex = 0;
   if (hostname.endsWith(PRODUCTION_STYLE_URL_HOSTNAME)) {
     account = hostname.substring(
       0,


### PR DESCRIPTION
Solves #403 - adds ability to use production-style URLs when using "account.localhost" as the host name.
E.g. default URL format for emulator is

> http://hostname[:port]/account/container

this adds ability to use 

> http[s]://account.localhost[:port]/container

It's users' responsibility that account.localhost resolves to 127.0.0.1. On Windows (I believe this works out of the box on Linux), this can be achieved by adding hosts file record, for example. 

C:\Windows\System32\drivers\etc\hosts
```
<...>
127.0.0.1       devstoreaccount1.localhost

```

I contemplated putting this functionality under some sort of flag (like environmental variable).
But then I realized that it's very unlikely to break any existing use patterns, as it requires issuing API requests to accountname.localhost, and having that resolve to 127.0.0.1, hence I proposed to enable this feature by default.

