### PR TITLE
Fix table etag format to be aligned with server, by escape encode ':' in it

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@
 Table:
 
 - Allow empty RowKey in an entity.
+- Fix etag format to be aligned with Azure server.
 
 ## 2021.2 Version 3.11.0
 

--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -62,7 +62,11 @@ export function newEtag(): string {
 
 export function newTableEntityEtag(startTime: Date): string {
   // Etag as returned by Table Storage should match W/"datetime'<ISO8601datetime>'"
-  return "W/\"datetime'" + truncatedISO8061Date(startTime, true) + "'\"";
+  return (
+    "W/\"datetime'" +
+    encodeURIComponent(truncatedISO8061Date(startTime, true)) +
+    "'\""
+  );
 }
 
 /**

--- a/tests/table/apis/table.entity.test.ts
+++ b/tests/table/apis/table.entity.test.ts
@@ -107,7 +107,7 @@ describe("table Entity APIs test", () => {
       assert.equal(response.statusCode, 201);
       assert.ok(
         response.headers?.etag.match(
-          "W/\"datetime'\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{7}Z'\""
+          "W/\"datetime'\\d{4}-\\d{2}-\\d{2}T\\d{2}%3A\\d{2}%3A\\d{2}.\\d{7}Z'\""
         )
       );
       done();
@@ -127,7 +127,7 @@ describe("table Entity APIs test", () => {
       assert.equal(response.statusCode, 201);
       assert.ok(
         response.headers?.etag.match(
-          "W/\"datetime'\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{7}Z'\""
+          "W/\"datetime'\\d{4}-\\d{2}-\\d{2}T\\d{2}%3A\\d{2}%3A\\d{2}.\\d{7}Z'\""
         )
       );
       done();


### PR DESCRIPTION
The PR is to fix : https://github.com/Azure/Azurite/issues/743

Thanks for contribution! Please go through following checklist before sending PR.

### PR Branch Destination

- For Azurite V3, please send PR to `master` branch.
- For legacy Azurite V2, please send PR to `legacy-dev` branch.

### Always Add Test Cases

Make sure test cases are added to cover the code change.

### Add Change Log

Add change log for the code change in `Upcoming Release` section in `ChangeLog.md`.

### Development Guideline

Please go to CONTRIBUTION.md for steps about setting up development environment and recommended Visual Studio Code extensions.
