### PR TITLE
Respond with status 404 when patching a non-existent entity.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ Table:
 - Reject table batch request bodies exceeding 4MB.
 - Fix binary table property validation to be 64K bytes not 32K characters.
 - Does not error when table created is a substring of another table.
+- Correctly responds with status 404 on patch with non-existant entity.
 
 ## 2022.04 Version 3.17.1
 

--- a/src/table/persistence/LokiTableMetadataStore.ts
+++ b/src/table/persistence/LokiTableMetadataStore.ts
@@ -418,6 +418,7 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
           batchId
         );
       } else {
+        this.failPatchOnMissingEntity(context);
         // Insert
         return this.insertTableEntity(context, table, account, entity, batchId);
       }
@@ -431,6 +432,15 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
         ifMatch,
         batchId
       );
+    }
+  }
+
+  private failPatchOnMissingEntity(context: Context) {
+    if (
+      context.context.request.req !== undefined &&
+      context.context.request.req.method === "PATCH"
+    ) {
+      throw StorageErrorFactory.ResourceNotFound(context);
     }
   }
 

--- a/tests/table/apis/table.entity.rest.test.ts
+++ b/tests/table/apis/table.entity.rest.test.ts
@@ -12,19 +12,20 @@ import { getUniqueName } from "../../testutils";
 import { createUniquePartitionKey } from "../utils/table.entity.test.utils";
 import {
   getToAzurite,
+  patchToAzurite,
   postToAzurite
 } from "../utils/table.entity.tests.rest.submitter";
 
 // Set true to enable debug log
 configLogger(false);
 
-describe("table Entity APIs test", () => {
+describe("table Entity APIs REST tests", () => {
   // TODO: Create a server factory as tests utils
   const host = "127.0.0.1";
   const port = 11002;
   const metadataDbPath = "__tableTestsStorage__";
   const enableDebugLog: boolean = true;
-  const debugLogPath: string = "g:/debug.log";
+  const debugLogPath: string = "";
   const config = new TableConfiguration(
     host,
     port,
@@ -511,6 +512,51 @@ describe("table Entity APIs test", () => {
           );
         }
       }
+    }
+  });
+
+  it("Should fail to update using patch verb if entity does not exist, @loki", async () => {
+    const patchTable = getUniqueName("patch");
+    const body = JSON.stringify({
+      TableName: patchTable
+    });
+    const createTableHeaders = {
+      "Content-Type": "application/json",
+      Accept: "application/json;odata=nometadata"
+    };
+    const createTableResult = await postToAzurite(
+      "Tables",
+      body,
+      createTableHeaders
+    );
+    assert.strictEqual(createTableResult.status, 201);
+
+    try {
+      const patchRequestResult = await patchToAzurite(
+        `${patchTable}(PartitionKey='9b0afb2e-3be7-4b95-9ce1-45e9a410cc19',RowKey='a')`,
+        '{"PartitionKey":"9b0afb2e-3be7-4b95-9ce1-45e9a410cc19","RowKey":"a"}',
+        {
+          "If-Match": "*",
+          "Content-Type": "application/json",
+          version: "",
+          "x-ms-client-request-id": "1",
+          DataServiceVersion: "3"
+        }
+      );
+      assert.strictEqual(patchRequestResult.status, 404);
+      // we expect this to fail, as our batch request specifies the etag
+      // https://docs.microsoft.com/en-us/rest/api/storageservices/merge-entity
+    } catch (err: any) {
+      assert.notStrictEqual(
+        err.response,
+        undefined,
+        "Axios error response state invalid"
+      );
+      assert.strictEqual(
+        err.response.status,
+        404,
+        "We did not get the expected failure."
+      );
     }
   });
 });

--- a/tests/table/utils/table.entity.tests.rest.submitter.ts
+++ b/tests/table/utils/table.entity.tests.rest.submitter.ts
@@ -89,3 +89,27 @@ function generateSas(): string {
 
   return new AzureSASCredential(accountSas).signature;
 }
+
+/**
+ * Sends raw patch request to Azurite
+ *
+ * @export
+ * @param {string} path
+ * @param {string} body
+ * @param {*} headers
+ * @return {*}  {Promise<AxiosResponse<any, any>>}
+ */
+export async function patchToAzurite(
+  path: string,
+  body: string,
+  headers: any
+): Promise<AxiosResponse<any, any>> {
+  const url = `${TableEntityTestConfig.protocol}://${
+    TableEntityTestConfig.host
+  }:${TableEntityTestConfig.port}/${
+    TableEntityTestConfig.accountName
+  }/${path}?${generateSas()}`;
+  const requestConfig = axiosRequestConfig(url, path, headers);
+  const result = await axios.patch(url, body, requestConfig);
+  return result;
+}


### PR DESCRIPTION
Fixes #1493

Adds test and code to respond with status 404 when patching a non-existent entity. 