### PR TITLE
Update codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,8 +22,10 @@ jobs:
 
     # If this run was triggered by a pull request event, then checkout
     # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
+    # Update: git checkout HEAD^2 is no longer necessary. 
+    # Step removed, as Code Scanning recommends analyzing the merge commit for best results.
+    # - run: git checkout HEAD^2
+    #  if: ${{ github.event_name == 'pull_request' }}
       
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
Update: git checkout HEAD^2 is no longer necessary. 
Step removed, as Code Scanning recommends analyzing the merge commit for best results.