### PR TITLE
Add SharedKeyLite auth support to blob service

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@ General:
 Blob:
 
 - Support Copy Blob From URL API when use different source and destination account (in same Azurite instance).
+- Add SharedKeyLite auth support to blob service.
 
 Table:
 


### PR DESCRIPTION
My use case is the same as previous users, I'm using a JClouds app, which still uses SharedKeyLite. More specifically, https://github.com/gaul/s3proxy. The idea is to use the S3 api to save blobs to Azure Storage.
I took the work from #402 and updated it to the latest changes.
I haven't found test cases, but I have manually tested it with Azure Storage Explorer and and a s3proxy. It was not working on s3proxy, and now it is.

Superseedes #402.
Closes #378.