### PR TITLE
Fix AppendBlock support for legacy azure-sdk-for-go

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 ## Upcoming Release
 
+- Resolve `AppendBlock` requests coming from github.com/Azure/azure-sdk-for-go/storage to the `appendBlock` method if the `--loose` flag is set.
+
 ## 2021.2 Version 3.11.0
 
 - Bump up Azure Storage service API version to 2020-06-12.


### PR DESCRIPTION
Fixes #702.

Unfortunately, I don't see any straightforward way of adding tests for this since `tests/blob/apis/appendblob.test.ts` uses an auto-generated client, which behaves correctly, unlike github.com/Azure/azure-sdk-for-go/storage. Hope that's acceptable, since the extra logic is active only when the `--loose` flag is set.

LE: I'm not sure why the `Component Governance Component Detection` check has failed. Please let me know if there's anything that I need to change in my code for this to succeed.