### PR TITLE
Add API Version check for table storage middleware

### DIFF
--- a/src/table/TableRequestListenerFactory.ts
+++ b/src/table/TableRequestListenerFactory.ts
@@ -32,7 +32,8 @@ export default class TableRequestListenerFactory
   public constructor(
     private readonly metadataStore: ITableMetadataStore,
     private readonly enableAccessLog: boolean,
-    private readonly accessLogWriteStream?: NodeJS.WritableStream // private readonly skipApiVersionCheck?: boolean,
+    private readonly accessLogWriteStream?: NodeJS.WritableStream,
+    private readonly skipApiVersionCheck?: boolean
   ) {}
 
   public createRequestListener(): RequestListener {
@@ -94,7 +95,7 @@ export default class TableRequestListenerFactory
     }
 
     // Manually created middleware to deserialize feature related context which swagger doesn't know
-    app.use(createTableStorageContextMiddleware());
+    app.use(createTableStorageContextMiddleware(this.skipApiVersionCheck));
 
     // Dispatch incoming HTTP request to specific operation
     app.use(middlewareFactory.createDispatchMiddleware());

--- a/src/table/TableServer.ts
+++ b/src/table/TableServer.ts
@@ -58,7 +58,8 @@ export default class TableServer extends ServerBase {
     const requestListenerFactory: IRequestListenerFactory = new TableRequestListenerFactory(
       metadataStore,
       configuration.enableAccessLog, // Access log includes every handled HTTP request
-      configuration.accessLogWriteStream
+      configuration.accessLogWriteStream,
+      configuration.skipApiVersionCheck
     );
 
     const host = configuration.host;

--- a/src/table/errors/StorageErrorFactory.ts
+++ b/src/table/errors/StorageErrorFactory.ts
@@ -10,6 +10,22 @@ import StorageError from "./StorageError";
 const defaultID: string = "DefaultID";
 
 export default class StorageErrorFactory {
+  public static getInvalidHeaderValue(
+    contextID: string = "",
+    additionalMessages?: { [key: string]: string }
+  ): StorageError {
+    if (additionalMessages === undefined) {
+      additionalMessages = {};
+    }
+    return new StorageError(
+      400,
+      "InvalidHeaderValue",
+      "The value for one of the HTTP headers is not in the correct format.",
+      contextID,
+      additionalMessages
+    );
+  }
+
   public static getTableAlreadyExists(context: Context): StorageError {
     return new StorageError(
       409,

--- a/src/table/middleware/tableStorageContext.middleware.ts
+++ b/src/table/middleware/tableStorageContext.middleware.ts
@@ -6,12 +6,16 @@ import { PRODUCTION_STYLE_URL_HOSTNAME } from "../../common/utils/constants";
 import TableStorageContext from "../context/TableStorageContext";
 import {
   DEFAULT_TABLE_CONTEXT_PATH,
-  HeaderConstants
+  HeaderConstants,
+  ValidAPIVersions
 } from "../utils/constants";
+import { checkApiVersion } from "../utils/utils";
 
-export default function createTableStorageContextMiddleware(): RequestHandler {
+export default function createTableStorageContextMiddleware(
+  skipApiVersionCheck?: boolean
+): RequestHandler {
   return (req: Request, res: Response, next: NextFunction) => {
-    return tableStorageContextMiddleware(req, res, next);
+    return tableStorageContextMiddleware(req, res, next, skipApiVersionCheck);
   };
 }
 
@@ -26,7 +30,8 @@ export default function createTableStorageContextMiddleware(): RequestHandler {
 export function tableStorageContextMiddleware(
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
+  skipApiVersionCheck?: boolean
 ): void {
   // Set server header in every Azurite response
   res.setHeader(
@@ -35,6 +40,13 @@ export function tableStorageContextMiddleware(
   );
 
   const requestID = uuid();
+
+  if (!skipApiVersionCheck) {
+    const apiVersion = req.header(HeaderConstants.X_MS_VERSION);
+    if (apiVersion !== undefined) {
+      checkApiVersion(apiVersion, ValidAPIVersions, requestID);
+    }
+  }
 
   const tableContext = new TableStorageContext(
     res.locals,

--- a/src/table/utils/constants.ts
+++ b/src/table/utils/constants.ts
@@ -18,6 +18,7 @@ export const TABLE_API_VERSION = "2019-12-12";
 export const HeaderConstants = {
   SERVER: "Server",
   VERSION: "3.8.0",
+  X_MS_VERSION: "x-ms-version",
   APPLICATION_JSON: "application/json"
 };
 
@@ -27,3 +28,26 @@ export const FULL_METADATA_ACCEPT = "application/json;odata=fullmetadata";
 
 export const RETURN_NO_CONTENT = "return-no-content";
 export const RETURN_CONTENT = "return-content";
+
+export const ValidAPIVersions = [
+  "2019-12-12",
+  "2019-07-07",
+  "2019-02-02",
+  "2018-11-09",
+  "2018-03-28",
+  "2017-11-09",
+  "2017-07-29",
+  "2017-04-17",
+  "2016-05-31",
+  "2015-12-11",
+  "2015-07-08",
+  "2015-04-05",
+  "2015-02-21",
+  "2014-02-14",
+  "2013-08-15",
+  "2012-02-12",
+  "2011-08-18",
+  "2009-09-19",
+  "2009-07-17",
+  "2009-04-14"
+];

--- a/src/table/utils/utils.ts
+++ b/src/table/utils/utils.ts
@@ -1,3 +1,5 @@
+import StorageErrorFactory from "../errors/StorageErrorFactory";
+
 export function newEtag(): string {
   // Etag should match ^"0x[A-F0-9]{15,}"$
   // Date().getTime().toString(16) only has 11 digital
@@ -9,4 +11,17 @@ export function newEtag(): string {
       .toUpperCase() +
     '"'
   );
+}
+
+export function checkApiVersion(
+  inputApiVersion: string,
+  validApiVersions: Array<string>,
+  requestId: string
+): void {
+  if (!validApiVersions.includes(inputApiVersion)) {
+    throw StorageErrorFactory.getInvalidHeaderValue(requestId, {
+      HeaderName: "x-ms-version",
+      HeaderValue: inputApiVersion
+    });
+  }
 }

--- a/tests/table/apis/table.test.ts
+++ b/tests/table/apis/table.test.ts
@@ -4,7 +4,10 @@ import * as Azure from "azure-storage";
 import { configLogger } from "../../../src/common/Logger";
 import TableConfiguration from "../../../src/table/TableConfiguration";
 import TableServer from "../../../src/table/TableServer";
-import { TABLE_API_VERSION } from "../../../src/table/utils/constants";
+import {
+  HeaderConstants,
+  TABLE_API_VERSION
+} from "../../../src/table/utils/constants";
 import {
   EMULATOR_ACCOUNT_KEY,
   EMULATOR_ACCOUNT_NAME,
@@ -242,6 +245,15 @@ describe("table APIs test", () => {
       assert.equal(result.statusCode, 404); // no body expected, we expect 404
       const storageError = error as any;
       assert.equal(storageError.code, "TableNotFound");
+      done();
+    });
+  });
+
+  it("createTable with invalid version, @loki", done => {
+    requestOverride.headers = { [HeaderConstants.X_MS_VERSION]: "invalid" };
+
+    tableService.createTable("test", (error, result) => {
+      assert.equal(result.statusCode, 400);
       done();
     });
   });


### PR DESCRIPTION
Fixes #516. The implementation is 90% copy/paste from the equivalent methods in blob storage.