### PR TITLE
Table batch error handling

### DIFF
--- a/src/table/batch/TableBatchOrchestrator.ts
+++ b/src/table/batch/TableBatchOrchestrator.ts
@@ -33,6 +33,8 @@ export default class TableBatchOrchestrator {
   private serialization = new TableBatchSerialization();
   private context: TableStorageContext;
   private parentHandler: TableHandler;
+  private wasError: boolean = false;
+  private errorResponse: string = "";
 
   public constructor(context: TableStorageContext, handler: TableHandler) {
     this.context = context;
@@ -53,9 +55,7 @@ export default class TableBatchOrchestrator {
     this.batchOperations = this.serialization.deserializeBatchRequest(
       batchRequestBody
     );
-
     await this.submitRequestsToHandlers();
-
     return this.serializeResponses();
   }
 
@@ -73,7 +73,7 @@ export default class TableBatchOrchestrator {
       this.requests.push(request);
     });
 
-    let contentID = 1; // contentID starts at 1 for batch
+    let contentID = 1; // ToDO: validate contentID starts at 1 for batch
     if (this.requests.length > 0) {
       for (const singleReq of this.requests) {
         try {
@@ -83,7 +83,15 @@ export default class TableBatchOrchestrator {
             contentID
           );
         } catch (err) {
-          throw err;
+          this.wasError = true;
+          this.errorResponse = this.serialization.serializeError(
+            err,
+            contentID,
+            singleReq
+          );
+          // need to reset changes until now
+          // then break out of loop and serilaize error
+          break;
         }
         contentID++;
       }
@@ -119,11 +127,20 @@ export default class TableBatchOrchestrator {
     responseString +=
       "Content-Type: multipart/mixed; boundary=" + changesetBoundary + "\r\n";
     changesetBoundary = "\r\n--" + changesetBoundary;
-    this.requests.forEach((request) => {
+    if (this.wasError === false) {
+      this.requests.forEach((request) => {
+        responseString += changesetBoundary;
+        responseString += request.response;
+        responseString += "\r\n\r\n";
+      });
+    } else {
+      // serialize the error
       responseString += changesetBoundary;
-      responseString += request.response;
-      responseString += "\r\n\r\n";
-    });
+      // then headers
+      // content type etc
+      // then HTTP/1.1 404 etc
+      responseString += this.errorResponse;
+    }
     responseString += changesetBoundary + "--\r\n";
     responseString += batchBoundary + "--\r\n";
     return responseString;

--- a/src/table/batch/TableBatchOrchestrator.ts
+++ b/src/table/batch/TableBatchOrchestrator.ts
@@ -55,7 +55,15 @@ export default class TableBatchOrchestrator {
     this.batchOperations = this.serialization.deserializeBatchRequest(
       batchRequestBody
     );
-    await this.submitRequestsToHandlers();
+    if (this.batchOperations.length > 100) {
+      this.wasError = true;
+      this.errorResponse = this.serialization.serializeGeneralRequestError(
+        "0:The batch request operation exceeds the maximum 100 changes per change set.",
+        this.context.xMsRequestID
+      );
+    } else {
+      await this.submitRequestsToHandlers();
+    }
     return this.serializeResponses();
   }
 
@@ -89,7 +97,7 @@ export default class TableBatchOrchestrator {
             contentID,
             singleReq
           );
-          // need to reset changes until now
+          // ToDo: need to reset changes until now
           // then break out of loop and serilaize error
           break;
         }

--- a/src/table/batch/TableBatchSerialization.ts
+++ b/src/table/batch/TableBatchSerialization.ts
@@ -482,6 +482,8 @@ export class TableBatchSerialization extends BatchSerialization {
         return "No Content";
       case 404:
         return "Not Found";
+      case 400:
+        return "Bad Request";
       default:
         return "STATUS_CODE_NOT_IMPLEMENTED";
     }
@@ -611,9 +613,9 @@ export class TableBatchSerialization extends BatchSerialization {
     const odataError = err as StorageError;
     errorReponse += changesetBoundary + "\r\n";
     // Errors in batch processing generate Bad Request error
-    errorReponse += this.serializeHttpStatusCode(errorReponse, 400);
+    errorReponse = this.serializeHttpStatusCode(errorReponse, 400);
     errorReponse += "Content-ID: " + contentID + "\r\n";
-    errorReponse += this.serializeDataServiceVersion(errorReponse, request);
+    errorReponse = this.serializeDataServiceVersion(errorReponse, request);
     // ToDo: Check if we need to observe other odata formats for errors
     errorReponse +=
       "Content-Type: application/json;odata=minimalmetadata;charset=utf-8\r\n";
@@ -642,9 +644,9 @@ export class TableBatchSerialization extends BatchSerialization {
 
     errorReponse += changesetBoundary + "\r\n";
     // Errors in batch processing generate Bad Request error
-    errorReponse += this.serializeHttpStatusCode(errorReponse, 400);
-    errorReponse += this.SerializeXContentTypeOptions(errorReponse);
-    errorReponse += this.serializeDataServiceVersion(errorReponse, undefined);
+    errorReponse = this.serializeHttpStatusCode(errorReponse, 400);
+    errorReponse = this.SerializeXContentTypeOptions(errorReponse);
+    errorReponse = this.serializeDataServiceVersion(errorReponse, undefined);
     // ToDo: Serialize Content type etc
     errorReponse +=
       "Content-Type: application/json;odata=minimalmetadata;charset=utf-8\r\n";

--- a/src/table/batch/TableBatchSerialization.ts
+++ b/src/table/batch/TableBatchSerialization.ts
@@ -9,7 +9,7 @@ import { BatchSerialization } from "../../common/batch/BatchSerialization";
 import TableBatchOperation from "../batch/TableBatchOperation";
 import * as Models from "../generated/artifacts/models";
 import TableBatchUtils from "./TableBatchUtils";
-import StorageError from "../../Table/errors/StorageError";
+import StorageError from "../errors/StorageError";
 import { truncatedISO8061Date } from "../../common/utils/utils";
 
 /**
@@ -614,8 +614,9 @@ export class TableBatchSerialization extends BatchSerialization {
     errorReponse += this.serializeHttpStatusCode(errorReponse, 400);
     errorReponse += "Content-ID: " + contentID + "\r\n";
     errorReponse += this.serializeDataServiceVersion(errorReponse, request);
-    // ToDo: Serialize Content type etc
-    errorReponse += "Content-Type" + "\r\n";
+    // ToDo: Check if we need to observe other odata formats for errors
+    errorReponse +=
+      "Content-Type: application/json;odata=minimalmetadata;charset=utf-8\r\n";
     errorReponse += "\r\n";
     errorReponse += odataError.body + "\r\n";
     return errorReponse;
@@ -645,7 +646,8 @@ export class TableBatchSerialization extends BatchSerialization {
     errorReponse += this.SerializeXContentTypeOptions(errorReponse);
     errorReponse += this.serializeDataServiceVersion(errorReponse, undefined);
     // ToDo: Serialize Content type etc
-    errorReponse += "Content-Type" + "\r\n";
+    errorReponse +=
+      "Content-Type: application/json;odata=minimalmetadata;charset=utf-8\r\n";
     errorReponse += "\r\n";
     let requestIdResponseString = "";
     if (requestId !== undefined) {

--- a/src/table/batch/TableBatchSerialization.ts
+++ b/src/table/batch/TableBatchSerialization.ts
@@ -621,6 +621,14 @@ export class TableBatchSerialization extends BatchSerialization {
     return errorReponse;
   }
 
+  /**
+   * Serializes top level errors not generated from individual request processing
+   *
+   * @param {string} odataErrorString
+   * @param {(string | undefined)} requestId
+   * @return {*}  {string}
+   * @memberof TableBatchSerialization
+   */
   public serializeGeneralRequestError(
     odataErrorString: string,
     requestId: string | undefined

--- a/tests/table/apis/AzureDataTablesTestEntity.ts
+++ b/tests/table/apis/AzureDataTablesTestEntity.ts
@@ -1,0 +1,34 @@
+import { getUniqueName } from "../../testutils";
+
+/**
+ * Creates an entity for tests, with a randomized row key,
+ * to avoid conflicts on inserts.
+ *
+ * @return {*}  {TestEntity}
+ */
+export function createBasicEntityForTest(
+  partitionKey: string
+): AzureDataTablesTestEntity {
+  return new AzureDataTablesTestEntity(
+    partitionKey,
+    getUniqueName("row"),
+    "value1"
+  );
+}
+
+/**
+ * This is the Entity Class used by Azure Data-Tables SDK tests
+ *
+ * @export
+ * @class AzureDataTablesTestEntity
+ */
+export class AzureDataTablesTestEntity {
+  public partitionKey: string;
+  public rowKey: string;
+  public myValue: string;
+  constructor(part: string, row: string, value: string) {
+    this.partitionKey = part;
+    this.rowKey = row;
+    this.myValue = value;
+  }
+}

--- a/tests/table/apis/TestEntity.ts
+++ b/tests/table/apis/TestEntity.ts
@@ -1,0 +1,21 @@
+import * as Azure from "azure-storage";
+const eg = Azure.TableUtilities.entityGenerator;
+
+/**
+ * Provides the default entity we use for Table tests
+ *
+ * @export
+ * @class TestEntity
+ */
+export class TestEntity {
+  public PartitionKey: Azure.TableUtilities.entityGenerator.EntityProperty<
+    string
+  >;
+  public RowKey: Azure.TableUtilities.entityGenerator.EntityProperty<string>;
+  public myValue: Azure.TableUtilities.entityGenerator.EntityProperty<string>;
+  constructor(part: string, row: string, value: string) {
+    this.PartitionKey = eg.String(part);
+    this.RowKey = eg.String(row);
+    this.myValue = eg.String(value);
+  }
+}

--- a/tests/table/apis/table-batch-api-error-handling.md
+++ b/tests/table/apis/table-batch-api-error-handling.md
@@ -13,38 +13,27 @@ https://docs.microsoft.com/en-us/rest/api/storageservices/performing-entity-grou
 
 The following list of features and behavior will serve as a checklist for testing Azurite Batch API error handling:
 
-- When a batch request fails, if the failure is during individual batch item processing, the response must be serialized as a batch response to the client. (done)
+### Done:
+
+- When a batch request fails, if the failure is during individual batch item processing, the response must be serialized as a batch response to the client.
 - When an individual operation fails, the response for the change set indicates status code 400 (Bad Request).
-  - Additional error information within the response indicates which operation failed by returning the index of that operation. The index is the sequence number of the command in the payload via the Content-ID. (done)
+  - Additional error information within the response indicates which operation failed by returning the index of that operation.
+  - The index is the sequence number of the command in the payload via the Content-ID.
+- A batch can include at most 100 entities.
+- Operations are processed in the order they are specified in the change set.
+- The Table service does not support linking operations in a change set.
+  -- is this a reference to content-id processing logic (done, as we don't support content id references)
+- the batch request returns status code 202 (Accepted), even if one of the operations in the change set fails.
+- If the batch request itself fails, it fails before any operation in the change set is executed. (done for max operations, other cases will be addressed as they come up)
+
+### ToDo:
+
+- Check if we need to observe other odata formats for errors
 - All entities in a batch must have the same PartitionKey value.
 - An entity can appear only once in a batch, and only one operation may be performed against it.
   - Requires that we check both partition key and row key (as an entity key is made up of both)
-- A batch can include at most 100 entities
-
-  - Error should look like a standard serialized batch error, accepted with 202, internall REST error of 400:
-    --batchresponse_c758570b-52bd-47c4-8e80-d368a0c0f310\r\n
-    Content-Type: multipart/mixed; boundary=changesetresponse_77dfbe65-cb7f-4bdf-a8f7-626dbfacd436\r\n
-    \r\n
-    --changesetresponse_77dfbe65-cb7f-4bdf-a8f7-626dbfacd436\r\n
-    Content-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n
-    \r\n
-    HTTP/1.1 400 Bad Request\r\n
-    X-Content-Type-Options: nosniff\r\n
-    DataServiceVersion: 3.0;\r\n
-    Content-Type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8\r\n
-    \r\n
-    {\"odata.error\":{\"code\":\"InvalidInput\",\"message\":{\"lang\":\"en-US\",\"value\":\"0:The batch request operation exceeds the maximum 100 changes per change set.\\nRequestId:8d58a05b-8002-0049-573d-384cd1000000\\nTime:2021-04-23T12:40:31.4944778Z\"}}}\r\n
-    --changesetresponse_77dfbe65-cb7f-4bdf-a8f7-626dbfacd436--\r\n
-    --batchresponse_c758570b-52bd-47c4-8e80-d368a0c0f310--\r\n"
-
-  - its total payload may be no more than 4 MiB in size.
-
+- its total payload may be no more than 4 MiB in size.
 - There should only be a single change set within a batch.
   --> If a batch includes more than one change set, the first change set will be processed by the service, and additional change sets will be rejected with status code 400 (Bad Request).
 - A Query must be a single operation in its batch.
-- Operations are processed in the order they are specified in the change set. (done)
-- The Table service does not support linking operations in a change set.
-  -- is this a reference to content-id processing logic (done, as we don't support content id references)
 - all operations in the change set either succeed or fail.
-- the batch request returns status code 202 (Accepted), even if one of the operations in the change set fails. (done)
-- If the batch request itself fails, it fails before any operation in the change set is executed.

--- a/tests/table/apis/table-batch-api-error-handling.md
+++ b/tests/table/apis/table-batch-api-error-handling.md
@@ -1,0 +1,29 @@
+# Table Batch API Error Handling
+
+## Overview
+
+Each feature or check will be covered by a test case.  
+Each test case will be validated against the service.  
+The test case against service will be used to validate and set response correctly where not clearly documented for the REST API.
+
+See also:
+https://docs.microsoft.com/en-us/rest/api/storageservices/performing-entity-group-transactions#sample-error-response
+
+## Details
+
+The following list of features and behavior will serve as a checklist for testing Azurite Batch API error handling:
+
+- When a batch request fails, if the failure is during individual batch item processing, the response must be serialized as a batch response to the client.
+- When an individual operation fails, the response for the change set indicates status code 400 (Bad Request). Additional error information within the response indicates which operation failed by returning the index of that operation. The index is the sequence number of the command in the payload via the Content-ID.
+- All entities in a batch must have the same PartitionKey value.
+- An entity can appear only once in a batch, and only one operation may be performed against it.
+- A batch can include at most 100 entities, and its total payload may be no more than 4 MiB in size.
+- There should only be a single change set within a batch.
+  --> If a batch includes more than one change set, the first change set will be processed by the service, and additional change sets will be rejected with status code 400 (Bad Request).
+- A Query must be a single operation in its batch.
+- Operations are processed in the order they are specified in the change set.
+- The Table service does not support linking operations in a change set.
+  -- is this a reference to content-id processing logic?
+- all operations in the change set either succeed or fail.
+- the batch request returns status code 202 (Accepted), even if one of the operations in the change set fails.
+- If the batch request itself fails, it fails before any operation in the change set is executed.

--- a/tests/table/apis/table-batch-api-error-handling.md
+++ b/tests/table/apis/table-batch-api-error-handling.md
@@ -13,17 +13,38 @@ https://docs.microsoft.com/en-us/rest/api/storageservices/performing-entity-grou
 
 The following list of features and behavior will serve as a checklist for testing Azurite Batch API error handling:
 
-- When a batch request fails, if the failure is during individual batch item processing, the response must be serialized as a batch response to the client.
-- When an individual operation fails, the response for the change set indicates status code 400 (Bad Request). Additional error information within the response indicates which operation failed by returning the index of that operation. The index is the sequence number of the command in the payload via the Content-ID.
+- When a batch request fails, if the failure is during individual batch item processing, the response must be serialized as a batch response to the client. (done)
+- When an individual operation fails, the response for the change set indicates status code 400 (Bad Request).
+  - Additional error information within the response indicates which operation failed by returning the index of that operation. The index is the sequence number of the command in the payload via the Content-ID. (done)
 - All entities in a batch must have the same PartitionKey value.
 - An entity can appear only once in a batch, and only one operation may be performed against it.
-- A batch can include at most 100 entities, and its total payload may be no more than 4 MiB in size.
+  - Requires that we check both partition key and row key (as an entity key is made up of both)
+- A batch can include at most 100 entities
+
+  - Error should look like a standard serialized batch error, accepted with 202, internall REST error of 400:
+    --batchresponse_c758570b-52bd-47c4-8e80-d368a0c0f310\r\n
+    Content-Type: multipart/mixed; boundary=changesetresponse_77dfbe65-cb7f-4bdf-a8f7-626dbfacd436\r\n
+    \r\n
+    --changesetresponse_77dfbe65-cb7f-4bdf-a8f7-626dbfacd436\r\n
+    Content-Type: application/http\r\nContent-Transfer-Encoding: binary\r\n
+    \r\n
+    HTTP/1.1 400 Bad Request\r\n
+    X-Content-Type-Options: nosniff\r\n
+    DataServiceVersion: 3.0;\r\n
+    Content-Type: application/json;odata=minimalmetadata;streaming=true;charset=utf-8\r\n
+    \r\n
+    {\"odata.error\":{\"code\":\"InvalidInput\",\"message\":{\"lang\":\"en-US\",\"value\":\"0:The batch request operation exceeds the maximum 100 changes per change set.\\nRequestId:8d58a05b-8002-0049-573d-384cd1000000\\nTime:2021-04-23T12:40:31.4944778Z\"}}}\r\n
+    --changesetresponse_77dfbe65-cb7f-4bdf-a8f7-626dbfacd436--\r\n
+    --batchresponse_c758570b-52bd-47c4-8e80-d368a0c0f310--\r\n"
+
+  - its total payload may be no more than 4 MiB in size.
+
 - There should only be a single change set within a batch.
   --> If a batch includes more than one change set, the first change set will be processed by the service, and additional change sets will be rejected with status code 400 (Bad Request).
 - A Query must be a single operation in its batch.
-- Operations are processed in the order they are specified in the change set.
+- Operations are processed in the order they are specified in the change set. (done)
 - The Table service does not support linking operations in a change set.
-  -- is this a reference to content-id processing logic?
+  -- is this a reference to content-id processing logic (done, as we don't support content id references)
 - all operations in the change set either succeed or fail.
-- the batch request returns status code 202 (Accepted), even if one of the operations in the change set fails.
+- the batch request returns status code 202 (Accepted), even if one of the operations in the change set fails. (done)
 - If the batch request itself fails, it fails before any operation in the change set is executed.

--- a/tests/table/apis/table.batch.tests.errorhandling.ts
+++ b/tests/table/apis/table.batch.tests.errorhandling.ts
@@ -1,0 +1,73 @@
+// Tests in this file are using @azure/data-tables
+
+import * as assert from "assert";
+import { TableClient, TablesSharedKeyCredential } from "@azure/data-tables";
+import { configLogger } from "../../../src/common/Logger";
+import TableServer from "../../../src/table/TableServer";
+import { EMULATOR_ACCOUNT_KEY, EMULATOR_ACCOUNT_NAME } from "../../testutils";
+import {
+  AzureDataTablesTestEntity,
+  createBasicEntityForTest
+} from "./AzureDataTablesTestEntity";
+import {
+  createTableServerForTestHttps,
+  createUniquePartitionKey,
+  HOST,
+  PORT
+} from "./table.entity.test.utils";
+
+// Set true to enable debug log
+configLogger(false);
+
+describe("table Entity APIs test", () => {
+  let server: TableServer;
+  // const tableName: string = getUniqueName("datatables");
+
+  // const tableClient = new TableClient(
+  //   `https://${HOST}:${PORT}/${EMULATOR_ACCOUNT_NAME}`,
+  //   tableName,
+  //   new TablesSharedKeyCredential(EMULATOR_ACCOUNT_NAME, EMULATOR_ACCOUNT_KEY)
+  // );
+
+  const requestOverride = { headers: {} };
+
+  before(async () => {
+    server = createTableServerForTestHttps();
+    await server.start();
+    requestOverride.headers = {
+      Prefer: "return-content",
+      accept: "application/json;odata=fullmetadata"
+    };
+  });
+
+  after(async () => {
+    await server.close();
+  });
+
+  it("Batch API should serialize errors according to group transaction spec, @loki", async () => {
+    const partitionKey = createUniquePartitionKey();
+    const testEntities: AzureDataTablesTestEntity[] = [
+      createBasicEntityForTest(partitionKey),
+      createBasicEntityForTest(partitionKey),
+      createBasicEntityForTest(partitionKey)
+    ];
+
+    const badTableClient = new TableClient(
+      `https://${HOST}:${PORT}/${EMULATOR_ACCOUNT_NAME}`,
+      "noExistingTable",
+      new TablesSharedKeyCredential(EMULATOR_ACCOUNT_NAME, EMULATOR_ACCOUNT_KEY)
+    );
+
+    // await badTableClient.create(); // deliberately do not create table
+    const batch = badTableClient.createBatch(partitionKey);
+    batch.createEntities(testEntities);
+
+    try {
+      const result = await batch.submitBatch();
+      assert.ok(result.subResponses[0].rowKey);
+    } catch (err) {
+      assert.ifError(err);
+    }
+    await badTableClient.delete();
+  });
+});

--- a/tests/table/apis/table.batch.tests.errorhandling.ts
+++ b/tests/table/apis/table.batch.tests.errorhandling.ts
@@ -25,13 +25,6 @@ configLogger(false);
 
 describe("table Entity APIs test", () => {
   let server: TableServer;
-  // const tableName: string = getUniqueName("datatables");
-
-  // const tableClient = new TableClient(
-  //   `https://${HOST}:${PORT}/${EMULATOR_ACCOUNT_NAME}`,
-  //   tableName,
-  //   new TablesSharedKeyCredential(EMULATOR_ACCOUNT_NAME, EMULATOR_ACCOUNT_KEY)
-  // );
 
   const requestOverride = { headers: {} };
 

--- a/tests/table/apis/table.entity.test.utils.ts
+++ b/tests/table/apis/table.entity.test.utils.ts
@@ -1,0 +1,86 @@
+import {
+  EMULATOR_ACCOUNT_KEY,
+  EMULATOR_ACCOUNT_NAME,
+  getUniqueName
+} from "../../testutils";
+import { TestEntity } from "./TestEntity";
+import TableServer from "../../../src/table/TableServer";
+import TableConfiguration from "../../../src/table/TableConfiguration";
+
+export const PROTOCOL = "http";
+export const HOST = "127.0.0.1";
+export const PORT = 11002;
+const metadataDbPath = "__tableTestsStorage__";
+const enableDebugLog: boolean = false;
+const debugLogPath: string = "g:/debug.log";
+const connectionString =
+  `DefaultEndpointsProtocol=${PROTOCOL};AccountName=${EMULATOR_ACCOUNT_NAME};` +
+  `AccountKey=${EMULATOR_ACCOUNT_KEY};TableEndpoint=${PROTOCOL}://${HOST}:${PORT}/${EMULATOR_ACCOUNT_NAME};`;
+
+const config = new TableConfiguration(
+  HOST,
+  PORT,
+  metadataDbPath,
+  enableDebugLog,
+  false,
+  undefined,
+  debugLogPath
+);
+
+const httpsConfig = new TableConfiguration(
+  HOST,
+  PORT,
+  metadataDbPath,
+  enableDebugLog,
+  false,
+  undefined,
+  debugLogPath,
+  false,
+  true,
+  "tests/server.cert",
+  "tests/server.key"
+);
+
+/**
+ * Creates an entity for tests, with a randomized row key,
+ * to avoid conflicts on inserts.
+ *
+ * @return {*}  {TestEntity}
+ */
+export function createBasicEntityForTest(): TestEntity {
+  return new TestEntity("part1", getUniqueName("row"), "value1");
+}
+
+/**
+ * Creates the Azurite TableServer used in Table API tests
+ *
+ * @export
+ * @return {*}  {TableServer}
+ */
+export function createTableServerForTest(): TableServer {
+  return new TableServer(config);
+}
+
+export function createTableServerForTestHttps(): TableServer {
+  return new TableServer(httpsConfig);
+}
+
+/**
+ * Provides the connection string to connect to the Azurite table server
+ *
+ * @export
+ * @return {*}  {string}
+ */
+export function createConnectionStringForTest(): string {
+  return connectionString;
+}
+
+/**
+ * return a unique parition key for data-tables tests
+ *
+ * @export
+ * @return {*}  {string}
+ */
+export function createUniquePartitionKey(): string {
+  return getUniqueName("datatablestests");
+}

--- a/tests/table/apis/table.entity.tests.azure.data-tables.ts
+++ b/tests/table/apis/table.entity.tests.azure.data-tables.ts
@@ -4,79 +4,40 @@ import * as assert from "assert";
 import LogicAppReproEntity from "./table.entity.test.logicapp.entity";
 import { TableClient, TablesSharedKeyCredential } from "@azure/data-tables";
 import { configLogger } from "../../../src/common/Logger";
-import TableConfiguration from "../../../src/table/TableConfiguration";
 import TableServer from "../../../src/table/TableServer";
 import {
   EMULATOR_ACCOUNT_KEY,
   EMULATOR_ACCOUNT_NAME,
   getUniqueName
 } from "../../testutils";
+import {
+  AzureDataTablesTestEntity,
+  createBasicEntityForTest
+} from "./AzureDataTablesTestEntity";
+import {
+  createTableServerForTestHttps,
+  createUniquePartitionKey,
+  HOST,
+  PORT
+} from "./table.entity.test.utils";
 
 // Set true to enable debug log
 configLogger(false);
-const partitionKeyForDataTablesTests: string = getUniqueName("datatablestests");
-/**
- * Creates an entity for tests, with a randomized row key,
- * to avoid conflicts on inserts.
- *
- * @return {*}  {TestEntity}
- */
-function createBasicEntityForTest(): AzureDataTablesTestEntity {
-  return new AzureDataTablesTestEntity(
-    partitionKeyForDataTablesTests,
-    getUniqueName("row"),
-    "value1"
-  );
-}
-
-class AzureDataTablesTestEntity {
-  public partitionKey: string;
-  public rowKey: string;
-  public myValue: string;
-  constructor(part: string, row: string, value: string) {
-    this.partitionKey = part;
-    this.rowKey = row;
-    this.myValue = value;
-  }
-}
 
 describe("table Entity APIs test", () => {
-  // TODO: Create a server factory as tests utils
-  const protocol = "https";
-  const host = "127.0.0.1";
-  const port = 11002;
-  const metadataDbPath = "__tableTestsStorage__";
-  const enableDebugLog: boolean = true;
-  const debugLogPath: string = "g:/debug.log";
-  const config = new TableConfiguration(
-    host,
-    port,
-    metadataDbPath,
-    enableDebugLog,
-    false,
-    undefined,
-    debugLogPath,
-    false,
-    true,
-    "tests/server.cert",
-    "tests/server.key"
-  );
-
   let server: TableServer;
-  const accountName = EMULATOR_ACCOUNT_NAME;
-  const sharedKey = EMULATOR_ACCOUNT_KEY;
   const tableName: string = getUniqueName("datatables");
 
   const tableClient = new TableClient(
-    `${protocol}://${host}:${port}/${accountName}`,
+    `https://${HOST}:${PORT}/${EMULATOR_ACCOUNT_NAME}`,
     tableName,
-    new TablesSharedKeyCredential(accountName, sharedKey)
+    new TablesSharedKeyCredential(EMULATOR_ACCOUNT_NAME, EMULATOR_ACCOUNT_KEY)
   );
 
   const requestOverride = { headers: {} };
 
   before(async () => {
-    server = new TableServer(config);
+    server = createTableServerForTestHttps();
     await server.start();
     requestOverride.headers = {
       Prefer: "return-content",
@@ -89,14 +50,15 @@ describe("table Entity APIs test", () => {
   });
 
   it("Batch API should return row keys in format understood by @azure/data-tables, @loki", async () => {
+    const partitionKey = createUniquePartitionKey();
     const testEntities: AzureDataTablesTestEntity[] = [
-      createBasicEntityForTest(),
-      createBasicEntityForTest(),
-      createBasicEntityForTest()
+      createBasicEntityForTest(partitionKey),
+      createBasicEntityForTest(partitionKey),
+      createBasicEntityForTest(partitionKey)
     ];
 
     await tableClient.create();
-    const batch = tableClient.createBatch(partitionKeyForDataTablesTests);
+    const batch = tableClient.createBatch(partitionKey);
     await batch.createEntities(testEntities);
     const result = await batch.submitBatch();
     assert.ok(result.subResponses[0].rowKey);

--- a/tests/table/apis/table.test.ts
+++ b/tests/table/apis/table.test.ts
@@ -2,46 +2,34 @@ import * as assert from "assert";
 import * as Azure from "azure-storage";
 
 import { configLogger } from "../../../src/common/Logger";
-import TableConfiguration from "../../../src/table/TableConfiguration";
 import TableServer from "../../../src/table/TableServer";
 import {
   HeaderConstants,
   TABLE_API_VERSION
 } from "../../../src/table/utils/constants";
 import {
-  EMULATOR_ACCOUNT_KEY,
   EMULATOR_ACCOUNT_NAME,
   getUniqueName,
   overrideRequest,
   restoreBuildRequestOptions
 } from "../../testutils";
+import {
+  HOST,
+  PROTOCOL,
+  PORT,
+  createConnectionStringForTest,
+  createTableServerForTest
+} from "./table.entity.test.utils";
 
 // Set true to enable debug log
 configLogger(false);
 
 describe("table APIs test", () => {
-  // TODO: Create a server factory as tests utils
-  const protocol = "http";
-  const host = "127.0.0.1";
-  const port = 11002;
-  const metadataDbPath = "__tableTestsStorage__";
-
-  const config = new TableConfiguration(
-    host,
-    port,
-    metadataDbPath,
-    false,
-    false
-  );
-
   let server: TableServer;
-  const accountName = EMULATOR_ACCOUNT_NAME;
-  const sharedKey = EMULATOR_ACCOUNT_KEY;
-  const connectionString =
-    `DefaultEndpointsProtocol=${protocol};AccountName=${accountName};` +
-    `AccountKey=${sharedKey};TableEndpoint=${protocol}://${host}:${port}/${accountName};`;
 
-  const tableService = Azure.createTableService(connectionString);
+  const tableService = Azure.createTableService(
+    createConnectionStringForTest()
+  );
 
   let tableName: string = getUniqueName("table");
 
@@ -49,7 +37,7 @@ describe("table APIs test", () => {
 
   before(async () => {
     overrideRequest(requestOverride, tableService);
-    server = new TableServer(config);
+    server = createTableServerForTest();
     tableName = getUniqueName("table");
     await server.start();
   });
@@ -103,14 +91,17 @@ describe("table APIs test", () => {
         assert.equal(headers["x-ms-version"], TABLE_API_VERSION);
         const bodies = response.body! as any;
         assert.deepStrictEqual(bodies.TableName, tableName);
-        assert.deepStrictEqual(bodies["odata.type"], `${accountName}.Tables`);
+        assert.deepStrictEqual(
+          bodies["odata.type"],
+          `${EMULATOR_ACCOUNT_NAME}.Tables`
+        );
         assert.deepStrictEqual(
           bodies["odata.metadata"],
-          `${protocol}://${host}:${port}/${accountName}/$metadata#Tables/@Element`
+          `${PROTOCOL}://${HOST}:${PORT}/${EMULATOR_ACCOUNT_NAME}/$metadata#Tables/@Element`
         );
         assert.deepStrictEqual(
           bodies["odata.id"],
-          `${protocol}://${host}:${port}/${accountName}/Tables(${tableName})`
+          `${PROTOCOL}://${HOST}:${PORT}/${EMULATOR_ACCOUNT_NAME}/Tables(${tableName})`
         );
         assert.deepStrictEqual(
           bodies["odata.editLink"],
@@ -154,7 +145,7 @@ describe("table APIs test", () => {
         const bodies = response.body! as any;
         assert.deepStrictEqual(
           bodies["odata.metadata"],
-          `${protocol}://${host}:${port}/${accountName}/$metadata#Tables`
+          `${PROTOCOL}://${HOST}:${PORT}/${EMULATOR_ACCOUNT_NAME}/$metadata#Tables`
         );
         assert.ok(bodies.value[0].TableName);
         assert.ok(bodies.value[0]["odata.type"]);
@@ -185,7 +176,7 @@ describe("table APIs test", () => {
         const bodies = response.body! as any;
         assert.deepStrictEqual(
           bodies["odata.metadata"],
-          `${protocol}://${host}:${port}/${accountName}/$metadata#Tables`
+          `${PROTOCOL}://${HOST}:${PORT}/${EMULATOR_ACCOUNT_NAME}/$metadata#Tables`
         );
         assert.ok(bodies.value[0].TableName);
       }


### PR DESCRIPTION
Fixes #739 
Now correctly serializes errors from Table API, adding support for @azure/data-tables SDK.  

Does not yet observe atomicity and snapshots on table API transactions.  

See tests\table\apis\table-batch-api-error-handling.md for error handling specs implemented so far and those still outstanding.