### PR TITLE
Skip Content-Length check for Append Block if --loose is set

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ Blob:
 
 - Fix an issue that result of blobs enumeration cannot be parsed by Azure SDK for Go.
 - Fix an issue that set tier to leased blob not work properly.
+- Skip Content-Length check for Append Block if the `--loose` flag is set.
 
 ## 2020.12 Version 3.10.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6175,6 +6175,15 @@
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
+    "ts-mockito": {
+      "version": "2.6.1",
+      "resolved": "https://repo1.uhc.com:443/artifactory/api/npm/npm-virtual/ts-mockito/-/ts-mockito-2.6.1.tgz",
+      "integrity": "sha1-vJ7iYZAzk05vrRxEVayltazjTnM=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.5"
+      }
+    },
     "ts-node": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "mocha": "^5.2.0",
     "prettier": "^1.16.4",
     "prettier-tslint": "^0.4.2",
+    "ts-mockito": "^2.6.1",
     "ts-node": "^7.0.1",
     "tslint": "^6.1.3",
     "typescript": "^3.1.4",

--- a/src/blob/BlobRequestListenerFactory.ts
+++ b/src/blob/BlobRequestListenerFactory.ts
@@ -68,38 +68,46 @@ export default class BlobRequestListenerFactory
 
     // Create handlers into handler middleware factory
     const pageBlobRangesManager = new PageBlobRangesManager();
+
+    const loose = this.loose || false;
     const handlers: IHandlers = {
       appendBlobHandler: new AppendBlobHandler(
         this.metadataStore,
         this.extentStore,
-        logger
+        logger,
+        loose
       ),
       blobHandler: new BlobHandler(
         this.metadataStore,
         this.extentStore,
         logger,
+        loose,
         pageBlobRangesManager
       ),
       blockBlobHandler: new BlockBlobHandler(
         this.metadataStore,
         this.extentStore,
-        logger
+        logger,
+        loose
       ),
       containerHandler: new ContainerHandler(
         this.metadataStore,
         this.extentStore,
-        logger
+        logger,
+        loose
       ),
       pageBlobHandler: new PageBlobHandler(
         this.metadataStore,
         this.extentStore,
         logger,
+        loose,
         pageBlobRangesManager
       ),
       serviceHandler: new ServiceHandler(
         this.metadataStore,
         this.extentStore,
-        logger
+        logger,
+        loose
       ),
       directoryHandler: {} as any
     };

--- a/src/blob/handlers/AppendBlobHandler.ts
+++ b/src/blob/handlers/AppendBlobHandler.ts
@@ -29,7 +29,7 @@ export default class AppendBlobHandler extends BaseHandler
     const date = blobCtx.startTime!;
     const etag = newEtag();
 
-    if (contentLength !== 0) {
+    if (contentLength !== 0 && !this.loose) {
       throw StorageErrorFactory.getInvalidOperation(
         blobCtx.contextId!,
         "Content-Length must be 0 for Create Append Blob request."

--- a/src/blob/handlers/BaseHandler.ts
+++ b/src/blob/handlers/BaseHandler.ts
@@ -14,6 +14,7 @@ export default class BaseHandler {
   constructor(
     protected readonly metadataStore: IBlobMetadataStore,
     protected readonly extentStore: IExtentStore,
-    protected readonly logger: ILogger
+    protected readonly logger: ILogger,
+    protected readonly loose: boolean
   ) {}
 }

--- a/src/blob/handlers/BlobHandler.ts
+++ b/src/blob/handlers/BlobHandler.ts
@@ -43,9 +43,10 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
     metadataStore: IBlobMetadataStore,
     extentStore: IExtentStore,
     logger: ILogger,
+    loose: boolean,
     private readonly rangesManager: IPageBlobRangesManager
   ) {
-    super(metadataStore, extentStore, logger);
+    super(metadataStore, extentStore, logger, loose);
   }
 
   public setAccessControl(

--- a/src/blob/handlers/PageBlobHandler.ts
+++ b/src/blob/handlers/PageBlobHandler.ts
@@ -31,9 +31,10 @@ export default class PageBlobHandler extends BaseHandler
     metadataStore: IBlobMetadataStore,
     extentStore: IExtentStore,
     logger: ILogger,
+    loose: boolean,
     private readonly rangesManager: IPageBlobRangesManager
   ) {
-    super(metadataStore, extentStore, logger);
+    super(metadataStore, extentStore, logger, loose);
   }
 
   public async uploadPagesFromURL(

--- a/tests/blob/handlers/AppendBlobHandler.test.ts
+++ b/tests/blob/handlers/AppendBlobHandler.test.ts
@@ -1,0 +1,223 @@
+import assert = require("assert");
+import { PassThrough } from "stream";
+import {
+  anyOfClass,
+  anything,
+  deepEqual,
+  instance,
+  mock,
+  when
+} from "ts-mockito";
+import BlobStorageContext from "../../../src/blob/context/BlobStorageContext";
+import * as Models from "../../../src/blob/generated/artifacts/models";
+import Context from "../../../src/blob/generated/Context";
+import IRequest from "../../../src/blob/generated/IRequest";
+import AppendBlobHandler from "../../../src/blob/handlers/AppendBlobHandler";
+import {
+  BlockModel,
+  IBlobMetadataStore
+} from "../../../src/blob/persistence/IBlobMetadataStore";
+import { HeaderConstants } from "../../../src/blob/utils/constants";
+import logger, { configLogger } from "../../../src/common/Logger";
+import IExtentStore, {
+  IExtentChunk
+} from "../../../src/common/persistence/IExtentStore";
+import { getUniqueName } from "../../testutils";
+
+// Set true to enable debug log
+configLogger(false);
+
+describe("AppendBlobHandler", () => {
+  const request: IRequest = mock<IRequest>();
+  when(request.getHeader(HeaderConstants.CONTENT_MD5)).thenReturn(undefined);
+  when(request.getRawHeaders()).thenReturn([]);
+
+  const blobCtx = new BlobStorageContext({ contextId: "" } as Context);
+  blobCtx.contextId = getUniqueName("contextID");
+  blobCtx.account = getUniqueName("account");
+  blobCtx.container = getUniqueName("container");
+  blobCtx.blob = getUniqueName("blob");
+  blobCtx.request = instance(request);
+
+  const buffer = Buffer.from("deadbeef");
+
+  const properties: Models.BlobProperties = {
+    lastModified: new Date(),
+    etag: getUniqueName("etag"),
+    blobType: Models.BlobType.AppendBlob,
+    contentLength: buffer.length
+  };
+
+  const extent: IExtentChunk = {
+    id: getUniqueName("extentID"),
+    offset: 0,
+    count: buffer.length
+  };
+
+  const metadataStore: IBlobMetadataStore = mock<IBlobMetadataStore>();
+  when(
+    metadataStore.downloadBlob(
+      anything(),
+      blobCtx.account,
+      blobCtx.container,
+      blobCtx.blob,
+      undefined
+    )
+  ).thenResolve({
+    name: blobCtx.blob,
+    accountName: blobCtx.account,
+    containerName: blobCtx.container,
+    isCommitted: false,
+    properties
+  });
+  when(
+    metadataStore.appendBlock(
+      anything(),
+      deepEqual({
+        accountName: blobCtx.account,
+        containerName: blobCtx.container,
+        blobName: blobCtx.blob,
+        isCommitted: true,
+        name: "",
+        size: extent.count,
+        persistency: extent
+      } as BlockModel),
+      undefined,
+      undefined,
+      undefined
+    )
+  ).thenResolve(properties);
+
+  const extentStore: IExtentStore = mock<IExtentStore>();
+  when(
+    // Need to reset the buffer stream for each test which calls this function
+    // so we accept any PassThrough stream here.
+    extentStore.appendExtent(anyOfClass(PassThrough), blobCtx.contextId)
+  ).thenResolve(extent);
+
+  describe("create", () => {
+    it("accepts requests withContent-Length == 0 @loki", async () => {
+      const handler = new AppendBlobHandler(
+        instance(metadataStore),
+        instance(extentStore),
+        logger,
+        false
+      );
+      await assert.doesNotReject(async () => {
+        await handler.create(0, {}, blobCtx);
+      });
+    });
+
+    it("accepts requests with Content-Length != 0 in loose mode @loki", async () => {
+      const handler = new AppendBlobHandler(
+        instance(metadataStore),
+        instance(extentStore),
+        logger,
+        true
+      );
+      await assert.doesNotReject(async () => {
+        await handler.create(buffer.length, {}, blobCtx);
+      });
+    });
+
+    it("rejects requests with Content-Length != 0 @loki", async () => {
+      const handler = new AppendBlobHandler(
+        instance(metadataStore),
+        instance(extentStore),
+        logger,
+        false
+      );
+      await assert.rejects(
+        async () => {
+          await handler.create(buffer.length, {}, blobCtx);
+        },
+        {
+          name: "StorageError",
+          storageErrorCode: "InvalidOperation"
+        }
+      );
+    });
+  });
+
+  describe("appendBlock", () => {
+    let bufferStream: PassThrough;
+    beforeEach(() => {
+      bufferStream = new PassThrough();
+      bufferStream.end(buffer);
+    });
+
+    it("accepts requests with Content-Length != 0 @loki", async () => {
+      const handler = new AppendBlobHandler(
+        instance(metadataStore),
+        instance(extentStore),
+        logger,
+        false
+      );
+      await assert.doesNotReject(async () => {
+        await handler.appendBlock(bufferStream, buffer.length, {}, blobCtx);
+      });
+    });
+
+    it("rejects requests with Content-Length == 0 @loki", async () => {
+      const handler = new AppendBlobHandler(
+        instance(metadataStore),
+        instance(extentStore),
+        logger,
+        false
+      );
+      await assert.rejects(
+        async () => {
+          await handler.appendBlock(bufferStream, 0, {}, blobCtx);
+        },
+        {
+          name: "StorageError",
+          storageErrorCode: "InvalidHeaderValue"
+        }
+      );
+    });
+
+    it("accepts requests with valid MD5 checksum @loki", async () => {
+      when(request.getHeader(HeaderConstants.CONTENT_MD5)).thenReturn(
+        "T0EkOEfaaTpPNWwEhhFLxg=="
+      );
+      when(extentStore.readExtent(extent, blobCtx.contextId)).thenResolve(
+        bufferStream
+      );
+
+      const handler = new AppendBlobHandler(
+        instance(metadataStore),
+        instance(extentStore),
+        logger,
+        false
+      );
+      await assert.doesNotReject(async () => {
+        await handler.appendBlock(bufferStream, buffer.length, {}, blobCtx);
+      });
+    });
+
+    it("rejects requests with invalid MD5 checksum @loki", async () => {
+      when(request.getHeader(HeaderConstants.CONTENT_MD5)).thenReturn(
+        "d3JvbmdfTUQ1X2NoZWNrc3VtCg=="
+      );
+      when(extentStore.readExtent(extent, blobCtx.contextId)).thenResolve(
+        bufferStream
+      );
+
+      const handler = new AppendBlobHandler(
+        instance(metadataStore),
+        instance(extentStore),
+        logger,
+        false
+      );
+      await assert.rejects(
+        async () => {
+          await handler.appendBlock(bufferStream, buffer.length, {}, blobCtx);
+        },
+        {
+          name: "StorageError",
+          storageErrorCode: "Md5Mismatch"
+        }
+      );
+    });
+  });
+});


### PR DESCRIPTION
Due to a bug in azure-sdk-for-go, the Append Block API call fails because this legacy library always sends a non-zero Content-Length header. This fix relaxes this Content-Length check when the `--loose` flag is set.

Also adds a bunch of tests for AppendBlobHandler. Hope you don't mind having `ts-mockito` as a dependency. Testing this functionality without mocking the metadatastore and the extentstore doesn't look feasible.

Fixes #682.
