### PR TITLE
Make emulator start commands asynchronous

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@
 General:
 
 - Updated Readme by adding account key must be base64 encoded string.
+- Make emulator start commands async so that they can be awaited by clients
 
 Table:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@
 General:
 
 - Updated Readme by adding account key must be base64 encoded string.
-- Make emulator start commands async so that they can be awaited by clients
+- Make emulator start commands async so that they can be awaited by clients.
 
 Table:
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,8 +71,8 @@ export function activate(context: ExtensionContext) {
       tableServerManager.clean();
     }),
 
-    commands.registerCommand(blobServerManager.getStartCommand(), () => {
-      blobServerManager.start();
+    commands.registerCommand(blobServerManager.getStartCommand(), async () => {
+      await blobServerManager.start();
     }),
     commands.registerCommand(blobServerManager.getCloseCommand(), () => {
       blobServerManager.close();
@@ -81,8 +81,8 @@ export function activate(context: ExtensionContext) {
       blobServerManager.clean();
     }),
 
-    commands.registerCommand(queueServerManager.getStartCommand(), () => {
-      queueServerManager.start();
+    commands.registerCommand(queueServerManager.getStartCommand(), async () => {
+      await queueServerManager.start();
     }),
     commands.registerCommand(queueServerManager.getCloseCommand(), () => {
       queueServerManager.close();
@@ -91,8 +91,8 @@ export function activate(context: ExtensionContext) {
       queueServerManager.clean();
     }),
 
-    commands.registerCommand(tableServerManager.getStartCommand(), () => {
-      tableServerManager.start();
+    commands.registerCommand(tableServerManager.getStartCommand(), async () => {
+      await tableServerManager.start();
     }),
     commands.registerCommand(tableServerManager.getCloseCommand(), () => {
       tableServerManager.close();


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestorage/issues/1000

We're have an issue where the emulator hasn't actually started by the time we refresh the tree. I'm guessing that this is because the registered start commands aren't actually `async` so when we try to `await` it, it doesn't actually wait for it to resolve.