### PR TITLE
fix: Resolve issues with datetime comparisons in scenarios where microsecond precision is provided in the underlying value.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,10 @@ Blob:
 
 - Fixed issue of: Append block not returning requestId in response.
 
+Table:
+ - Fixed an issue when querying datetimes with microsecond precision which resulted in match failures. (issue #2069)
+
+
 ## 2023.07 Version 3.25.0
 
 Table:

--- a/src/table/persistence/QueryInterpreter/QueryNodes/DateTimeNode.ts
+++ b/src/table/persistence/QueryInterpreter/QueryNodes/DateTimeNode.ts
@@ -1,5 +1,6 @@
 import { IQueryContext } from "../IQueryContext";
 import IQueryNode from "./IQueryNode";
+import ValueNode from "./ValueNode";
 
 /**
  * Represents a constant value of type `datetime` which is stored in its underlying JavaScript representation.
@@ -9,18 +10,29 @@ import IQueryNode from "./IQueryNode";
  * the query `PartitionKey eq datetime'2019-01-01T00:00:00.000Z'` would contain a `DateTimeNode` with the value
  * `2019-01-01T00:00:00.000Z`.
  */
-export default class DateTimeNode<T> implements IQueryNode {
-  constructor(private value: Date) { }
-
+export default class DateTimeNode<T> extends ValueNode {
   get name(): string {
     return "datetime";
   }
 
-  evaluate(_context: IQueryContext): any {
-    return this.value.toISOString();
-  }
+  compare(context: IQueryContext, other: IQueryNode): number {
+    // NOTE(notheotherben): This approach leverages the fact that the `Date` constructor will parse ISO8601 strings
+    //                 however it runs into a limitation of the accuracy of JS dates (which are limited to millisecond
+    //                 resolution). As a result, we're effectively truncating the value to millisecond precision by doing
+    //                 this. This is fundamentally a trade-off between enforcing valid datetime values and providing perfect
+    //                 accuracy, and we've opted to enforce valid datetime values as those are more likely to cause problems
+    //                 when moving to production.
+    const thisValue = new Date(this.value);
+    const otherValue = new Date(other.evaluate(context));
 
-  toString(): string {
-    return `(${this.name} ${this.value.toISOString()})`;
+    if (thisValue.valueOf() < otherValue.valueOf()) {
+      return -1;
+    } else if (thisValue.valueOf() > otherValue.valueOf()) {
+      return 1;
+    } else if (thisValue.valueOf() === otherValue.valueOf()) {
+      return 0;
+    } else {
+      return NaN;
+    }
   }
 }

--- a/src/table/persistence/QueryInterpreter/QueryNodes/EqualsNode.ts
+++ b/src/table/persistence/QueryInterpreter/QueryNodes/EqualsNode.ts
@@ -1,6 +1,6 @@
 import { IQueryContext } from "../IQueryContext";
 import BinaryOperatorNode from "./BinaryOperatorNode";
-import GuidNode from "./GuidNode";
+import ValueNode from "./ValueNode";
 
 /**
  * Represents a logical equality operation between two nodes (the `eq` query operator).
@@ -21,13 +21,14 @@ export default class EqualsNode extends BinaryOperatorNode {
   }
 
   evaluate(context: IQueryContext): any {
-    return this.left.evaluate(context) === this.right.evaluate(context) || this.backwardsCompatibleGuidEvaluate(context);
-  }
+    if (this.left instanceof ValueNode) {
+      return this.left.compare(context, this.right) === 0;
+    }
 
-  private backwardsCompatibleGuidEvaluate(context: IQueryContext): boolean {
-    const left = this.left instanceof GuidNode ? this.left.legacyStorageFormat() : this.left.evaluate(context);
-    const right = this.right instanceof GuidNode ? this.right.legacyStorageFormat() : this.right.evaluate(context);
+    if (this.right instanceof ValueNode) {
+      return this.right.compare(context, this.left) === 0;
+    }
 
-    return left === right;
+    return this.left.evaluate(context) === this.right.evaluate(context);
   }
 }

--- a/src/table/persistence/QueryInterpreter/QueryNodes/GreaterThanEqualNode.ts
+++ b/src/table/persistence/QueryInterpreter/QueryNodes/GreaterThanEqualNode.ts
@@ -1,5 +1,6 @@
 import { IQueryContext } from "../IQueryContext";
 import BinaryOperatorNode from "./BinaryOperatorNode";
+import ValueNode from "./ValueNode";
 
 /**
  * Represents a logical greater than or equal operation between two nodes (the `ge` query operator).
@@ -17,6 +18,14 @@ export default class GreaterThanEqualNode extends BinaryOperatorNode {
   }
 
   evaluate(context: IQueryContext): any {
+    if (this.left instanceof ValueNode) {
+      return this.left.compare(context, this.right) >= 0;
+    }
+
+    if (this.right instanceof ValueNode) {
+      return this.right.compare(context, this.left) <= 0;
+    }
+
     return this.left.evaluate(context) >= this.right.evaluate(context);
   }
 }

--- a/src/table/persistence/QueryInterpreter/QueryNodes/GreaterThanNode.ts
+++ b/src/table/persistence/QueryInterpreter/QueryNodes/GreaterThanNode.ts
@@ -1,5 +1,6 @@
 import { IQueryContext } from "../IQueryContext";
 import BinaryOperatorNode from "./BinaryOperatorNode";
+import ValueNode from "./ValueNode";
 
 /**
  * Represents a logical greater than operation between two nodes (the `gt` query operator).
@@ -17,6 +18,14 @@ export default class GreaterThanNode extends BinaryOperatorNode {
   }
 
   evaluate(context: IQueryContext): any {
+    if (this.left instanceof ValueNode) {
+      return this.left.compare(context, this.right) > 0;
+    }
+
+    if (this.right instanceof ValueNode) {
+      return this.right.compare(context, this.left) < 0;
+    }
+
     return this.left.evaluate(context) > this.right.evaluate(context);
   }
 }

--- a/src/table/persistence/QueryInterpreter/QueryNodes/GuidNode.ts
+++ b/src/table/persistence/QueryInterpreter/QueryNodes/GuidNode.ts
@@ -27,7 +27,7 @@ export default class GuidNode<T> extends ValueNode {
     let thisValue = this.value;
 
     // If the other value is not in its raw GUID format, then let's convert this value to its base64 representation
-    if (!/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/i.test(otherValue)) {
+    if (!/^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(otherValue)) {
       thisValue = Buffer.from(this.value).toString("base64");
     }
 

--- a/src/table/persistence/QueryInterpreter/QueryNodes/LessThanEqualNode.ts
+++ b/src/table/persistence/QueryInterpreter/QueryNodes/LessThanEqualNode.ts
@@ -1,5 +1,6 @@
 import { IQueryContext } from "../IQueryContext";
 import BinaryOperatorNode from "./BinaryOperatorNode";
+import ValueNode from "./ValueNode";
 
 /**
  * Represents a logical less than or equal operation between two nodes (the `le` query operator).
@@ -17,6 +18,14 @@ export default class LessThanEqualNode extends BinaryOperatorNode {
   }
 
   evaluate(context: IQueryContext): any {
+    if (this.left instanceof ValueNode) {
+      return this.left.compare(context, this.right) <= 0;
+    }
+
+    if (this.right instanceof ValueNode) {
+      return this.right.compare(context, this.left) >= 0;
+    }
+
     return this.left.evaluate(context) <= this.right.evaluate(context);
   }
 }

--- a/src/table/persistence/QueryInterpreter/QueryNodes/LessThanNode.ts
+++ b/src/table/persistence/QueryInterpreter/QueryNodes/LessThanNode.ts
@@ -1,5 +1,6 @@
 import { IQueryContext } from "../IQueryContext";
 import BinaryOperatorNode from "./BinaryOperatorNode";
+import ValueNode from "./ValueNode";
 
 /**
  * Represents a logical less than operation between two nodes (the `lt` query operator).
@@ -17,6 +18,14 @@ export default class LessThanNode extends BinaryOperatorNode {
   }
 
   evaluate(context: IQueryContext): any {
+    if (this.left instanceof ValueNode) {
+      return this.left.compare(context, this.right) < 0;
+    }
+
+    if (this.right instanceof ValueNode) {
+      return this.right.compare(context, this.left) > 0;
+    }
+
     return this.left.evaluate(context) < this.right.evaluate(context);
   }
 }

--- a/src/table/persistence/QueryInterpreter/QueryNodes/NotEqualsNode.ts
+++ b/src/table/persistence/QueryInterpreter/QueryNodes/NotEqualsNode.ts
@@ -1,6 +1,6 @@
 import { IQueryContext } from "../IQueryContext";
 import BinaryOperatorNode from "./BinaryOperatorNode";
-import GuidNode from "./GuidNode";
+import ValueNode from "./ValueNode";
 
 /**
  * Represents a logical not equal operation between two nodes (the `ne` query operator).
@@ -21,18 +21,17 @@ export default class NotEqualsNode extends BinaryOperatorNode {
   }
 
   evaluate(context: IQueryContext): any {
+    if (this.left instanceof ValueNode) {
+      return this.left.compare(context, this.right) !== 0;
+    }
+
+    if (this.right instanceof ValueNode) {
+      return this.right.compare(context, this.left) !== 0;
+    }
+
     const left = this.left.evaluate(context);
     const right = this.right.evaluate(context);
 
-    // If either side is undefined, we should not match - this only occurs in scenarios where
-    // the field itself doesn't exist on the entity.
-    return left !== right && left !== undefined && right !== undefined && this.backwardsCompatibleGuidEvaluate(context);
-  }
-
-  private backwardsCompatibleGuidEvaluate(context: IQueryContext): boolean {
-    const left = this.left instanceof GuidNode ? this.left.legacyStorageFormat() : this.left.evaluate(context);
-    const right = this.right instanceof GuidNode ? this.right.legacyStorageFormat() : this.right.evaluate(context);
-
-    return left !== right;
+    return left !== right && left !== undefined && right !== undefined;
   }
 }

--- a/src/table/persistence/QueryInterpreter/QueryNodes/ValueNode.ts
+++ b/src/table/persistence/QueryInterpreter/QueryNodes/ValueNode.ts
@@ -1,0 +1,30 @@
+import { IQueryContext } from "../IQueryContext";
+import IQueryNode from "./IQueryNode";
+
+/**
+ * Represents a typed value which can implement its own comparison logic.
+ */
+export default abstract class ValueNode implements IQueryNode {
+  constructor(protected value: string) { }
+
+  abstract get name(): string;
+
+  evaluate(_context: IQueryContext): any {
+    return this.value;
+  }
+
+  compare(context: IQueryContext, other: IQueryNode): number {
+    const otherValue = other.evaluate(context);
+    if (this.value < otherValue) {
+      return -1;
+    } else if (this.value > otherValue) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  toString(): string {
+    return `(${this.name} ${this.value})`;
+  }
+}

--- a/src/table/persistence/QueryInterpreter/QueryParser.ts
+++ b/src/table/persistence/QueryInterpreter/QueryParser.ts
@@ -223,7 +223,7 @@ class QueryParser {
 
     switch (typeHint.value?.toLowerCase()) {
       case "datetime":
-        return new DateTimeNode(new Date(value.value!));
+        return new DateTimeNode(value.value!);
       case "guid":
         return new GuidNode(value.value!);
       case "binary":

--- a/tests/table/unit/query.interpreter.unit.test.ts
+++ b/tests/table/unit/query.interpreter.unit.test.ts
@@ -32,6 +32,7 @@ describe("Query Interpreter", () => {
       double: -123.01,
       bool: true,
       date: "2020-01-01T00:00:00.000Z",
+      microsecondDate: "2023-01-01T00:00:00.000000Z",
       guid: Buffer.from("00000000-0000-0000-0000-000000000000").toString("base64"),
       guidLegacy: "00000000-0000-0000-0000-000000000000",
       binary: Buffer.from("binaryData").toString("base64"),
@@ -240,6 +241,129 @@ describe("Query Interpreter", () => {
         name: "GUID inequality (legacy)",
         originalQuery: "guidLegacy ne guid'22222222-2222-2222-2222-222222222222'",
         expectedResult: true
+      }
+    ])
+
+    runTestCases("DateTimes", referenceEntity, [
+      {
+        name: "DateTime equality",
+        originalQuery: "date eq datetime'2020-01-01T00:00:00.000Z'",
+        expectedResult: true
+      },
+      {
+        name: "DateTime equality (doesn't match)",
+        originalQuery: "date eq datetime'2020-01-01T00:00:01.000Z'",
+        expectedResult: false
+      },
+      {
+        name: "DateTime equality (microseconds)",
+        originalQuery: "microsecondDate eq datetime'2023-01-01T00:00:00.000000Z'",
+        expectedResult: true
+      },
+      {
+        name: "DateTime equality (microseconds) (doesn't match)",
+        originalQuery: "microsecondDate eq datetime'2023-01-01T00:00:00.001000Z'",
+        expectedResult: false
+      },
+      {
+        name: "DateTime inequality",
+        originalQuery: "date ne datetime'2020-01-01T00:00:01.000000Z'",
+        expectedResult: true
+      },
+      {
+        name: "DateTime inequality (doesn't match)",
+        originalQuery: "date ne datetime'2020-01-01T00:00:00.000000Z'",
+        expectedResult: false
+      },
+      {
+        name: "DateTime inequality (microseconds)",
+        originalQuery: "microsecondDate ne datetime'2023-01-01T00:00:01.000000Z'",
+        expectedResult: true
+      },
+      {
+        name: "DateTime inequality (microseconds) (doesn't match)",
+        originalQuery: "microsecondDate ne datetime'2023-01-01T00:00:00.000000Z'",
+        expectedResult: false
+      },
+      {
+        name: "DateTime greater than",
+        originalQuery: "date gt datetime'2019-12-31T23:59:59.999999Z'",
+        expectedResult: true
+      },
+      {
+        name: "DateTime greater than (doesn't match)",
+        originalQuery: "date gt datetime'2020-01-01T00:00:00.000000Z'",
+        expectedResult: false
+      },
+      {
+        name: "DateTime greater than (microseconds)",
+        originalQuery: "microsecondDate gt datetime'2022-12-31T23:59:59.999999Z'",
+        expectedResult: true
+      },
+      {
+        name: "DateTime greater than (microseconds) (doesn't match)",
+        originalQuery: "microsecondDate gt datetime'2023-01-01T00:00:00.000000Z'",
+        expectedResult: false
+      },
+      {
+        name: "DateTime greater than or equal",
+        originalQuery: "date ge datetime'2020-01-01T00:00:00.000000Z'",
+        expectedResult: true
+      },
+      {
+        name: "DateTime greater than or equal (doesn't match)",
+        originalQuery: "date ge datetime'2020-01-01T00:00:00.001000Z'",
+        expectedResult: false
+      },
+      {
+        name: "DateTime greater than or equal (microseconds)",
+        originalQuery: "microsecondDate ge datetime'2023-01-01T00:00:00.000000Z'",
+        expectedResult: true
+      },
+      {
+        name: "DateTime greater than or equal (microseconds) (doesn't match)",
+        originalQuery: "microsecondDate ge datetime'2023-01-01T00:00:00.001000Z'",
+        expectedResult: false
+      },
+      {
+        name: "DateTime less than",
+        originalQuery: "date lt datetime'2020-01-01T00:00:00.001Z'",
+        expectedResult: true
+      },
+      {
+        name: "DateTime less than (doesn't match)",
+        originalQuery: "date lt datetime'2020-01-01T00:00:00.000Z'",
+        expectedResult: false
+      },
+      {
+        name: "DateTime less than (microseconds)",
+        originalQuery: "microsecondDate lt datetime'2023-01-01T00:00:00.001000Z'",
+        expectedResult: true
+      },
+      {
+        name: "DateTime less than (microseconds) (doesn't match)",
+        originalQuery: "microsecondDate lt datetime'2023-01-01T00:00:00.000000Z'",
+        expectedResult: false
+      },
+      {
+        name: "DateTime less than or equal",
+        originalQuery: "date le datetime'2020-01-01T00:00:00.000000Z'",
+        expectedResult: true
+      },
+      {
+        name: "DateTime less than or equal (doesn't match)",
+        originalQuery: "date le datetime'2019-12-31T23:59:59.999999Z'",
+        expectedResult: false
+      },
+      {
+        name: "DateTime less than or equal (microseconds)",
+        originalQuery: "microsecondDate le datetime'2023-01-01T00:00:00.000000Z'",
+        expectedResult: true
+      },
+      {
+        name: "DateTime less than or equal (microseconds) (doesn't match)",
+        originalQuery: "microsecondDate le datetime'2022-12-31T23:59:59.999999Z'",
+        expectedResult: false
       }
     ])
   })


### PR DESCRIPTION
This PR makes some changes to the way our query interpreter is architected, enabling us to handle `DateTime` comparisons with more appropriate custom logic which avoids the `myField eq datetime'2023-07-27T14:01:00.000000Z'` query failing to match backend entries with the same underlying format due to the manner in which JavaScript's `Date` constructor truncates these values.

Fixes #2069