### PR TITLE
Do not return empty <Snapshot/> tag in container blobs enumeration.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,12 @@
 
 > Note. This file includes changes after 3.0.0-preview. For legacy Azurite changes, please goto GitHub [releases](https://github.com/Azure/Azurite/releases).
 
+## Upcoming Release
+
+Blob:
+
+- Fix an issue that result of blobs enumeration cannot be parsed by Azure SDK for Go.
+
 ## 2020.12 Version 3.10.0
 
 - Bump up Azure Storage service API version to 2020-04-08.

--- a/src/blob/generated/artifacts/mappers.ts
+++ b/src/blob/generated/artifacts/mappers.ts
@@ -496,7 +496,6 @@ export const BlobItem: msRest.CompositeMapper = {
       },
       snapshot: {
         xmlName: "Snapshot",
-        required: true,
         serializedName: "Snapshot",
         type: {
           name: "String"

--- a/src/blob/generated/artifacts/models.ts
+++ b/src/blob/generated/artifacts/models.ts
@@ -195,7 +195,7 @@ export interface BlobMetadata {
 export interface BlobItem {
   name: string;
   deleted?: boolean;
-  snapshot: string;
+  snapshot?: string;
   properties: BlobProperties;
   metadata?: BlobMetadata;
 }

--- a/src/blob/handlers/ContainerHandler.ts
+++ b/src/blob/handlers/ContainerHandler.ts
@@ -582,6 +582,7 @@ export default class ContainerHandler extends BaseHandler
           return {
             ...item,
             deleted: item.deleted !== true ? undefined : true,
+            snapshot: item.snapshot || undefined,
             properties: {
               ...item.properties,
               etag: removeQuotationFromListBlobEtag(item.properties.etag),
@@ -704,6 +705,7 @@ export default class ContainerHandler extends BaseHandler
         blobItems: blobItems.map(item => {
           return {
             ...item,
+            snapshot: item.snapshot || undefined,
             properties: {
               ...item.properties,
               etag: removeQuotationFromListBlobEtag(item.properties.etag),

--- a/src/blob/persistence/LokiBlobMetadataStore.ts
+++ b/src/blob/persistence/LokiBlobMetadataStore.ts
@@ -1028,12 +1028,14 @@ export default class LokiBlobMetadataStore
       context
     );
 
+    const snapshotTime = convertDateTimeStringMsTo7Digital(
+      context.startTime!.toISOString()
+    );
+
     const snapshotBlob: BlobModel = {
       name: doc.name,
       deleted: false,
-      snapshot: convertDateTimeStringMsTo7Digital(
-        context.startTime!.toISOString()
-      ),
+      snapshot: snapshotTime,
       properties: { ...doc.properties },
       metadata: metadata ? { ...metadata } : { ...doc.metadata },
       accountName: doc.accountName,
@@ -1065,7 +1067,7 @@ export default class LokiBlobMetadataStore
 
     return {
       properties: snapshotBlob.properties,
-      snapshot: snapshotBlob.snapshot
+      snapshot: snapshotTime
     };
   }
 

--- a/src/blob/persistence/SqlBlobMetadataStore.ts
+++ b/src/blob/persistence/SqlBlobMetadataStore.ts
@@ -1775,9 +1775,11 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
         context
       ).validate(new BlobReadLeaseValidator(leaseAccessConditions));
 
-      snapshotBlob.snapshot = convertDateTimeStringMsTo7Digital(
+      const snapshotTime = convertDateTimeStringMsTo7Digital(
         context.startTime!.toISOString()
       );
+
+      snapshotBlob.snapshot = snapshotTime;
       snapshotBlob.metadata = metadata || snapshotBlob.metadata;
 
       new BlobLeaseSyncer(snapshotBlob).sync({
@@ -1796,7 +1798,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
 
       return {
         properties: snapshotBlob.properties,
-        snapshot: snapshotBlob.snapshot
+        snapshot: snapshotTime
       };
     });
   }

--- a/swagger/blob-storage-2019-02-02.json
+++ b/swagger/blob-storage-2019-02-02.json
@@ -7974,7 +7974,7 @@
       },
       "description": "An Azure Storage blob",
       "type": "object",
-      "required": ["Name", "Snapshot", "Properties"],
+      "required": ["Name", "Properties"],
       "properties": {
         "Name": {
           "type": "string"

--- a/swagger/blob.md
+++ b/swagger/blob.md
@@ -22,6 +22,6 @@ enum-types: true
 
 2. Updated blocklisttype for list blob blocks from required to optional.
 
-3. Make "Deleted" from required to optional for BlobItem model.
+3. Make "Deleted" and "Snapshot" from required to optional for BlobItem model.
 
 4. Make `ApiVersionParameter` parameter from required to optional.

--- a/tests/blob/apis/container.test.ts
+++ b/tests/blob/apis/container.test.ts
@@ -468,6 +468,7 @@ describe("ContainerAPIs", () => {
         getResult.etag,
         '"' + result.segment.blobItems![i].properties.etag + '"'
       );
+      assert.deepStrictEqual(result.segment.blobItems![i].snapshot, undefined);
       i++;
     }
 


### PR DESCRIPTION
Azure includes \<Snapshot\> XML tag in output only if it is not empty.
Such behaviour is documented in
https://docs.microsoft.com/en-us/rest/api/storageservices/enumerating-blob-resources

Azure SDK for Go fails while parsing response with empty tag.

Fixes #663