### PR TITLE
Allows Insert with empty string on partitionKey and rowKey

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ Table:
 - Corrected serialization of errors during Entity Group Transactions.
 - Correct entity tests using invalid eTag formats.
 - Added support for PATCH Verb in Table Batch Operations / Entity Group Transactions.
+- Allowed use of empty string for partitionKey and rowKey on InsertEntity.
 
 Blob:
 

--- a/src/table/handlers/TableHandler.ts
+++ b/src/table/handlers/TableHandler.ts
@@ -179,8 +179,8 @@ export default class TableHandler extends BaseHandler implements ITableHandler {
 
     if (
       !options.tableEntityProperties ||
-      !options.tableEntityProperties.PartitionKey ||
-      // rowKey may be empty string
+      // rowKey and partitionKey may be empty string
+      options.tableEntityProperties.PartitionKey === null ||
       options.tableEntityProperties.RowKey === null
     ) {
       throw StorageErrorFactory.getPropertiesNeedValue(context);

--- a/src/table/handlers/TableHandler.ts
+++ b/src/table/handlers/TableHandler.ts
@@ -177,6 +177,10 @@ export default class TableHandler extends BaseHandler implements ITableHandler {
     const accept = this.getAndCheckPayloadFormat(tableContext);
     const prefer = this.getAndCheckPreferHeader(tableContext);
 
+    // curently unable to use checking functions as the partitionKey
+    // and rowKey are not coming through the context.
+    // const partitionKey = this.getAndCheckPartitionKey(tableContext);
+    // const rowKey = this.getAndCheckRowKey(tableContext);
     if (
       !options.tableEntityProperties ||
       // rowKey and partitionKey may be empty string

--- a/tests/table/apis/table.entity.tests.ts
+++ b/tests/table/apis/table.entity.tests.ts
@@ -1214,4 +1214,42 @@ describe("table Entity APIs test", () => {
       }
     );
   });
+
+  it("Can create entities with empty string for row and partition key, @loki", (done) => {
+    requestOverride.headers = {
+      Prefer: "return-content",
+      accept: "application/json;odata=fullmetadata"
+    };
+
+    const emptyKeysEntity = createBasicEntityForTest();
+    emptyKeysEntity.PartitionKey._ = "";
+    emptyKeysEntity.RowKey._ = "";
+
+    tableService.insertEntity<TestEntity>(
+      tableName,
+      emptyKeysEntity,
+      (updateError, updateResult, updateResponse) => {
+        if (updateError) {
+          assert.ifError(updateError);
+          done();
+        } else {
+          assert.strictEqual(updateResponse.statusCode, 201);
+          tableService.retrieveEntity<TestEntity>(
+            tableName,
+            "",
+            "",
+            (error, result, response) => {
+              if (error) {
+                assert.ifError(error);
+              } else if (result) {
+                const entity: TestEntity = result;
+                assert.equal(entity.myValue._, emptyKeysEntity.myValue._);
+              }
+              done();
+            }
+          );
+        }
+      }
+    );
+  });
 });


### PR DESCRIPTION
Allows Insert with empty string on partitionKey and rowKey.
Fixes #834 