### PR TITLE
Return x-ms-copy-status from syncCopyFromURL

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@ Table:
 Blob:
 
 - Fixed SAS-token validation for requests with Content-Encoding/Content-Language headers.
+- Return `x-ms-copy-status` header from syncCopyFromURL.
 
 ## 2021.6 Version 3.13.1
 

--- a/src/blob/errors/StorageErrorFactory.ts
+++ b/src/blob/errors/StorageErrorFactory.ts
@@ -728,4 +728,17 @@ export default class StorageErrorFactory {
       contextID
     );
   }
+
+  public static getUnexpectedSyncCopyStatus(
+    contextID: string,
+    copyStatus: string
+  ): StorageError {
+    return new StorageError(
+      409,
+      "UnexpectedSyncCopyStatus",
+      'Expected copyStatus to be "success" but got different status.',
+      contextID,
+      { ReceivedCopyStatus: copyStatus }
+    );
+  }
 }

--- a/src/blob/handlers/BlobHandler.ts
+++ b/src/blob/handlers/BlobHandler.ts
@@ -849,6 +849,18 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
       options
     );
 
+    let copyStatus: Models.SyncCopyStatusType | undefined;
+    if (res.copyStatus !== undefined) {
+      if (res.copyStatus === Models.CopyStatusType.Success) {
+        copyStatus = Models.SyncCopyStatusType.Success;
+      } else {
+        throw StorageErrorFactory.getUnexpectedSyncCopyStatus(
+          context.contextId!,
+          res.copyStatus
+        );
+      }
+    }
+
     const response: Models.BlobCopyFromURLResponse = {
       statusCode: 202,
       eTag: res.etag,
@@ -857,6 +869,7 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
       version: BLOB_API_VERSION,
       date: context.startTime,
       copyId: res.copyId,
+      copyStatus,
       clientRequestId: options.requestId
     };
 

--- a/src/blob/persistence/LokiBlobMetadataStore.ts
+++ b/src/blob/persistence/LokiBlobMetadataStore.ts
@@ -2050,6 +2050,7 @@ export default class LokiBlobMetadataStore
             ? destBlob.properties.leaseDuration
             : undefined,
         copyId: uuid(),
+        copyStatus: Models.CopyStatusType.Success,
         copySource,
         copyProgress: sourceBlob.properties.contentLength
           ? `${sourceBlob.properties.contentLength}/${sourceBlob.properties.contentLength}`

--- a/tests/blob/apis/blob.test.ts
+++ b/tests/blob/apis/blob.test.ts
@@ -1045,11 +1045,11 @@ describe("BlobAPIs", () => {
     const result_copy = await destBlobClient.syncCopyFromURL(
       sourceBlobClient.url
     );
-
     assert.equal(
-      result_copy!._response.request.headers.get("x-ms-client-request-id"),
-      result_copy!._response.request.requestId
+      result_copy._response.request.headers.get("x-ms-client-request-id"),
+      result_copy._response.request.requestId
     );
+    assert.equal(result_copy.copyStatus, "success");
 
     const result = await destBlobClient.getProperties();
     assert.ok(result.date);
@@ -1163,9 +1163,10 @@ describe("BlobAPIs", () => {
       sourceBlobClient.url
     );
     assert.equal(
-      result_copy!._response.request.headers.get("x-ms-client-request-id"),
-      result_copy!._response.request.requestId
+      result_copy._response.request.headers.get("x-ms-client-request-id"),
+      result_copy._response.request.requestId
     );
+    assert.equal(result_copy.copyStatus, "success");
 
     const result = await destBlobClient.getProperties();
     assert.ok(result.date);


### PR DESCRIPTION
Fixes #603 

This makes the syncCopyFromURL operation for blobs return a copy status (`x-ms-copy-status` response header).

## Implementation notes

The value of the header can only be "success" as defined in the `SyncCopyStatusType` enum. However all methods from the metadata stores seem to return `BlobProperties`, which contain a normal `CopyStatusType`.

I added a conversion to the sync copy status to the `BlobHandler` as well as a new error in case the copy status is not "success". Please let me know if this is the correct approach here. Otherwise I'm happy to change that.