### PR TITLE
Handle SIGTERM. Signal for Docker stop

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 ## Upcoming Release
 
 - Add support for copying blobs across storage accounts within the same Azurite instance.
+- Add handling of SIGTERM to gracefully stop the docker container
 
 ## 2020.07 Version 3.8.0
 

--- a/src/queue/main.ts
+++ b/src/queue/main.ts
@@ -18,6 +18,16 @@ import {
 
 const accessAsync = promisify(access);
 
+function shutdown(server: QueueServer) {
+  const beforeCloseMessage = `Azurite Queue service is closing...`;
+  const afterCloseMessage = `Azurite Queue service successfully closed`;
+
+  console.log(beforeCloseMessage);
+  server.close().then(() => {
+    console.log(afterCloseMessage);
+  });
+}
+
 /**
  * Entry for Azurite queue service.
  */
@@ -76,26 +86,17 @@ async function main() {
   );
 
   // Handle close event
-  const beforeCloseMessage = `Azurite Queue service is closing...`;
-  const afterCloseMessage = `Azurite Queue service successfully closed`;
   process
-    .once("message", msg => {
+    .once("message", (msg: string) => {
       if (msg === "shutdown") {
-        console.log(beforeCloseMessage);
-        server.close().then(() => {
-          console.log(afterCloseMessage);
-        });
+        shutdown(server);
       }
     })
-    .once("SIGINT", () => {
-      console.log(beforeCloseMessage);
-      server.close().then(() => {
-        console.log(afterCloseMessage);
-      });
-    });
+    .once("SIGINT", () => shutdown(server))
+    .once("SIGTERM", () => shutdown(server));
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error(`Exit due to unhandled error: ${err.message}`);
   process.exit(1);
 });


### PR DESCRIPTION
Docker defaults to using SIGTERM on `docker stop` This consolidates the handlers to a single function used by the 3 ways of stopping the app.

You can see this by the time it takes to stop the Azurite container without handling `SIGTERM` vs when you handle it. Docker will wait 10 seconds before forcibly killing the container. 

### Latest container
```
❯ time docker stop azurite
azurite

real    0m10.467s
user    0m0.073s
sys     0m0.100s
```

### Container that handles SIGTERM
```
❯ time docker stop azurite-sigterm
azurite-sigterm

real    0m0.431s
user    0m0.111s
sys     0m0.053s
```