### PR TITLE
Corrects query for Long Int in Metadata layer

### DIFF
--- a/src/table/persistence/LokiTableMetadataStore.ts
+++ b/src/table/persistence/LokiTableMetadataStore.ts
@@ -755,6 +755,8 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
           matchLongInt.length === 1
         ) {
           token = token.replace(/L\b/g, "");
+          // however, as long int is stored as string, we need to add inverted commas
+          token = "'" + token + "'";
         } else if (previousIsOp && token.startsWith("datetime")) {
           token = token.replace(/\bdatetime\b/g, "");
           token = `new Date(${token}).getTime()`;

--- a/tests/table/apis/AzureDataTablesTestEntity.ts
+++ b/tests/table/apis/AzureDataTablesTestEntity.ts
@@ -26,6 +26,9 @@ export class AzureDataTablesTestEntity {
   public partitionKey: string;
   public rowKey: string;
   public myValue: string;
+  public int32Field: number = 54321;
+  public int64Field: string = "12345";
+  public "Int64Field@odata.type": "Edm.Int64";
   constructor(part: string, row: string, value: string) {
     this.partitionKey = part;
     this.rowKey = row;

--- a/tests/table/apis/table.entity.tests.azure.data-tables.ts
+++ b/tests/table/apis/table.entity.tests.azure.data-tables.ts
@@ -175,7 +175,7 @@ describe("table Entity APIs test", () => {
     await tableClient.delete();
   });
 
-  it.only("should find a long int, @loki", async () => {
+  it("should find a long int, @loki", async () => {
     const partitionKey = createUniquePartitionKey();
     const testEntity: AzureDataTablesTestEntity = createBasicEntityForTest(
       partitionKey

--- a/tests/table/apis/table.entity.tests.azure.data-tables.ts
+++ b/tests/table/apis/table.entity.tests.azure.data-tables.ts
@@ -153,4 +153,46 @@ describe("table Entity APIs test", () => {
 
     await tableClient.delete();
   });
+
+  it("should find an int as a number, @loki", async () => {
+    const partitionKey = createUniquePartitionKey();
+    const testEntity: AzureDataTablesTestEntity = createBasicEntityForTest(
+      partitionKey
+    );
+
+    await tableClient.create({ requestOptions: { timeout: 60000 } });
+    const result = await tableClient.createEntity(testEntity);
+    assert.ok(result.etag);
+
+    const queryResult = await tableClient
+      .listEntities<AzureDataTablesTestEntity>({
+        queryOptions: {
+          filter: `PartitionKey eq '${partitionKey}' and int32Field eq 54321`
+        }
+      })
+      .next();
+    assert.notStrictEqual(queryResult.value, undefined);
+    await tableClient.delete();
+  });
+
+  it.only("should find a long int, @loki", async () => {
+    const partitionKey = createUniquePartitionKey();
+    const testEntity: AzureDataTablesTestEntity = createBasicEntityForTest(
+      partitionKey
+    );
+
+    await tableClient.create({ requestOptions: { timeout: 60000 } });
+    const result = await tableClient.createEntity(testEntity);
+    assert.ok(result.etag);
+
+    const queryResult = await tableClient
+      .listEntities<AzureDataTablesTestEntity>({
+        queryOptions: {
+          filter: `PartitionKey eq '${partitionKey}' and int64Field eq 12345L`
+        }
+      })
+      .next();
+    assert.notStrictEqual(queryResult.value, undefined);
+    await tableClient.delete();
+  });
 });


### PR DESCRIPTION
added inverted commas to query filter when applied to metadata layer for Long int, as these are stored as string in LokiJs, as opposed to ints, which are stored as number.

Added 2 tests via the @azure/data-tables tests for int and long int.

Fixes #755 