### PR TITLE
Fixed load multiple page with rows without rowkey

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ Table:
 - Fix binary table property validation to be 64K bytes not 32K characters.
 - Does not error when table created is a substring of another table.
 - Correctly responds with status 404 on patch with non-existant entity.
+- Fix pagination when no rowkey in continuation token
 
 ## 2022.04 Version 3.17.1
 

--- a/src/table/persistence/LokiTableMetadataStore.ts
+++ b/src/table/persistence/LokiTableMetadataStore.ts
@@ -510,7 +510,7 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
     const decodedNextPartitionKey =
       this.decodeContinuationHeader(nextPartitionKey);
     const decodedNextRowKey = this.decodeContinuationHeader(nextRowKey);
-
+    
     // .find using a segment filter is not filtering in the same way that the sorting function sorts
     // I think offset will cause more problems than it solves, as we will have to step and sort all
     // results here, so I am adding 2 additional predicates here to cover the cases with
@@ -533,6 +533,11 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
             return true;
           }
           return false;
+        }
+        if (decodedNextPartitionKey !== undefined) {
+          if (data.PartitionKey < decodedNextPartitionKey) {
+            return false;
+          }
         }
         return true;
       })

--- a/src/table/persistence/LokiTableMetadataStore.ts
+++ b/src/table/persistence/LokiTableMetadataStore.ts
@@ -510,7 +510,7 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
     const decodedNextPartitionKey =
       this.decodeContinuationHeader(nextPartitionKey);
     const decodedNextRowKey = this.decodeContinuationHeader(nextRowKey);
-    
+
     // .find using a segment filter is not filtering in the same way that the sorting function sorts
     // I think offset will cause more problems than it solves, as we will have to step and sort all
     // results here, so I am adding 2 additional predicates here to cover the cases with


### PR DESCRIPTION
This fix an issue when loading multiple pages of rows that does have empty string rowkey.  #1554