### PR TITLE
[Table] Phase 1 Feature - Insert Or Replace Entity

### DIFF
--- a/src/table/handlers/TableHandler.ts
+++ b/src/table/handlers/TableHandler.ts
@@ -338,13 +338,13 @@ export default class TableHandler extends BaseHandler implements ITableHandler {
       );
 
       if (exists !== null) {
-        // entity exists so we update
+        // entity exists so we update and force with "*" etag
         await this.metadataStore.updateTableEntity(
           context,
           tableName,
           accountName!,
           entity,
-          ifMatch!
+          "*"
         );
       } else {
         await this.metadataStore.insertTableEntity(

--- a/src/table/persistence/ITableMetadataStore.ts
+++ b/src/table/persistence/ITableMetadataStore.ts
@@ -43,9 +43,10 @@ export default interface ITableMetadataStore {
   queryTableEntitiesWithPartitionAndRowKey(
     context: Context,
     table: string,
+    accountName: string,
     partitionKey: string,
     rowKey: string
-  ): Promise<{ [propertyName: string]: any }[]>;
+  ): Promise<IEntity>;
   updateTableEntity(
     context: Context,
     tableName: string,
@@ -65,7 +66,7 @@ export default interface ITableMetadataStore {
     accountName: string,
     partitionKey: string,
     rowKey: string,
-    eatg: string
+    etag: string
   ): Promise<void>;
   insertTableEntity(
     context: Context,

--- a/src/table/persistence/LokiTableMetadataStore.ts
+++ b/src/table/persistence/LokiTableMetadataStore.ts
@@ -153,12 +153,27 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
 
   public async queryTableEntitiesWithPartitionAndRowKey(
     context: Context,
-    table: string,
+    tableName: string,
+    accountName: string,
     partitionKey: string,
     rowKey: string
-  ): Promise<{ [propertyName: string]: any }[]> {
-    // TODO
-    throw new NotImplementedError();
+  ): Promise<IEntity> {
+    const tableColl = this.db.getCollection(
+      this.getUniqueTableCollectionName(accountName, tableName)
+    );
+
+    // Throw error, if table not exists
+    if (!tableColl) {
+      throw StorageErrorFactory.getTableNotExist(context);
+    }
+
+    // Get requested Doc
+    const requestedDoc = tableColl.findOne({
+      PartitionKey: partitionKey,
+      RowKey: rowKey
+    }) as IEntity;
+
+    return requestedDoc;
   }
 
   public async updateTableEntity(

--- a/src/table/persistence/LokiTableMetadataStore.ts
+++ b/src/table/persistence/LokiTableMetadataStore.ts
@@ -203,13 +203,14 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
       throw StorageErrorFactory.getEntityNotExist(context);
     } else {
       // Test if etag value is valid
-      if (etag !== "*" && currentDoc.eTag !== etag) {
-        throw StorageErrorFactory.getPreconditionFailed(context);
+      if (etag === "*" || currentDoc.eTag === etag) {
+        tableColl.remove(currentDoc);
+        tableColl.insert(entity);
+        return;
       }
     }
 
-    tableColl.remove(currentDoc);
-    tableColl.insert(entity);
+    throw StorageErrorFactory.getPreconditionFailed(context);
   }
 
   public async mergeTableEntity(

--- a/tests/table/apis/table.entity.test.ts
+++ b/tests/table/apis/table.entity.test.ts
@@ -326,7 +326,31 @@ describe("table Entity APIs test", () => {
       tableName,
       {
         PartitionKey: "part1",
-        RowKey: "row4",
+        RowKey: "row6",
+        myValue: "firstValue"
+      },
+      (updateError, updateResult, updateResponse) => {
+        if (updateError) {
+          assert.ifError(updateError);
+          done();
+        } else {
+          assert.equal(updateResponse.statusCode, 204); // No content
+          done();
+        }
+      }
+    );
+  });
+
+  it("Insert or Replace (upsert) on an Entity that exists, @loki", done => {
+    requestOverride.headers = {
+      Prefer: "return-content",
+      accept: "application/json;odata=fullmetadata"
+    };
+    tableService.insertOrReplaceEntity(
+      tableName,
+      {
+        PartitionKey: "part1",
+        RowKey: "row6",
         myValue: "newValue"
       },
       (updateError, updateResult, updateResponse) => {

--- a/tests/table/apis/table.entity.test.ts
+++ b/tests/table/apis/table.entity.test.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import * as Azure from "azure-storage";
 
+import StorageError from "../../../src/blob/errors/StorageError";
 import { configLogger } from "../../../src/common/Logger";
 import TableConfiguration from "../../../src/table/TableConfiguration";
 import TableServer from "../../../src/table/TableServer";
@@ -10,7 +11,6 @@ import {
   getUniqueName,
   overrideRequest
 } from "../../testutils";
-import StorageError from "../../../src/blob/errors/StorageError";
 
 // Set true to enable debug log
 configLogger(false);
@@ -311,6 +311,30 @@ describe("table Entity APIs test", () => {
           );
         } else {
           assert.ifError(error);
+          done();
+        }
+      }
+    );
+  });
+
+  it("Insert or Replace (upsert) on an Entity that does not exist, @loki", done => {
+    requestOverride.headers = {
+      Prefer: "return-content",
+      accept: "application/json;odata=fullmetadata"
+    };
+    tableService.insertOrReplaceEntity(
+      tableName,
+      {
+        PartitionKey: "part1",
+        RowKey: "row4",
+        myValue: "newValue"
+      },
+      (updateError, updateResult, updateResponse) => {
+        if (updateError) {
+          assert.ifError(updateError);
+          done();
+        } else {
+          assert.equal(updateResponse.statusCode, 204); // No content
           done();
         }
       }

--- a/tests/table/apis/table.test.ts
+++ b/tests/table/apis/table.test.ts
@@ -147,7 +147,7 @@ describe("table APIs test", () => {
           bodies["odata.metadata"],
           `${protocol}://${host}:${port}/${accountName}/$metadata#Tables`
         );
-        assert.ok(bodies.TableResponseProperties[0]["TableName"]);
+        assert.ok(bodies.TableResponseProperties[0].TableName);
         assert.ok(bodies.TableResponseProperties[0]["odata.type"]);
         assert.ok(bodies.TableResponseProperties[0]["odata.id"]);
         assert.ok(bodies.TableResponseProperties[0]["odata.editLink"]);
@@ -177,7 +177,7 @@ describe("table APIs test", () => {
           bodies["odata.metadata"],
           `${protocol}://${host}:${port}/${accountName}/$metadata#Tables`
         );
-        assert.ok(bodies.TableResponseProperties[0]["TableName"]);
+        assert.ok(bodies.TableResponseProperties[0].TableName);
       }
       done();
     });
@@ -200,7 +200,7 @@ describe("table APIs test", () => {
         const headers = response.headers!;
         assert.equal(headers["x-ms-version"], TABLE_API_VERSION);
         const bodies = response.body! as any;
-        assert.ok(bodies.TableResponseProperties[0]["TableName"]);
+        assert.ok(bodies.TableResponseProperties[0].TableName);
       }
       done();
     });


### PR DESCRIPTION
[Table] Phase 1 Feature - Insert Or Replace Entity #492

Upsert added incl query table entities with partition key and row key in the loki data handler.

Added test case to validate "insert" API call via SDK, and verified that this does not include the ifMatch / etag header on the request to the API.
