### PR TITLE
Removes code to apprend -secondary flag. for issue #1142

### DIFF
--- a/src/blob/authentication/BlobSharedKeyAuthenticator.ts
+++ b/src/blob/authentication/BlobSharedKeyAuthenticator.ts
@@ -69,7 +69,7 @@ export default class BlobSharedKeyAuthenticator implements IAuthenticator {
       this.getCanonicalizedResourceString(
         req,
         account,
-        context.context.isSecondary ? blobContext.authenticationPath + "-secondary" : blobContext.authenticationPath
+        blobContext.authenticationPath
       );
 
     this.logger.info(

--- a/src/queue/authentication/QueueSharedKeyAuthenticator.ts
+++ b/src/queue/authentication/QueueSharedKeyAuthenticator.ts
@@ -12,7 +12,7 @@ export default class QueueSharedKeyAuthenticator implements IAuthenticator {
   public constructor(
     private readonly dataStore: IAccountDataStore,
     private readonly logger: ILogger
-  ) {}
+  ) { }
 
   public async validate(
     req: IRequest,
@@ -61,7 +61,7 @@ export default class QueueSharedKeyAuthenticator implements IAuthenticator {
         authType,
         req,
         account,
-        context.context.isSecondary ? queueContext.authenticationPath + "-secondary" : queueContext.authenticationPath
+        queueContext.authenticationPath
       );
 
     this.logger.info(

--- a/src/table/authentication/TableSharedKeyAuthenticator.ts
+++ b/src/table/authentication/TableSharedKeyAuthenticator.ts
@@ -12,7 +12,7 @@ export default class TableSharedKeyAuthenticator implements IAuthenticator {
   public constructor(
     private readonly dataStore: IAccountDataStore,
     private readonly logger: ILogger
-  ) {}
+  ) { }
 
   public async validate(
     req: IRequest,
@@ -55,13 +55,13 @@ export default class TableSharedKeyAuthenticator implements IAuthenticator {
         this.getHeaderValueToSign(req, HeaderConstants.CONTENT_MD5),
         this.getHeaderValueToSign(req, HeaderConstants.CONTENT_TYPE),
         this.getHeaderValueToSign(req, HeaderConstants.DATE) ||
-          this.getHeaderValueToSign(req, HeaderConstants.X_MS_DATE)
+        this.getHeaderValueToSign(req, HeaderConstants.X_MS_DATE)
       ].join("\n") +
       "\n" +
       this.getCanonicalizedResourceString(
         req,
         account,
-        context.context.isSecondary ? tableContext.authenticationPath?.substring(0, tableContext.authenticationPath?.length - 1) + "-secondary/" : tableContext.authenticationPath
+        tableContext.authenticationPath
       );
 
     this.logger.info(

--- a/tests/blob/apis/service.test.ts
+++ b/tests/blob/apis/service.test.ts
@@ -411,7 +411,7 @@ describe("ServiceAPIs - secondary location endpoint", () => {
   const factory = new BlobTestServerFactory();
   const server = factory.createServer();
 
-  const baseURL = `http://${server.config.host}:${server.config.port}/devstoreaccount1-secondary`;
+  const baseURL = `http://${server.config.host}:${server.config.port}/devstoreaccount1`;
   const serviceClient = new BlobServiceClient(
     baseURL,
     newPipeline(
@@ -436,8 +436,8 @@ describe("ServiceAPIs - secondary location endpoint", () => {
     await server.clean();
   });
 
-  it("Get Blob service stats @loki", async () => {
-
+  //TODO: Re-enable this test case after support for automatic secondary URI is added to @azure/storage-blob
+  it.skip("Get Blob service stats @loki", async () => {
     await serviceClient.getStatistics()
       .then((result) => {
         assert.strictEqual(result.geoReplication?.status, "live");

--- a/tests/queue/apis/queueService.test.ts
+++ b/tests/queue/apis/queueService.test.ts
@@ -287,7 +287,7 @@ describe("QueueServiceAPIs - secondary location endpoint", () => {
     false
   );
 
-  const baseURL = `http://${host}:${port}/devstoreaccount1-secondary`;
+  const baseURL = `http://${host}:${port}/devstoreaccount1`;
   const serviceClient = new QueueServiceClient(
     baseURL,
     newPipeline(
@@ -315,8 +315,8 @@ describe("QueueServiceAPIs - secondary location endpoint", () => {
     await rmRecursive(persistencePath);
   });
 
-  it("Get Queue service stats @loki", async () => {
-
+  // TODO: Re-enable this test case after support for automatic secondary URI is added to @azure/storage-queue
+  it.skip("Get Queue service stats @loki", async () => {
     await serviceClient.getStatistics()
       .then((result) => {
         assert.strictEqual(result.geoReplication?.status, "live");

--- a/tests/table/apis/table.service.test.ts
+++ b/tests/table/apis/table.service.test.ts
@@ -173,8 +173,8 @@ describe("table APIs test", () => {
       });
   });
 });
-
-describe("table APIs test - secondary location endpoint", () => {
+// TODO: Re-enable this test case after support for automatic secondary URI is added to @azure/storage
+describe.skip("table APIs test - secondary location endpoint", () => {
   let server: TableServer;
   const tableService = Azure.createTableService(
     createSecondaryConnectionStringForTest(testLocalAzuriteInstance)


### PR DESCRIPTION
This PR removes code to append -secondary flag in authenticator. This URI change should be taken care by the client and not by the authenticator.

Skips test cases that require secondary URI. to be re-enabled after this bug https://github.com/Azure/azure-sdk-for-js/issues/13033 is fixed.

### PR Branch Destination
Master branch

###Test Cases
This PR skips three test cases as they are requiring a hard-coded secondary URL. This should be passed as an option to client and client should replace it with correct path. Since, this feature isn't there yet in @azure/storage due to bug -> https://github.com/Azure/azure-sdk-for-js/issues/13033, leaving it as a revisit item. 
