### PR TITLE
feat: add scripts for building multi-architecture azurite docker images

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,6 +257,15 @@
     "docker:build:internal": "npm run docker:prebuild && cross-var docker build --no-cache --rm -f \"Dockerfile\" -t xstoreazurite.azurecr.io/internal/azure-storage/azurite:$npm_package_version . && cross-var docker tag xstoreazurite.azurecr.io/internal/azure-storage/azurite:$npm_package_version xstoreazurite.azurecr.io/internal/azure-storage/azurite:latest",
     "docker:publish": "cross-var docker push xstoreazurite.azurecr.io/public/azure-storage/azurite:$npm_package_version",
     "docker:publish:internal": "cross-var docker push xstoreazurite.azurecr.io/internal/azure-storage/azurite:$npm_package_version",
+    "docker:init-multi-platform-builder": "docker buildx create --name multi-platform-builder --use",
+    "docker:build-amd64": "cross-var docker buildx build --platform linux/amd64 --load --no-cache --rm -f \"Dockerfile\" -t xstoreazurite.azurecr.io/public/azure-storage/azurite:$npm_package_version-amd64 .",
+    "docker:build-arm64": "cross-var docker buildx build --platform linux/arm64 --load --no-cache --rm -f \"Dockerfile\" -t xstoreazurite.azurecr.io/public/azure-storage/azurite:$npm_package_version-arm64 .",
+    "docker:publish-amd64": "cross-var docker push xstoreazurite.azurecr.io/public/azure-storage/azurite:$npm_package_version-amd64",
+    "docker:publish-arm64": "cross-var docker push xstoreazurite.azurecr.io/public/azure-storage/azurite:$npm_package_version-arm64",
+    "docker:create-manifest-versioned": "cross-var docker manifest create xstoreazurite.azurecr.io/public/azure-storage/azurite:$npm_package_version xstoreazurite.azurecr.io/public/azure-storage/azurite:$npm_package_version-amd64 xstoreazurite.azurecr.io/public/azure-storage/azurite:$npm_package_version-arm64",
+    "docker:create-manifest-latest": "cross-var docker manifest create xstoreazurite.azurecr.io/public/azure-storage/azurite:latest xstoreazurite.azurecr.io/public/azure-storage/azurite:$npm_package_version-amd64 xstoreazurite.azurecr.io/public/azure-storage/azurite:$npm_package_version-arm64",
+    "docker:publish-manifest-versioned": "cross-var docker manifest push xstoreazurite.azurecr.io/public/azure-storage/azurite:$npm_package_version",
+    "docker:publish-manifest-latest": "cross-var docker manifest push xstoreazurite.azurecr.io/public/azure-storage/azurite:latest",
     "prepare": "npm run build",
     "build": "tsc",
     "build:autorest:debug": "autorest ./swagger/blob.md --typescript --typescript.debugger --use=E:/GitHub/XiaoningLiu/autorest.typescript.server",
@@ -286,8 +295,7 @@
     "db:migrate:blob:metadata": "sequelize db:migrate --config migrations/blob/metadata/config/config.json --migrations-path migrations/blob/metadata/migrations",
     "db:create:blob:metadata": "sequelize db:create --config migrations/blob/metadata/config/config.json --migrations-path migrations/blob/metadata/migrations"
   },
-  "husky": {
-  },
+  "husky": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azurite.git"


### PR DESCRIPTION
Add support for building docker images for amd64 and arm64 architectures.
Addresses [issue](https://github.com/Azure/Azurite/issues/1556)
@kdambekalns
@blueww 

When running on Apple Silicon without multi-arch support
<img width="358" alt="175796126-cfdbb11c-252e-44dd-bbe5-0c76793e124e" src="https://user-images.githubusercontent.com/984705/175833327-ecf780d1-8fdb-4bb9-a9db-9d8f12894914.png">

When running on Apple Silicon with multi-arch support
<img width="614" alt="Screen Shot 2022-06-26 at 1 51 07 PM" src="https://user-images.githubusercontent.com/984705/175833346-6e481c9b-f039-4f93-ad84-e83f3e1f36cf.png">

The scripts need to be invoked during your CI/CD build pipeline.
It looks like that partially occurs in `azure-pipelines.yml` however I couldn't find anything that actually publishes to the docker image/container registry.

Ideally the order would go something like this:
```
npm run docker:init-multi-platform-builder
npm run docker:build-amd64
npm run docker:build-arm64
npm run docker:publish-amd64
npm run docker:publish-arm64
npm run docker:create-manifest-versioned
npm run docker:create-manifest-latest
npm run docker:publish-manifest-versioned
npm run docker:publish-manifest-latest
```

This would result in 4 artifacts being published to the docker registry:
- `xstoreazurite.azurecr.io/public/azure-storage/azurite:3.18.0-amd64` (image)
- `xstoreazurite.azurecr.io/public/azure-storage/azurite:3.18.0-arm64` (image)
- `xstoreazurite.azurecr.io/public/azure-storage/azurite:3.18.0` (manifest)
- `xstoreazurite.azurecr.io/public/azure-storage/azurite:latest` (manifest)

this would permit users to pull the multi-architecture "image" in any of the following ways:
- `docker pull xstoreazurite.azurecr.io/public/azure-storage/azurite`
- `docker pull xstoreazurite.azurecr.io/public/azure-storage/azurite:latest`
- `docker pull xstoreazurite.azurecr.io/public/azure-storage/azurite:3.18.0`

it's not clear to me how these artifacts all get replicated to `mcr.microsoft.com` but I suspect you all know how to do that :)

**Note**: if your pipeline is able to build and push at the same time, the sequence can be greatly simplified into a single command like so
```
cross-var docker buildx build 
  --platform linux/amd64,linux/arm64 
  --push
  --no-cache
  --rm
  --file Dockerfile
  --tag xstoreazurite.azurecr.io/public/azure-storage/azurite:$npm_package_version
  --tag xstoreazurite.azurecr.io/public/azure-storage/azurite:latest
  .
```