### PR TITLE
Fixes issue with incorrect results when using Boolean values in table query

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,10 @@ Blob:
 - Added more allowed value to list blob request "include" query parameter:'tags', 'versions', 'deletedwithversions', 'immutabilitypolicy', 'legalhold', 'permissions'
 - Added more allowed value to list container request "include" query parameter: 'deleted'
 
+Table:
+
+- Fixed issue with incorrect results returned when using boolean values in query.
+
 ## 2021.9 Version 3.14.2
 
 Blob:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@ Blob:
 Table:
 
 - Fixed issue with incorrect results returned when using boolean values in query.
+- Fixed issue with incorrect results returned with whitespacing and parens with int64 values in query.
 
 ## 2021.9 Version 3.14.2
 

--- a/src/table/persistence/LokiTableMetadataStore.ts
+++ b/src/table/persistence/LokiTableMetadataStore.ts
@@ -816,10 +816,11 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
         }
       } else if (query[i] === "(" || query[i] === ")") {
         if (
-          i !== 0 &&
-          (query[i - 1].match(/\d/) !== null ||
-            query.slice(i - 5, i) === " true" ||
-            query.slice(i - 6, i) === " false")
+          (i !== 0 &&
+            (query[i - 1].match(/\d/) !== null ||
+              query.slice(i - 5, i) === " true" ||
+              query.slice(i - 6, i) === " false")) ||
+          query.substring(tokenStart, i).match(/\b[0-9]+L\b/g) != null
         ) {
           // this is needed if query does not contain whitespace between number token / boolean and paren
           appendToken();

--- a/src/table/persistence/LokiTableMetadataStore.ts
+++ b/src/table/persistence/LokiTableMetadataStore.ts
@@ -815,8 +815,13 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
           inString = false;
         }
       } else if (query[i] === "(" || query[i] === ")") {
-        if (i !== 0 && query[i - 1].match(/\d/) !== null) {
-          // this is needed if query does not contain whitespace between number token and paren
+        if (
+          i !== 0 &&
+          (query[i - 1].match(/\d/) !== null ||
+            query.slice(i - 5, i) === " true" ||
+            query.slice(i - 6, i) === " false")
+        ) {
+          // this is needed if query does not contain whitespace between number token / boolean and paren
           appendToken();
         }
         i--;

--- a/src/table/persistence/LokiTableMetadataStore.ts
+++ b/src/table/persistence/LokiTableMetadataStore.ts
@@ -818,8 +818,8 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
         if (
           (i !== 0 &&
             (query[i - 1].match(/\d/) !== null ||
-              query.slice(i - 5, i) === " true" ||
-              query.slice(i - 6, i) === " false")) ||
+              (i >= 5 && query.slice(i - 5, i) === " true") ||
+              (i >= 6 && query.slice(i - 6, i) === " false"))) ||
           query.substring(tokenStart, i).match(/\b[0-9]+L\b/g) != null
         ) {
           // this is needed if query does not contain whitespace between number token / boolean and paren

--- a/tests/table/apis/table.entity.tests.azure.data-tables.ts
+++ b/tests/table/apis/table.entity.tests.azure.data-tables.ts
@@ -388,7 +388,7 @@ describe("table Entity APIs test", () => {
   });
 
   it("should return the correct number of results querying with a boolean field regardless of whitespacing behaviours, @loki", async () => {
-    const partitionKeyForQueryTest = createUniquePartitionKey("");
+    const partitionKeyForQueryTest = createUniquePartitionKey("bool");
     const totalItems = 10;
     await tableClient.createTable();
     const timestamp = new Date();
@@ -443,6 +443,70 @@ describe("table Entity APIs test", () => {
         all.length,
         queryTest.expectedResult,
         `Failed with query ${queryTest.queryOptions.filter}`
+      );
+      testsCompleted++;
+    }
+    assert.strictEqual(testsCompleted, queriesAndExpectedResult.length);
+    await tableClient.deleteTable();
+  });
+
+  it("should return the correct number of results querying with an int64 field regardless of whitespacing behaviours, @loki", async () => {
+    const partitionKeyForQueryTest = createUniquePartitionKey("int64");
+    const totalItems = 10;
+    await tableClient.createTable();
+    const timestamp = new Date();
+    timestamp.setDate(timestamp.getDate() + 1);
+    for (let i = 0; i < totalItems; i++) {
+      const testEntity: AzureDataTablesTestEntity = createBasicEntityForTest(
+        partitionKeyForQueryTest
+      );
+      testEntity.int64Field = `${i}`;
+      const result = await tableClient.createEntity(testEntity);
+      assert.notStrictEqual(result.etag, undefined);
+    }
+    const maxPageSize = 10;
+    let testsCompleted = 0;
+    // take note of the different whitespacing and query formatting:
+    const queriesAndExpectedResult = [
+      {
+        queryOptions: {
+          filter: odata`(PartitionKey eq ${partitionKeyForQueryTest}) and (int64Field eq 1L )`
+        },
+        expectedResult: 1
+      },
+      {
+        queryOptions: {
+          filter: odata`(PartitionKey eq ${partitionKeyForQueryTest}) and (int64Field eq 2L)`
+        },
+        expectedResult: 2
+      },
+      {
+        queryOptions: {
+          filter: odata`(PartitionKey eq ${partitionKeyForQueryTest}) and (int64Field eq 6L)`
+        },
+        expectedResult: 6
+      }
+    ];
+
+    for (const queryTest of queriesAndExpectedResult) {
+      const entities = tableClient.listEntities<AzureDataTablesTestEntity>({
+        queryOptions: queryTest.queryOptions
+      });
+      let all: AzureDataTablesTestEntity[] = [];
+      for await (const entity of entities.byPage({
+        maxPageSize
+      })) {
+        all = [...all, ...entity];
+      }
+      assert.strictEqual(
+        all.length,
+        1,
+        `Failed on number of results with query ${queryTest.queryOptions.filter}`
+      );
+      assert.strictEqual(
+        all[0].int64Field,
+        queryTest.expectedResult.toString(),
+        `Failed to validate value with query ${queryTest.queryOptions.filter}`
       );
       testsCompleted++;
     }


### PR DESCRIPTION
fixes #1051
Contains test case to validate change.
Corrects case for query conversion in metadata store if no space between Boolean value and parens. 