### PR TITLE
Etag returned by Table Storage follows Azure format now

### DIFF
--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -60,9 +60,9 @@ export function newEtag(): string {
   );
 }
 
-export function newTableEntityEtag(): string {
+export function newTableEntityEtag(startTime: Date): string {
   // Etag as returned by Table Storage should match W/"datetime'<ISO8601datetime>'"
-  return "W/\"datetime'" + new Date().toISOString() + "'\"";
+  return "W/\"datetime'" + truncatedISO8061Date(startTime, true) + "'\"";
 }
 
 /**

--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -60,6 +60,11 @@ export function newEtag(): string {
   );
 }
 
+export function newTableEntityEtag(): string {
+  // Etag as returned by Table Storage should match W/"datetime'<ISO8601datetime>'"
+  return "W/\"datetime'" + new Date().toISOString() + "'\"";
+}
+
 /**
  * Generates a hash signature for an HTTP request or for a SAS.
  *

--- a/src/table/handlers/TableHandler.ts
+++ b/src/table/handlers/TableHandler.ts
@@ -1,5 +1,5 @@
 import BufferStream from "../../common/utils/BufferStream";
-import { newEtag } from "../../common/utils/utils";
+import { newTableEntityEtag } from "../../common/utils/utils";
 import TableStorageContext from "../context/TableStorageContext";
 import { NormalizedEntity } from "../entity/NormalizedEntity";
 import NotImplementedError from "../errors/NotImplementedError";
@@ -178,7 +178,7 @@ export default class TableHandler extends BaseHandler implements ITableHandler {
       RowKey: options.tableEntityProperties.RowKey,
       properties: options.tableEntityProperties,
       lastModifiedTime: context.startTime!,
-      eTag: newEtag()
+      eTag: newTableEntityEtag()
     };
 
     let nomarlizedEntity;
@@ -279,7 +279,7 @@ export default class TableHandler extends BaseHandler implements ITableHandler {
       throw StorageErrorFactory.getPreconditionFailed(context);
     }
 
-    const eTag = newEtag();
+    const eTag = newTableEntityEtag();
 
     // Entity, which is used to update an existing entity
     const entity: Entity = {
@@ -349,7 +349,7 @@ export default class TableHandler extends BaseHandler implements ITableHandler {
       );
     }
 
-    const eTag = newEtag();
+    const eTag = newTableEntityEtag();
 
     const entity: Entity = {
       PartitionKey: partitionKey,

--- a/src/table/handlers/TableHandler.ts
+++ b/src/table/handlers/TableHandler.ts
@@ -178,7 +178,7 @@ export default class TableHandler extends BaseHandler implements ITableHandler {
       RowKey: options.tableEntityProperties.RowKey,
       properties: options.tableEntityProperties,
       lastModifiedTime: context.startTime!,
-      eTag: newTableEntityEtag()
+      eTag: newTableEntityEtag(context.startTime!)
     };
 
     let nomarlizedEntity;
@@ -279,7 +279,7 @@ export default class TableHandler extends BaseHandler implements ITableHandler {
       throw StorageErrorFactory.getPreconditionFailed(context);
     }
 
-    const eTag = newTableEntityEtag();
+    const eTag = newTableEntityEtag(context.startTime!);
 
     // Entity, which is used to update an existing entity
     const entity: Entity = {
@@ -349,7 +349,7 @@ export default class TableHandler extends BaseHandler implements ITableHandler {
       );
     }
 
-    const eTag = newTableEntityEtag();
+    const eTag = newTableEntityEtag(context.startTime!);
 
     const entity: Entity = {
       PartitionKey: partitionKey,

--- a/tests/table/apis/table.entity.test.ts
+++ b/tests/table/apis/table.entity.test.ts
@@ -75,6 +75,11 @@ describe("table Entity APIs test", () => {
     };
     tableService.insertEntity(tableName, entity, (error, result, response) => {
       assert.equal(response.statusCode, 201);
+      assert.ok(
+        response.headers?.etag.match(
+          "W/\"datetime'\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z'\""
+        )
+      );
       done();
     });
   });

--- a/tests/table/apis/table.entity.test.ts
+++ b/tests/table/apis/table.entity.test.ts
@@ -77,7 +77,7 @@ describe("table Entity APIs test", () => {
       assert.equal(response.statusCode, 201);
       assert.ok(
         response.headers?.etag.match(
-          "W/\"datetime'\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z'\""
+          "W/\"datetime'\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{7}Z'\""
         )
       );
       done();


### PR DESCRIPTION
Fix for https://github.com/Azure/Azurite/issues/688 (format of etag returned by Table Storage endpoint)