### PR TITLE
fix sql metadata store getBlockList for non-existent blob

### DIFF
--- a/src/blob/persistence/SqlBlobMetadataStore.ts
+++ b/src/blob/persistence/SqlBlobMetadataStore.ts
@@ -1486,8 +1486,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
           containerName: container,
           blobName: blob,
           snapshot: "",
-          deleting: 0,
-          isCommitted
+          deleting: 0
         },
         transaction: t
       });

--- a/tests/blob/apis/blockblob.test.ts
+++ b/tests/blob/apis/blockblob.test.ts
@@ -421,7 +421,21 @@ describe("BlockBlobAPIs", () => {
       assert.deepEqual(404, error.statusCode);
       return;
     }
+    assert.fail();
+  });
 
+  it("getBlockList for non-existent container @loki @sql", async () => {
+    const fakeContainer = getUniqueName("container");
+    const fakeContainerClient = serviceClient.getContainerClient(fakeContainer);
+    const fakeBlobClient = fakeContainerClient.getBlobClient(blobName);
+    const fakeBlockBlobClient = fakeBlobClient.getBlockBlobClient();
+
+    try {
+      await fakeBlockBlobClient.getBlockList("committed");
+    } catch (error) {
+      assert.deepEqual(404, error.statusCode);
+      return;
+    }
     assert.fail();
   });
 

--- a/tests/blob/apis/blockblob.test.ts
+++ b/tests/blob/apis/blockblob.test.ts
@@ -138,10 +138,12 @@ describe("BlockBlobAPIs", () => {
     );
     await blockBlobClient.stageBlock(base64encode("2"), body, body.length);
 
-    const listBlobResponse = await (await containerClient
-      .listBlobsFlat({ includeUncommitedBlobs: true })
-      .byPage()
-      .next()).value;
+    const listBlobResponse = await (
+      await containerClient
+        .listBlobsFlat({ includeUncommitedBlobs: true })
+        .byPage()
+        .next()
+    ).value;
     assert.equal(listBlobResponse.segment.blobItems.length, 1);
     assert.deepStrictEqual(
       listBlobResponse.segment.blobItems[0].properties.contentLength,
@@ -167,10 +169,12 @@ describe("BlockBlobAPIs", () => {
 
     await blockBlobClient.stageBlock(base64encode("1"), body, body.length);
 
-    const listBlobResponse = (await containerClient
-      .listBlobsFlat({ includeUncommitedBlobs: true })
-      .byPage()
-      .next()).value;
+    const listBlobResponse = (
+      await containerClient
+        .listBlobsFlat({ includeUncommitedBlobs: true })
+        .byPage()
+        .next()
+    ).value;
     assert.equal(listBlobResponse.segment.blobItems.length, 1);
     assert.deepStrictEqual(
       listBlobResponse.segment.blobItems[0].properties.contentLength,
@@ -408,6 +412,17 @@ describe("BlockBlobAPIs", () => {
     assert.equal(listResponse.uncommittedBlocks!.length, 1);
     assert.equal(listResponse.uncommittedBlocks![0].name, base64encode("123"));
     assert.equal(listResponse.uncommittedBlocks![0].size, body.length);
+  });
+
+  it("getBlockList for non-existent blob @loki @sql", async () => {
+    try {
+      await blockBlobClient.getBlockList("committed");
+    } catch (error) {
+      assert.deepEqual(404, error.statusCode);
+      return;
+    }
+
+    assert.fail();
   });
 
   it("upload with Readable stream body and default parameters @loki @sql", async () => {


### PR DESCRIPTION
currently there is an issue with the `sql` metadata store and `getBlockList`. this API behaves differently between `loki` and `sql`, and the `loki` behavior appears to be correct when compared to real azure storage.

a test has been added to illustrate the issue, and a secondary commit will be added to validate the fix.

fixes https://github.com/Azure/Azurite/issues/579