### PR TITLE
Update ubuntu to use latest rather than 16.04 in Pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ jobs:
   - job: blobtestlinux
     displayName: Blob Test Linux
     pool:
-      vmImage: "ubuntu-16.04"
+      vmImage: "ubuntu-latest"
     strategy:
       matrix:
         node_8_x:
@@ -100,7 +100,7 @@ jobs:
   - job: blobtestmysql
     displayName: Blob Test Mysql
     pool:
-      vmImage: "ubuntu-16.04"
+      vmImage: "ubuntu-latest"
     strategy:
       matrix:
         node_8_x:
@@ -137,7 +137,7 @@ jobs:
   - job: queuetestlinux
     displayName: Queue Test Linux
     pool:
-      vmImage: "ubuntu-16.04"
+      vmImage: "ubuntu-latest"
     strategy:
       matrix:
         node_8_x:
@@ -224,7 +224,7 @@ jobs:
   - job: tabletestlinux
     displayName: Table Test Linux
     pool:
-      vmImage: "ubuntu-16.04"
+      vmImage: "ubuntu-latest"
     strategy:
       matrix:
         node_8_x:
@@ -311,7 +311,7 @@ jobs:
   - job: azuritenodejslinux
     displayName: Azurite Linux
     pool:
-      vmImage: "ubuntu-16.04"
+      vmImage: "ubuntu-latest"
     strategy:
       matrix:
         node_8_x:
@@ -458,7 +458,7 @@ jobs:
   - job: docker
     displayName: Docker Build
     pool:
-      vmImage: "ubuntu-16.04"
+      vmImage: "ubuntu-latest"
     steps:
       - script: |
           npm ci
@@ -481,7 +481,7 @@ jobs:
   - job: governance
     displayName: Component Governance Component Detection
     pool:
-      vmImage: "ubuntu-16.04"
+      vmImage: "ubuntu-latest"
     steps:
       - task: ComponentGovernanceComponentDetection@0
         inputs:


### PR DESCRIPTION
16.04 LTS environment is deprecated and will be removed on September 20, 2021.
Migrate to ubuntu-latest