### PR TITLE
Fix validation of Blob SAS token when using the second key for an account in `AZURITE_ACCOUNTS`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 ## Upcoming Release
 
+Blob:
+
+- Fix validation of Blob SAS token when using the second key for an account in `AZURITE_ACCOUNTS`
+
 ## 2023.08 Version 3.26.0
 
 General:

--- a/src/blob/authentication/AccountSASAuthenticator.ts
+++ b/src/blob/authentication/AccountSASAuthenticator.ts
@@ -134,7 +134,7 @@ export default class AccountSASAuthenticator implements IAuthenticator {
         context.contextId!
       );
 
-      const sig2Pass = sig2 !== signature;
+      const sig2Pass = sig2 === signature;
       this.logger.info(
         `AccountSASAuthenticator:validate() Signature based on key2 validation ${
           sig2Pass ? "passed" : "failed"

--- a/src/blob/authentication/BlobSASAuthenticator.ts
+++ b/src/blob/authentication/BlobSASAuthenticator.ts
@@ -276,7 +276,7 @@ export default class BlobSASAuthenticator implements IAuthenticator {
           context.contextId!
         );
 
-        const sig2Pass = sig2 !== signature;
+        const sig2Pass = sig2 === signature;
         this.logger.info(
           `BlobSASAuthenticator:validate() Signature based on key2 validation ${
             sig2Pass ? "passed" : "failed"

--- a/src/queue/authentication/QueueSASAuthenticator.ts
+++ b/src/queue/authentication/QueueSASAuthenticator.ts
@@ -154,7 +154,7 @@ export default class QueueSASAuthenticator implements IAuthenticator {
         context.contextID!
       );
 
-      const sig2Pass = sig2 !== signature;
+      const sig2Pass = sig2 === signature;
       this.logger.info(
         `QueueSASAuthenticator:validate() Signature based on key2 validation ${
           sig2Pass ? "passed" : "failed"

--- a/src/table/authentication/AccountSASAuthenticator.ts
+++ b/src/table/authentication/AccountSASAuthenticator.ts
@@ -125,7 +125,7 @@ export default class AccountSASAuthenticator implements IAuthenticator {
         context.contextID!
       );
 
-      const sig2Pass = sig2 !== signature;
+      const sig2Pass = sig2 === signature;
       this.logger.info(
         `AccountSASAuthenticator:validate() Signature based on key2 validation ${
           sig2Pass ? "passed" : "failed"

--- a/src/table/authentication/TableSASAuthenticator.ts
+++ b/src/table/authentication/TableSASAuthenticator.ts
@@ -155,7 +155,7 @@ export default class TableSASAuthenticator implements IAuthenticator {
         context.contextID!
       );
 
-      const sig2Pass = sig2 !== signature;
+      const sig2Pass = sig2 === signature;
       this.logger.info(
         `TableSASAuthenticator:validate() Signature based on key2 validation ${
           sig2Pass ? "passed" : "failed"

--- a/tests/blob/sas.test.ts
+++ b/tests/blob/sas.test.ts
@@ -60,7 +60,7 @@ describe("Shared Access Signature (SAS) authentication", () => {
     )
   );
 
-  const serviceClient1 = new BlobServiceClient(
+  const serviceClientSecondKey = new BlobServiceClient(
     baseURL,
     newPipeline(
       new StorageSharedKeyCredential(
@@ -766,7 +766,7 @@ describe("Shared Access Signature (SAS) authentication", () => {
     tmr.setDate(tmr.getDate() + 1);
 
     // By default, credential is always the last element of pipeline factories
-    const factories = (serviceClient1 as any).pipeline.factories;
+    const factories = (serviceClientSecondKey as any).pipeline.factories;
     const storageSharedKeyCredential = factories[factories.length - 1];
 
     const containerName = getUniqueName("container");


### PR DESCRIPTION
This PR fixes use cases below when using `AZURITE_ACCOUNTS` defining a second key for the account.

- A blob request using any key but any of the 2 keys defined in `AZURITE_ACCOUNTS` passes instead of failing.
- A blob request using the second key defined in `AZURITE_ACCOUNTS` fails instead of passing.