### PR TITLE
fix issue 1810 GetAccountInformation doesn't return x-ms-is-hns-enabled

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ Blob:
 - Fix validation of Blob SAS token when using the second key for an account in `AZURITE_ACCOUNTS`
 - Set accessTierInferred to false after upload blob with accessTier (issue #2038)
 - Support blob new access tier Cold
+- Added "x-ms-is-hns-enabled" header in x-ms-is-hns-enabled API responds (issue #1810)
 
 Queue:
 

--- a/src/blob/handlers/ServiceHandler.ts
+++ b/src/blob/handlers/ServiceHandler.ts
@@ -7,6 +7,7 @@ import { parseXML } from "../generated/utils/xml";
 import {
   BLOB_API_VERSION,
   DEFAULT_LIST_CONTAINERS_MAX_RESULTS,
+  EMULATOR_ACCOUNT_ISHIERARCHICALNAMESPACEENABLED,
   EMULATOR_ACCOUNT_KIND,
   EMULATOR_ACCOUNT_SKUNAME,
   HeaderConstants,
@@ -335,13 +336,14 @@ export default class ServiceHandler extends BaseHandler
   public async getAccountInfo(
     context: Context
   ): Promise<Models.ServiceGetAccountInfoResponse> {
-    const response: Models.ContainerGetAccountInfoResponse = {
+    const response: Models.ServiceGetAccountInfoResponse = {
       statusCode: 200,
       requestId: context.contextId,
       clientRequestId: context.request!.getHeader("x-ms-client-request-id"),
       skuName: EMULATOR_ACCOUNT_SKUNAME,
       accountKind: EMULATOR_ACCOUNT_KIND,
       date: context.startTime!,
+      isHierarchicalNamespaceEnabled: EMULATOR_ACCOUNT_ISHIERARCHICALNAMESPACEENABLED,
       version: BLOB_API_VERSION
     };
     return response;

--- a/src/blob/utils/constants.ts
+++ b/src/blob/utils/constants.ts
@@ -30,6 +30,7 @@ export const EMULATOR_ACCOUNT_KEY = Buffer.from(
 
 export const EMULATOR_ACCOUNT_SKUNAME = Models.SkuName.StandardRAGRS;
 export const EMULATOR_ACCOUNT_KIND = Models.AccountKind.StorageV2;
+export const EMULATOR_ACCOUNT_ISHIERARCHICALNAMESPACEENABLED = false;
 
 export const HeaderConstants = {
   AUTHORIZATION: "authorization",

--- a/tests/blob/apis/service.test.ts
+++ b/tests/blob/apis/service.test.ts
@@ -11,6 +11,7 @@ import {
 import * as assert from "assert";
 
 import {
+  EMULATOR_ACCOUNT_ISHIERARCHICALNAMESPACEENABLED,
   EMULATOR_ACCOUNT_KIND,
   EMULATOR_ACCOUNT_SKUNAME
 } from "../../../src/blob/utils/constants";
@@ -415,6 +416,7 @@ describe("ServiceAPIs", () => {
     const result = await serviceClient.getAccountInfo();
     assert.equal(result.accountKind, EMULATOR_ACCOUNT_KIND);
     assert.equal(result.skuName, EMULATOR_ACCOUNT_SKUNAME);
+    assert.equal(result.isHierarchicalNamespaceEnabled, EMULATOR_ACCOUNT_ISHIERARCHICALNAMESPACEENABLED);
     assert.equal(
       result._response.request.headers.get("x-ms-client-request-id"),
       result.clientRequestId


### PR DESCRIPTION
Thanks for contribution! Please go through following checklist before sending PR.

Fix https://github.com/Azure/Azurite/issues/1810

### PR Branch Destination

- For Azurite V3, please send PR to `main` branch.
- For legacy Azurite V2, please send PR to `legacy-dev` branch.

### Always Add Test Cases

Make sure test cases are added to cover the code change.

### Add Change Log

Add change log for the code change in `Upcoming Release` section in `ChangeLog.md`.

### Development Guideline

Please go to CONTRIBUTION.md for steps about setting up development environment and recommended Visual Studio Code extensions.
