### PR TITLE
Support rscc, rscd, rsce, rscl, rsct query parameters in SAS tokens

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 ## Upcoming Release
 
+General:
+
+- Support rscc, rscd, rsce, rscl, rsct query parameters in SAS tokens.
+
 Table:
 
 - Added getServiceProperties response

--- a/src/blob/handlers/BlobHandler.ts
+++ b/src/blob/handlers/BlobHandler.ts
@@ -167,7 +167,12 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
               : undefined,
           isServerEncrypted: true,
           clientRequestId: options.requestId,
-          ...res.properties
+          ...res.properties,
+          cacheControl: context.request!.getQuery("rscc") ?? res.properties.cacheControl,
+          contentDisposition: context.request!.getQuery("rscd") ?? res.properties.contentDisposition,
+          contentEncoding: context.request!.getQuery("rsce") ?? res.properties.contentEncoding,
+          contentLanguage: context.request!.getQuery("rscl") ?? res.properties.contentLanguage,
+          contentType: context.request!.getQuery("rsct") ?? res.properties.contentType,
         };
 
     return response;
@@ -1048,6 +1053,11 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
       date: context.startTime!,
       version: BLOB_API_VERSION,
       ...blob.properties,
+      cacheControl: context.request!.getQuery("rscc") ?? blob.properties.cacheControl,
+      contentDisposition: context.request!.getQuery("rscd") ?? blob.properties.contentDisposition,
+      contentEncoding: context.request!.getQuery("rsce") ?? blob.properties.contentEncoding,
+      contentLanguage: context.request!.getQuery("rscl") ?? blob.properties.contentLanguage,
+      contentType: context.request!.getQuery("rsct") ?? blob.properties.contentType,
       blobContentMD5: blob.properties.contentMD5,
       acceptRanges: "bytes",
       contentLength,
@@ -1058,7 +1068,7 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
       blobCommittedBlockCount:
         blob.properties.blobType === Models.BlobType.AppendBlob
           ? (blob.committedBlocksInOrder || []).length
-          : undefined
+          : undefined,
     };
 
     return response;
@@ -1168,6 +1178,11 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
       date: context.startTime!,
       version: BLOB_API_VERSION,
       ...blob.properties,
+      cacheControl: context.request!.getQuery("rscc") ?? blob.properties.cacheControl,
+      contentDisposition: context.request!.getQuery("rscd") ?? blob.properties.contentDisposition,
+      contentEncoding: context.request!.getQuery("rsce") ?? blob.properties.contentEncoding,
+      contentLanguage: context.request!.getQuery("rscl") ?? blob.properties.contentLanguage,
+      contentType: context.request!.getQuery("rsct") ?? blob.properties.contentType,
       contentLength,
       contentRange,
       contentMD5,

--- a/src/blob/middlewares/StrictModelMiddlewareFactory.ts
+++ b/src/blob/middlewares/StrictModelMiddlewareFactory.ts
@@ -40,13 +40,7 @@ export const UnsupportedParametersBlocker: StrictModelRequestValidator = async (
   context: Context,
   logger: ILogger
 ): Promise<void> => {
-  const UnsupportedParameterKeys = [
-    // https://docs.microsoft.com/en-us/rest/api/storageservices/create-service-sas#specifying-query-parameters-to-override-response-headers-blob-and-file-services-only
-    "rscc",
-    "rscc",
-    "rsce",
-    "rsce",
-    "rsct"
+  const UnsupportedParameterKeys: string[] = [
   ];
 
   for (const parameterKey of UnsupportedParameterKeys) {


### PR DESCRIPTION
Support rscc, rscd, rsce, rscl, rsct query parameters in SAS tokens; fixes https://github.com/Azure/Azurite/issues/997.