### PR TITLE
ci - fix windows CI deprecation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@
 General:
 
 - Ensure the storage location exists, and allow relative paths in the VSCode extension settings that are resolved based on the workspace folder.
+- Update Azure CI to use latest image of windows due to deprecation of `vs2017-win2016` image
 
 Queue:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
   - job: blobtestwin
     displayName: Blob Test Windows
     pool:
-      vmImage: "vs2017-win2016"
+      vmImage: 'windows-2022'
     strategy:
       matrix:
         node_8_x:
@@ -167,7 +167,7 @@ jobs:
   - job: queuetestwin
     displayName: Queue Test Windows
     pool:
-      vmImage: "vs2017-win2016"
+      vmImage: 'windows-2022'
     strategy:
       matrix:
         node_8_x:
@@ -254,7 +254,7 @@ jobs:
   - job: tabletestwin
     displayName: Table Test Windows
     pool:
-      vmImage: "vs2017-win2016"
+      vmImage: 'windows-2022'
     strategy:
       matrix:
         node_8_x:
@@ -361,7 +361,7 @@ jobs:
   - job: azuritenodejswin
     displayName: Azurite Windows
     pool:
-      vmImage: "vs2017-win2016"
+      vmImage: 'windows-2022'
     strategy:
       matrix:
         node_8_x:
@@ -493,7 +493,7 @@ jobs:
   - job: exetest
     displayName: .exe Test Windows
     pool:
-      vmImage: "vs2017-win2016"
+      vmImage: 'windows-2022'
     strategy:
       matrix:
         # one of the node modules use a try/catch syntax not supported by node 8


### PR DESCRIPTION
Hey, hope this type of PR is ok. I noticed a lot of CI jobs failing due to a brownout of the current windows image being used (see below snippet for full error). I've updated the pipelines to use the latest version of windows available for Azure CI in order to fix this

This PR: 
- Updates Azure pipelines to use the latest windows image (`windows-2022`) due to deprecation of `vs2017-win2016` (EOL is March 2022). 


Documentation / references:
https://github.com/actions/virtual-environments/issues/4312
https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation

Error in CI:
```
##[error]This is a scheduled windows-2016 brownout. The windows-2016 environment is deprecated and will be removed on March 15, 2022. For more details, see https://github.com/actions/virtual-environments/issues/4312
,##[error]The remote provider was unable to process the request.
Started: Today at 17:36
Duration: 3h 46m 2s
```


