### PR TITLE
#688 - added URL encoding for Table Storage etag

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 ## Upcoming Release
 
+Table:
+
+- Fixed Etag returned by Table Storage to follow Azure format.
+
 ## 2020.11 Version 3.9.0-table-alpha.1
 
 Table:

--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "watch": "tsc -watch -p ./",
     "blob": "node -r ts-node/register src/blob/main.ts",
     "queue": "node -r ts-node/register src/queue/main.ts",
+    "table": "node -r ts-node/register src/table/main.ts",
     "azurite": "node -r ts-node/register src/azurite.ts",
     "lint": "tslint -p tsconfig.json -c tslint.json src/**/*.ts",
     "test": "npm run lint && cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 mocha --compilers ts-node/register --no-timeouts --grep @loki --recursive tests/**/*.test.ts tests/**/**/*.test.ts",

--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -62,7 +62,11 @@ export function newEtag(): string {
 
 export function newTableEntityEtag(startTime: Date): string {
   // Etag as returned by Table Storage should match W/"datetime'<ISO8601datetime>'"
-  return "W/\"datetime'" + truncatedISO8061Date(startTime, true) + "'\"";
+  return (
+    "W/\"datetime'" +
+    encodeURIComponent(truncatedISO8061Date(startTime, true)) +
+    "'\""
+  );
 }
 
 /**

--- a/tests/table/apis/table.entity.test.ts
+++ b/tests/table/apis/table.entity.test.ts
@@ -77,7 +77,7 @@ describe("table Entity APIs test", () => {
       assert.equal(response.statusCode, 201);
       assert.ok(
         response.headers?.etag.match(
-          "W/\"datetime'\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{7}Z'\""
+          "W/\"datetime'\\d{4}-\\d{2}-\\d{2}T\\d{2}%3A\\d{2}%3A\\d{2}.\\d{7}Z'\""
         )
       );
       done();


### PR DESCRIPTION
Follow up to PR https://github.com/Azure/Azurite/pull/697 - added missing URL encoding for datetime component.
