### PR TITLE
support developing durable functions with a local Azure Functions 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 ## Upcoming Release
 
+Queue:
+
+- Fixed issue with running Durable Functions from Azure Functions where the Functions would send oddly an formatted negative number the messagettl parameter.
+
 ## 2023.02 Version 3.22.0
 
 General:

--- a/src/queue/QueueRequestListenerFactory.ts
+++ b/src/queue/QueueRequestListenerFactory.ts
@@ -47,7 +47,7 @@ export default class QueueRequestListenerFactory
     private readonly skipApiVersionCheck?: boolean,
     private readonly oauth?: OAuthLevel,
     private readonly disableProductStyleUrl?: boolean
-  ) { }
+  ) {}
 
   public createRequestListener(): RequestListener {
     const app = express().disable("x-powered-by");

--- a/src/queue/QueueRequestListenerFactory.ts
+++ b/src/queue/QueueRequestListenerFactory.ts
@@ -98,11 +98,12 @@ export default class QueueRequestListenerFactory
     // Sometimes Azure Functions sends messagettl as -1 with a unicode minus sign (−)
     app.use((req, res, next) => {
       if (req && req.query && req.query.messagettl) {
-        let messagettl = req.query.messagettl?.replace("−", "-");
+        const messagettl = req.query.messagettl?.replace("−", "-");
         req.query.messagettl = messagettl;
       }
       next();
-    })
+    });
+
     // Dispatch incoming HTTP request to specific operation
     app.use(middlewareFactory.createDispatchMiddleware());
 


### PR DESCRIPTION
Sometimes the local Azure Functions host will set messagettl to −1 instead of -1 (the first numer uses unicode letter U+2212 instead of the regular '-' character). This causes Azurite to, understandiby, return a 400 error and the durable function to not start. By adding the code here this is mitigated by replacing '−' with '-' in messagettl query paramters before they are attemted to be used and thus avoiding retuinijng 400.

Thanks for contribution! Please go through following checklist before sending PR.

### PR Branch Destination

- For Azurite V3, please send PR to `main` branch.
- For legacy Azurite V2, please send PR to `legacy-dev` branch.

### Always Add Test Cases

Make sure test cases are added to cover the code change.

QueueServiceClient does not allow adding strings as messagettl. Could you please advice on how to create the test case in this instance? :)

### Add Change Log

Add change log for the code change in `Upcoming Release` section in `ChangeLog.md`.

### Development Guideline

Please go to CONTRIBUTION.md for steps about setting up development environment and recommended Visual Studio Code extensions.
