### PR TITLE
don't default the delimiter for list blob hierarchy to slash

### DIFF
--- a/src/blob/handlers/ContainerHandler.ts
+++ b/src/blob/handlers/ContainerHandler.ts
@@ -630,7 +630,6 @@ export default class ContainerHandler extends BaseHandler
 
     const request = context.request!;
     const marker = options.marker;
-    delimiter = delimiter === "" ? "/" : delimiter;
     options.prefix = options.prefix || "";
     options.marker = options.marker || "";
     let includeSnapshots: boolean = false;
@@ -660,7 +659,7 @@ export default class ContainerHandler extends BaseHandler
       context,
       accountName,
       containerName,
-      delimiter,
+      delimiter === "" ? undefined : delimiter,
       undefined,
       options.prefix,
       options.maxresults,


### PR DESCRIPTION
Regarding the [list-blobs](https://learn.microsoft.com/en-us/rest/api/storageservices/list-blobs#uri-parameters) endpoint. Azure handles an empty `delimiter` query parameter as such (as if it was not given). But Azurite defaults it to a `/` (slash). This behaviour was [added by](https://github.com/Azure/Azurite/commit/6ef53aec1c3c32be8754237a08e5c6ab9990cbb0#diff-ef140eda9dd541760b3a8c2ad07ee5462eb8b1a6f87ea7669107623fa5fcfb77R829) @XiaoningLiu, but I cannot determine the exact reason. 

It causes incompatibility issues. E.g. in the Azure Storage Explorer; the returned flat list of blobs is empty when there are in fact blobs in the container. And also in minio, which [uses the azure storage go library](https://github.com/minio/minio/blob/RELEASE.2022-03-17T06-34-49Z/cmd/gateway/azure/gateway-azure.go#L668) which [always sets](https://github.com/Azure/azure-storage-blob-go/blob/v0.10.0/azblob/zz_generated_container.go#L700) the `delimiter` query parameter.

This PR removes the defaulting behaviour.