### PR TITLE
Add requestId to appendBlock operation.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 ## Upcoming Release
 
+Blob:
+
+- Fixed issue of: Append block not returning requestId in response.
+
 ## 2023.07 Version 3.25.0
 
 Table:

--- a/src/blob/handlers/AppendBlobHandler.ts
+++ b/src/blob/handlers/AppendBlobHandler.ts
@@ -201,6 +201,7 @@ export default class AppendBlobHandler extends BaseHandler
 
     const response: Models.AppendBlobAppendBlockResponse = {
       statusCode: 201,
+      requestId: context.contextId,
       eTag: properties.etag,
       lastModified: properties.lastModified,
       contentMD5: contentMD5Buffer,


### PR DESCRIPTION
Add missing requestId to the appendBlock operation of an append blob.

Fixes #631.
