### PR TITLE
Updated azure-pipeline.yaml MacOS VM Image name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,7 @@ jobs:
   - job: blobtestmac
     displayName: Blob Test Mac
     pool:
-      vmImage: "macOS-10.14"
+      vmImage: "macOS-10.15"
     strategy:
       matrix:
         node_8_x:
@@ -196,7 +196,7 @@ jobs:
   - job: queuetestmac
     displayName: Queue Test Mac
     pool:
-      vmImage: "macOS-10.14"
+      vmImage: "macOS-10.15"
     strategy:
       matrix:
         node_8_x:
@@ -283,7 +283,7 @@ jobs:
   - job: tabletestmac
     displayName: Table Test Mac
     pool:
-      vmImage: "macOS-10.14"
+      vmImage: "macOS-10.15"
     strategy:
       matrix:
         node_8_x:
@@ -410,7 +410,7 @@ jobs:
   - job: azuritenodejsmac
     displayName: Azurite Mac
     pool:
-      vmImage: "macOS-10.14"
+      vmImage: "macOS-10.15"
     strategy:
       matrix:
         node_8_x:


### PR DESCRIPTION
Updating the pipeline as we are getting failed PRs.
I suspect that we need to pre-empt the deprecation of macOS-10.14 images, as these are not being found:

```
##[warning]An image label with the label macOS-10.14 does not exist.\
,##[error]The remote provider was unable to process the request.
```

I assume that we will eventually need to change to macOS-11
See:
https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml 