### PR TITLE
Fix issue 1579: Missing etag in header for GET Operation

### DIFF
--- a/src/table/handlers/TableHandler.ts
+++ b/src/table/handlers/TableHandler.ts
@@ -688,6 +688,7 @@ export default class TableHandler extends BaseHandler implements ITableHandler {
       date: tableContext.startTime,
       clientRequestId: options.requestId,
       requestId: context.contextID,
+      eTag: entity.eTag,
       version: TABLE_API_VERSION
     };
 


### PR DESCRIPTION
Fix issue: [#1579](https://github.com/Azure/Azurite/issues/1579)

Added test case to check specifically for etag in headers in table.entity.rest.test.ts

and modified TableHandler.ts in line 686 to solve issue.

This is an updated PR of (closed) #1613 since the old PR contained unwanted changes.