### PR TITLE
Bump base image to alpine 3.17

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 ## Upcoming Release
 
+General:
+
+- Base image alpine version bumped to 3.17
+
 ## 2023.02 Version 3.22.0
 
 General:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Builder
 #
-FROM node:lts-alpine3.10 AS builder
+FROM node:lts-alpine3.17 AS builder
 
 WORKDIR /opt/azurite
 
@@ -20,7 +20,7 @@ RUN npm run build && \
 #
 # Production image
 #
-FROM node:lts-alpine3.10
+FROM node:lts-alpine3.17
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
Increasing alpine version to 3.17 in docker image  (fixes #1814)
