### PR TITLE
listBlobs should only list committed blobs

### DIFF
--- a/src/blob/handlers/ContainerHandler.ts
+++ b/src/blob/handlers/ContainerHandler.ts
@@ -534,9 +534,15 @@ export default class ContainerHandler extends BaseHandler
     const delimiter = "";
     options.marker = options.marker || "";
     let includeSnapshots: boolean = false;
+    let includeUncommittedBlobs: boolean = false;
     if (options.include !== undefined) {
       if (options.include.includes(Models.ListBlobsIncludeItem.Snapshots)) {
         includeSnapshots = true;
+      }
+      if (
+        options.include.includes(Models.ListBlobsIncludeItem.Uncommittedblobs)
+      ) {
+        includeUncommittedBlobs = true;
       }
     }
     if (
@@ -554,7 +560,8 @@ export default class ContainerHandler extends BaseHandler
       options.prefix,
       options.maxresults,
       marker,
-      includeSnapshots
+      includeSnapshots,
+      includeUncommittedBlobs
     );
 
     const serviceEndpoint = `${request.getEndpoint()}/${accountName}`;
@@ -621,9 +628,15 @@ export default class ContainerHandler extends BaseHandler
     options.prefix = options.prefix || "";
     options.marker = options.marker || "";
     let includeSnapshots: boolean = false;
+    let includeUncommittedBlobs: boolean = false;
     if (options.include !== undefined) {
       if (options.include.includes(Models.ListBlobsIncludeItem.Snapshots)) {
         includeSnapshots = true;
+      }
+      if (
+        options.include.includes(Models.ListBlobsIncludeItem.Uncommittedblobs)
+      ) {
+        includeUncommittedBlobs = true;
       }
     }
     if (
@@ -641,7 +654,8 @@ export default class ContainerHandler extends BaseHandler
       options.prefix,
       options.maxresults,
       marker,
-      includeSnapshots
+      includeSnapshots,
+      includeUncommittedBlobs
     );
 
     const blobItems: Models.BlobItem[] = [];

--- a/src/blob/persistence/BlobReferredExtentsAsyncIterator.ts
+++ b/src/blob/persistence/BlobReferredExtentsAsyncIterator.ts
@@ -33,7 +33,8 @@ export default class BlobReferredExtentsAsyncIterator
       const [blobs, marker] = await this.blobMetadataStore.listAllBlobs(
         undefined,
         this.blobListingMarker,
-        true
+        true, // includeSnapshots
+        true // includeUncommitedBlobs
       );
       this.blobListingMarker = marker;
       if (marker === undefined) {

--- a/src/blob/persistence/IBlobMetadataStore.ts
+++ b/src/blob/persistence/IBlobMetadataStore.ts
@@ -486,13 +486,15 @@ export interface IBlobMetadataStore
     prefix?: string,
     maxResults?: number,
     marker?: string,
-    includeSnapshots?: boolean
+    includeSnapshots?: boolean,
+    includeUncommittedBlobs?: boolean
   ): Promise<[BlobModel[], string | undefined]>;
 
   listAllBlobs(
     maxResults?: number,
     marker?: string,
-    includeSnapshots?: boolean
+    includeSnapshots?: boolean,
+    includeUncommittedBlobs?: boolean
   ): Promise<[BlobModel[], string | undefined]>;
 
   /**

--- a/src/blob/persistence/SqlBlobMetadataStore.ts
+++ b/src/blob/persistence/SqlBlobMetadataStore.ts
@@ -1246,7 +1246,6 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     });
   }
 
-  // TODO: Filter uncommitted blobs
   public async listBlobs(
     context: Context,
     account: string,
@@ -1255,7 +1254,8 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     prefix: string = "",
     maxResults: number = DEFAULT_LIST_BLOBS_MAX_RESULTS,
     marker?: string,
-    includeSnapshots?: boolean
+    includeSnapshots?: boolean,
+    includeUncommittedBlobs?: boolean
   ): Promise<[BlobModel[], any | undefined]> {
     return this.sequelize.transaction(async t => {
       const containerFindResult = await ContainersModel.findOne({
@@ -1297,6 +1297,9 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
       if (!includeSnapshots) {
         whereQuery.snapshot = "";
       }
+      if (!includeUncommittedBlobs) {
+        whereQuery.isCommitted = true;
+      }
       whereQuery.deleting = 0;
 
       const blobFindResult = await BlobsModel.findAll({
@@ -1328,7 +1331,8 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
   public async listAllBlobs(
     maxResults: number = DEFAULT_LIST_BLOBS_MAX_RESULTS,
     marker?: string,
-    includeSnapshots?: boolean
+    includeSnapshots?: boolean,
+    includeUncommittedBlobs?: boolean
   ): Promise<[BlobModel[], any | undefined]> {
     const whereQuery: any = {};
     if (marker !== undefined) {
@@ -1338,6 +1342,9 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     }
     if (!includeSnapshots) {
       whereQuery.snapshot = "";
+    }
+    if (!includeUncommittedBlobs) {
+      whereQuery.isCommitted = true;
     }
     whereQuery.deleting = 0;
 

--- a/tests/blob/apis/container.test.ts
+++ b/tests/blob/apis/container.test.ts
@@ -503,15 +503,14 @@ describe("ContainerAPIs", () => {
       await blob.delete(Aborter.none);
     }
   });
-  
-  // This is expected to break because listBlobs currently does not filter uncommitted blobs.
+
   it("should only show uncommitted blobs in listBlobFlatSegment with uncommittedblobs option @loki @sql", async () => {
     const blobURL = BlobURL.fromContainerURL(
       containerURL,
-      getUniqueName('uncommittedblob')
+      getUniqueName("uncommittedblob")
     );
-    const blockBlobURL = BlockBlobURL.fromBlobURL(blobURL)
-      
+    const blockBlobURL = BlockBlobURL.fromBlobURL(blobURL);
+
     const body = "HelloWorld";
     await blockBlobURL.stageBlock(
       Aborter.none,
@@ -519,14 +518,12 @@ describe("ContainerAPIs", () => {
       body,
       body.length
     );
-    
+
     const result1 = await containerURL.listBlobFlatSegment(
       Aborter.none,
       undefined,
       {
-        include: [
-          "uncommittedblobs"
-        ]
+        include: ["uncommittedblobs"]
       }
     );
     assert.equal(result1.segment.blobItems.length, 1);
@@ -536,6 +533,42 @@ describe("ContainerAPIs", () => {
       undefined
     );
     assert.equal(result2.segment.blobItems.length, 0);
+
+    await blobURL.delete(Aborter.none);
+  });
+
+  it("should only show uncommitted blobs in listBlobHierarchySegment with uncommittedblobs option @loki @sql", async () => {
+    const delimiter = "/";
+    const blobURL = BlobURL.fromContainerURL(
+      containerURL,
+      getUniqueName("path/uncommittedblob")
+    );
+    const blockBlobURL = BlockBlobURL.fromBlobURL(blobURL);
+
+    const body = "HelloWorld";
+    await blockBlobURL.stageBlock(
+      Aborter.none,
+      base64encode("1"),
+      body,
+      body.length
+    );
+
+    const result1 = await containerURL.listBlobHierarchySegment(
+      Aborter.none,
+      delimiter,
+      undefined,
+      {
+        include: ["uncommittedblobs"]
+      }
+    );
+    assert.equal(result1.segment.blobPrefixes!.length, 1);
+
+    const result2 = await containerURL.listBlobHierarchySegment(
+      Aborter.none,
+      delimiter,
+      undefined
+    );
+    assert.equal(result2.segment.blobPrefixes!.length, 0);
 
     await blobURL.delete(Aborter.none);
   });

--- a/tests/blob/apis/container.test.ts
+++ b/tests/blob/apis/container.test.ts
@@ -533,8 +533,6 @@ describe("ContainerAPIs", () => {
       undefined
     );
     assert.equal(result2.segment.blobItems.length, 0);
-
-    await blobURL.delete(Aborter.none);
   });
 
   it("should only show uncommitted blobs in listBlobHierarchySegment with uncommittedblobs option @loki @sql", async () => {
@@ -569,8 +567,6 @@ describe("ContainerAPIs", () => {
       undefined
     );
     assert.equal(result2.segment.blobPrefixes!.length, 0);
-
-    await blobURL.delete(Aborter.none);
   });
 
   it("should correctly order all blobs in the container @loki @sql", async () => {


### PR DESCRIPTION
Fixes https://github.com/Azure/Azurite/issues/463

Currently, `listBlobs` will return all blobs, including staged / uncommitted blobs.  This is a discrepancy from real Azure storage, where only committed blobs are returned unless you explicitly request them using the `includes: uncommittedblobs` option.