### PR TITLE
Fix upsert merge to not throw a 404 when the entity is missing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 ## Upcoming Release
 
+Table:
+- Correctly responds with status 202 on merge with non-existent entity.
+- Properly differentiate between upsert and update in batch merge and replace.
+
 ## 2022.06 Version 3.18.0
 
 General:

--- a/src/table/batch/TableBatchOrchestrator.ts
+++ b/src/table/batch/TableBatchOrchestrator.ts
@@ -425,14 +425,14 @@ export default class TableBatchOrchestrator {
     updatedContext.batchId = batchId;
     const partitionKey = this.extractRequestPartitionKey(request);
     const rowKey = this.extractRequestRowKey(request);
-    const ifmatch: string = request.getHeader("if-match") || "*";
+    const ifMatch = request.getHeader("if-match");
 
     response = await this.parentHandler.updateEntity(
       request.getPath(),
       partitionKey,
       rowKey,
       {
-        ifMatch: ifmatch,
+        ifMatch,
         ...request.params
       } as BatchTableUpdateEntityOptionalParams,
       updatedContext
@@ -547,14 +547,14 @@ export default class TableBatchOrchestrator {
 
     const partitionKey = this.extractRequestPartitionKey(request);
     const rowKey = this.extractRequestRowKey(request);
-    const ifmatch: string = request.getHeader("if-match") || "*";
+    const ifMatch = request.getHeader("if-match");
 
     response = await this.parentHandler.mergeEntity(
       request.getPath(),
       partitionKey,
       rowKey,
       {
-        ifMatch: ifmatch,
+        ifMatch,
         ...request.params
       } as BatchTableMergeEntityOptionalParams,
       updatedContext

--- a/src/table/persistence/LokiTableMetadataStore.ts
+++ b/src/table/persistence/LokiTableMetadataStore.ts
@@ -349,7 +349,7 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
     ifMatch?: string,
     batchId?: string
   ): Promise<Entity> {
-    if (ifMatch === undefined || ifMatch === "*") {
+    if (ifMatch === undefined) {
       // Upsert
       const existingEntity =
         await this.queryTableEntitiesWithPartitionAndRowKey(
@@ -396,7 +396,7 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
     ifMatch?: string,
     batchId?: string
   ): Promise<Entity> {
-    if (ifMatch === undefined || ifMatch === "*") {
+    if (ifMatch === undefined) {
       // Upsert
       const existingEntity =
         await this.queryTableEntitiesWithPartitionAndRowKey(
@@ -418,7 +418,6 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
           batchId
         );
       } else {
-        this.failPatchOnMissingEntity(context);
         // Insert
         return this.insertTableEntity(context, table, account, entity, batchId);
       }
@@ -432,15 +431,6 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
         ifMatch,
         batchId
       );
-    }
-  }
-
-  private failPatchOnMissingEntity(context: Context) {
-    if (
-      context.context.request.req !== undefined &&
-      context.context.request.req.method === "PATCH"
-    ) {
-      throw StorageErrorFactory.ResourceNotFound(context);
     }
   }
 

--- a/tests/table/apis/table.entity.test.ts
+++ b/tests/table/apis/table.entity.test.ts
@@ -336,10 +336,10 @@ describe("table Entity APIs test - using Azure-Storage", () => {
       tableName,
       entityToUpdate,
       (updateError, updateResult, updateResponse) => {
-        if (updateError) {
-          assert.fail("Test threw an error : " + updateError);
+        if (!updateError) {
+          assert.fail("Test should have thrown an error");
         } else {
-          assert.strictEqual(updateResponse.statusCode, 204);
+          assert.strictEqual(updateResponse.statusCode, 404);
         }
         done();
       }
@@ -604,6 +604,7 @@ describe("table Entity APIs test - using Azure-Storage", () => {
   });
 
   [
+    { pk: "pk", rk: "rk", label: "normal partition key and row key" },
     { pk: "", rk: "rk", label: "empty partition key" },
     { pk: "pk", rk: "", label: "empty row key" },
   ].forEach(({ pk, rk, label }) => {
@@ -643,6 +644,33 @@ describe("table Entity APIs test - using Azure-Storage", () => {
                   done();
                 }
               );
+            }
+          }
+        );
+      });
+    });
+
+    ["MERGE", "REPLACE"].forEach(operation => {
+      it(`${operation} of non-existent entity with ${label} in a BATCH, @loki`, (done) => {
+        requestOverride.headers = {
+          Prefer: "return-content",
+          accept: "application/json;odata=fullmetadata"
+        };
+
+        const batchEntity1 = new TestEntity(!pk ? pk : getUniqueName(pk), !rk ? rk : getUniqueName(rk), "value1");
+
+        const entityBatch: Azure.TableBatch = new Azure.TableBatch();
+        entityBatch.addOperation(operation, batchEntity1);
+
+        tableService.executeBatch(
+          tableName,
+          entityBatch,
+          (updateError, updateResult, updateResponse) => {
+            if (!updateError) {
+              assert.fail("Test should have thrown an error");
+            } else {
+              assert.strictEqual(updateResponse.statusCode, 404);
+              done();
             }
           }
         );

--- a/tests/table/auth/sas.test.ts
+++ b/tests/table/auth/sas.test.ts
@@ -451,7 +451,7 @@ describe("Shared Access Signature (SAS) authentication", () => {
       );
 
       // this upserts, so we expect success
-      sasService.replaceEntity(
+      sasService.insertOrReplaceEntity(
         tableName,
         { PartitionKey: "part1", RowKey: "row4", myValue: "newValue" },
         (updateError, updateResult, updateResponse) => {
@@ -466,7 +466,7 @@ describe("Shared Access Signature (SAS) authentication", () => {
               updateResponse.statusCode,
               204,
               "We did not get the expected status code : " +
-                updateResponse.statusCode
+              updateResponse.statusCode
             );
           }
           done();


### PR DESCRIPTION
If-Match: * and no If-Match header behaves differently. If-Match: * requires the entity to exist.

Address https://github.com/Azure/Azurite/issues/1565 as well as another pre-existing problem where Batch Update acted like an Upsert.