### PR TITLE
Allow canonicalized prefix for blob metadata operations

### DIFF
--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -28,7 +28,7 @@ export function convertRawHeadersToMetadata(
   for (let i = 0; i < rawHeaders.length; i = i + 2) {
     const header = rawHeaders[i];
     if (
-      header.startsWith(metadataPrefix) &&
+      header.toLowerCase().startsWith(metadataPrefix) &&
       header.length > metadataPrefix.length
     ) {
       const key = header.substr(metadataPrefix.length);

--- a/tests/blob/utils.test.ts
+++ b/tests/blob/utils.test.ts
@@ -10,12 +10,15 @@ describe("Utils", () => {
       "x-ms-meta-name2",
       "234",
       "x-ms-meta-name1",
+      "Value",
+      "X-Ms-Meta-Name3",
       "Value"
     ]);
     assert.deepStrictEqual(metadata, {
       Name1: "Value",
       name2: "234",
-      name1: "Value"
+      name1: "Value",
+      Name3: "Value"
     });
   });
 


### PR DESCRIPTION
Recently, I have run into a problem using the official Golang SDK for Azure Blob Storage and the Azurite emulator.
I have previously discussed the issue over at the SDK's repo (see https://github.com/Azure/azure-storage-blob-go/issues/191).

The production service handles metadata operations slightly differently than the service emulator, as it accepts set-metadata operations using a canonicalized header prefix (`X-Ms-Meta-` instead of the documented `x-ms-meta-`).

I guess it's best to stick closer to the production service than to the literal documentation in this case. I've updated the respective part of Azurite's metadata header algorithm to accept the same headers that the production service accepts.