### PR TITLE
Update to Table Batch API to address complex row and partition keys

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,8 @@ Table:
 - Fix etag format to be aligned with Azure server.
 - Fix delete none exist table error code and error message, to be aligned with Azure server.
 - Convert entity properties with type "Edm.DateTime" to UTC time, to be aligned with Azure server.
+- Support Batch API
+- Allow complex RowKey and PartitionKey in batch API
 
 ## 2021.2 Version 3.11.0
 

--- a/src/table/batch/TableBatchOrchestrator.ts
+++ b/src/table/batch/TableBatchOrchestrator.ts
@@ -261,6 +261,10 @@ export default class TableBatchOrchestrator {
         partitionKey = jsonBody.PartitionKey;
         rowKey = jsonBody.RowKey;
       }
+    } else {
+      // keys can have more complex values which are URI encoded
+      partitionKey = decodeURIComponent(partitionKey);
+      rowKey = decodeURIComponent(rowKey);
     }
     return { partitionKey, rowKey };
   }

--- a/src/table/batch/TableBatchOrchestrator.ts
+++ b/src/table/batch/TableBatchOrchestrator.ts
@@ -247,25 +247,13 @@ export default class TableBatchOrchestrator {
     let rowKey: string;
 
     const url = request.getUrl();
-    const partKeyMatch = url.match(/(PartitionKey=)(%27)?'?(\w+)/gi);
+    // URL should always be URL encoded
+    const partKeyMatch = url.match(/(?<=PartitionKey=%27)(.+)(?=%27,)/gi);
     partitionKey = partKeyMatch ? partKeyMatch[0] : "";
-    const rowKeyMatch = url.match(/(RowKey=)(%27)?'?(\w+)/gi);
+    const rowKeyMatch = url.match(/(?<=RowKey=%27)(.+)(?=%27\))/gi);
     rowKey = rowKeyMatch ? rowKeyMatch[0] : "";
 
-    if (partitionKey !== "" || rowKey !== "") {
-      // we need to filter out the delimeter (if URL encoded)
-      const urlencodedMatch = partitionKey.match(/%/);
-      let matchStringLength = 14;
-      if (urlencodedMatch) {
-        matchStringLength += 2;
-      }
-      partitionKey = partitionKey.substring(matchStringLength);
-      matchStringLength = 8;
-      if (urlencodedMatch) {
-        matchStringLength += 2;
-      }
-      rowKey = rowKey.substring(matchStringLength);
-    } else {
+    if (partitionKey === "" || rowKey === "") {
       // row key not in URL, must be in body
       const body = request.getBody();
       if (body !== "") {

--- a/src/table/batch/TableBatchOrchestrator.ts
+++ b/src/table/batch/TableBatchOrchestrator.ts
@@ -246,11 +246,11 @@ export default class TableBatchOrchestrator {
     let partitionKey: string;
     let rowKey: string;
 
-    const url = request.getUrl();
+    const url = decodeURI(request.getUrl());
     // URL should always be URL encoded
-    const partKeyMatch = url.match(/(?<=PartitionKey=%27)(.+)(?=%27,)/gi);
+    const partKeyMatch = url.match(/(?<=PartitionKey=')(.+)(?=',)/gi);
     partitionKey = partKeyMatch ? partKeyMatch[0] : "";
-    const rowKeyMatch = url.match(/(?<=RowKey=%27)(.+)(?=%27\))/gi);
+    const rowKeyMatch = url.match(/(?<=RowKey=')(.+)(?='\))/gi);
     rowKey = rowKeyMatch ? rowKeyMatch[0] : "";
 
     if (partitionKey === "" || rowKey === "") {

--- a/src/table/batch/TableBatchSerialization.ts
+++ b/src/table/batch/TableBatchSerialization.ts
@@ -543,12 +543,12 @@ export class TableBatchSerialization extends BatchSerialization {
     const trimmedUrl: string = request
       .getUrl()
       .substring(0, parenthesesPosition);
-    let entityPath = trimmedUrl + "(PartitionKey=%27";
+    let entityPath = trimmedUrl + "(PartitionKey='";
     entityPath += request.params.tableEntityProperties!.PartitionKey;
-    entityPath += "%27,";
-    entityPath += "RowKey=%27";
+    entityPath += "',";
+    entityPath += "RowKey='";
     entityPath += request.params.tableEntityProperties!.RowKey;
-    entityPath += "%27)\r\n";
+    entityPath += "')\r\n";
     return entityPath;
   }
 

--- a/src/table/batch/TableBatchSerialization.ts
+++ b/src/table/batch/TableBatchSerialization.ts
@@ -183,8 +183,7 @@ export class TableBatchSerialization extends BatchSerialization {
       this.SerializeEntityPath(serializedResponses, request);
 
     if (null !== response.eTag && undefined !== response.eTag) {
-      // prettier-ignore
-      serializedResponses += "ETag: " + response.eTag.replace(":","%3A");
+      serializedResponses += "ETag: " + response.eTag;
     }
     return serializedResponses;
   }
@@ -258,7 +257,7 @@ export class TableBatchSerialization extends BatchSerialization {
     );
 
     if (null !== response.eTag && undefined !== response.eTag) {
-      serializedResponses += "ETag: " + response.eTag.replace(":", "%3A");
+      serializedResponses += "ETag: " + response.eTag;
     }
     return serializedResponses;
   }
@@ -317,7 +316,7 @@ export class TableBatchSerialization extends BatchSerialization {
     );
 
     if (null !== response.eTag && undefined !== response.eTag) {
-      serializedResponses += "ETag: " + response.eTag.replace(":", "%3A");
+      serializedResponses += "ETag: " + response.eTag;
     }
     return serializedResponses;
   }
@@ -354,7 +353,7 @@ export class TableBatchSerialization extends BatchSerialization {
     serializedResponses = this.AddNoSniffNoCache(serializedResponses);
 
     if (response.eTag) {
-      serializedResponses += "ETag: " + response.eTag.replace(":", "%3A");
+      serializedResponses += "ETag: " + response.eTag;
     }
     serializedResponses += "\r\n";
 

--- a/tests/table/apis/table.entity.test.ts
+++ b/tests/table/apis/table.entity.test.ts
@@ -1016,4 +1016,90 @@ describe("table Entity APIs test", () => {
       );
     });
   });
+
+  it.only("Operates on batch items with complex row keys, @loki", (done) => {
+    requestOverride.headers = {
+      Prefer: "return-content",
+      accept: "application/json;odata=fullmetadata"
+    };
+    const insertEntity1 = createBasicEntityForTest();
+    insertEntity1.RowKey._ = "8b0a63c8-9542-49d8-9dd2-d7af9fa8790f_0B";
+    const insertEntity2 = createBasicEntityForTest();
+    insertEntity2.RowKey._ = "8b0a63c8-9542-49d8-9dd2-d7af9fa8790f_0C";
+    const insertEntity3 = createBasicEntityForTest();
+    insertEntity3.RowKey._ = "8b0a63c8-9542-49d8-9dd2-d7af9fa8790f_0D";
+    const insertEntity4 = createBasicEntityForTest();
+    insertEntity4.RowKey._ = "8b0a63c8-9542-49d8-9dd2-d7af9fa8790f_0E";
+
+    tableService.insertEntity<TestEntity>(tableName, insertEntity1, () => {
+      tableService.insertEntity<TestEntity>(tableName, insertEntity2, () => {
+        const entityBatch: Azure.TableBatch = new Azure.TableBatch();
+        entityBatch.insertEntity(insertEntity3, {});
+        entityBatch.insertEntity(insertEntity4, {});
+        entityBatch.deleteEntity(insertEntity1);
+        entityBatch.deleteEntity(insertEntity2);
+        tableService.executeBatch(
+          tableName,
+          entityBatch,
+          (updateError, updateResult, updateResponse) => {
+            if (updateError) {
+              assert.ifError(updateError);
+              done();
+            } else {
+              assert.equal(updateResponse.statusCode, 202);
+              tableService.retrieveEntity<TestEntity>(
+                tableName,
+                insertEntity3.PartitionKey._,
+                insertEntity3.RowKey._,
+                (error: any, result, response) => {
+                  assert.strictEqual(
+                    response.statusCode,
+                    200,
+                    "We did not find the 3rd entity!"
+                  );
+                  tableService.retrieveEntity<TestEntity>(
+                    tableName,
+                    insertEntity4.PartitionKey._,
+                    insertEntity4.RowKey._,
+                    (error2: any, result2, response2) => {
+                      assert.strictEqual(
+                        response2.statusCode,
+                        200,
+                        "We did not find the 4th entity!"
+                      );
+                      tableService.retrieveEntity<TestEntity>(
+                        tableName,
+                        insertEntity1.PartitionKey._,
+                        insertEntity1.RowKey._,
+                        (error3: any, result3, response3) => {
+                          assert.strictEqual(
+                            response3.statusCode,
+                            404,
+                            "We did not delete the 1st entity!"
+                          );
+                          tableService.retrieveEntity<TestEntity>(
+                            tableName,
+                            insertEntity2.PartitionKey._,
+                            insertEntity2.RowKey._,
+                            (error4: any, result4, response4) => {
+                              assert.strictEqual(
+                                response4.statusCode,
+                                404,
+                                "We did not delete the 2nd entity!"
+                              );
+                              done();
+                            }
+                          );
+                        }
+                      );
+                    }
+                  );
+                }
+              );
+            }
+          }
+        );
+      });
+    });
+  });
 });

--- a/tests/table/apis/table.entity.test.ts
+++ b/tests/table/apis/table.entity.test.ts
@@ -1198,7 +1198,7 @@ describe("table Entity APIs test", () => {
     });
   });
 
-  it.only("Ensure Valid Etag format from Batch, @loki", (done) => {
+  it("Ensure Valid Etag format from Batch, @loki", (done) => {
     requestOverride.headers = {
       Prefer: "return-content",
       accept: "application/json;odata=fullmetadata"


### PR DESCRIPTION
Addresses the case where RowKey or PartitionKey are complex, and incorrectly deserialized by Batch API.

2 Test Cases added for complex RowKey and PartitionKey
Based on my testing the following issues should be resolved:

fixes #741  
fixes #745  
fixes #733  
fixes #750