### PR TITLE
fix(table): Ensure that we correctly handle value comparisons against null/empty/undefined values for GUIDs and DateTimes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ Queue:
 Table:
 
 - Fixed the errorCode returned, when malformed Etag is provided for table Update/Delete calls. (issue #2013)
+- Fixed an issue when comparing `'' eq guid'00000000-0000-0000-0000-000000000000'` which would erroneously report these as equal. (issue #2169)
 
 ## 2023.08 Version 3.26.0
 

--- a/src/table/persistence/QueryInterpreter/QueryNodes/BinaryDataNode.ts
+++ b/src/table/persistence/QueryInterpreter/QueryNodes/BinaryDataNode.ts
@@ -1,5 +1,5 @@
 import { IQueryContext } from "../IQueryContext";
-import IQueryNode from "./IQueryNode";
+import ValueNode from "./ValueNode";
 
 /**
  * Represents a constant value which should be decoded from its `hex` representation
@@ -9,18 +9,12 @@ import IQueryNode from "./IQueryNode";
  * and is used to ensure that these values are evaluated against their normalized base64 format. For
  * example, the query `PartitionKey eq binary'0011'` would contain a `BinaryNode` with the value `0x0011`.
  */
-export default class BinaryNode<T> implements IQueryNode {
-  constructor(private value: string) { }
-
+export default class BinaryNode extends ValueNode {
   get name(): string {
     return "binary";
   }
 
   evaluate(_context: IQueryContext): any {
     return Buffer.from(this.value, "hex").toString("base64");
-  }
-
-  toString(): string {
-    return `(${this.name} ${this.value})`;
   }
 }

--- a/src/table/persistence/QueryInterpreter/QueryNodes/DateTimeNode.ts
+++ b/src/table/persistence/QueryInterpreter/QueryNodes/DateTimeNode.ts
@@ -16,22 +16,31 @@ export default class DateTimeNode<T> extends ValueNode {
   }
 
   compare(context: IQueryContext, other: IQueryNode): number {
+    const otherValue = other.evaluate(context);
+
+    // NOTE(notheotherben): This is a special case for the `null` value, which is not a valid datetime value in Azure Storage
+    //                      but is considered a valid input for "epoch" in the JS Date constructor. We're explicitly handling
+    //                      returning NaN here to ensure that null doesn't match dates in the table.
+    if (this.value === null || otherValue === null) {
+      return NaN;
+    }
+
     // NOTE(notheotherben): This approach leverages the fact that the `Date` constructor will parse ISO8601 strings
     //                 however it runs into a limitation of the accuracy of JS dates (which are limited to millisecond
     //                 resolution). As a result, we're effectively truncating the value to millisecond precision by doing
     //                 this. This is fundamentally a trade-off between enforcing valid datetime values and providing perfect
     //                 accuracy, and we've opted to enforce valid datetime values as those are more likely to cause problems
     //                 when moving to production.
-    const thisValue = new Date(this.value);
-    const otherValue = new Date(other.evaluate(context));
+    const thisDate = new Date(this.value);
+    const otherDate = new Date(otherValue);
 
-    if (isNaN(thisValue.valueOf()) || isNaN(otherValue.valueOf())) {
+    if (isNaN(thisDate.valueOf()) || isNaN(otherDate.valueOf())) {
       return NaN;
-    } else if (thisValue.valueOf() < otherValue.valueOf()) {
+    } else if (thisDate.valueOf() < otherDate.valueOf()) {
       return -1;
-    } else if (thisValue.valueOf() > otherValue.valueOf()) {
+    } else if (thisDate.valueOf() > otherDate.valueOf()) {
       return 1;
-    } else if (thisValue.valueOf() === otherValue.valueOf()) {
+    } else if (thisDate.valueOf() === otherDate.valueOf()) {
       return 0;
     } else {
       return NaN;

--- a/src/table/persistence/QueryInterpreter/QueryNodes/DateTimeNode.ts
+++ b/src/table/persistence/QueryInterpreter/QueryNodes/DateTimeNode.ts
@@ -25,7 +25,9 @@ export default class DateTimeNode<T> extends ValueNode {
     const thisValue = new Date(this.value);
     const otherValue = new Date(other.evaluate(context));
 
-    if (thisValue.valueOf() < otherValue.valueOf()) {
+    if (isNaN(thisValue.valueOf()) || isNaN(otherValue.valueOf())) {
+      return NaN;
+    } else if (thisValue.valueOf() < otherValue.valueOf()) {
       return -1;
     } else if (thisValue.valueOf() > otherValue.valueOf()) {
       return 1;

--- a/src/table/persistence/QueryInterpreter/QueryNodes/GuidNode.ts
+++ b/src/table/persistence/QueryInterpreter/QueryNodes/GuidNode.ts
@@ -31,7 +31,9 @@ export default class GuidNode<T> extends ValueNode {
       thisValue = Buffer.from(this.value).toString("base64");
     }
 
-    if (thisValue < otherValue) {
+    if (!thisValue || !otherValue) {
+      return NaN;
+    } else if (thisValue < otherValue) {
       return -1;
     } else if (thisValue > otherValue) {
       return 1;

--- a/src/table/persistence/QueryInterpreter/QueryNodes/NotEqualsNode.ts
+++ b/src/table/persistence/QueryInterpreter/QueryNodes/NotEqualsNode.ts
@@ -22,11 +22,13 @@ export default class NotEqualsNode extends BinaryOperatorNode {
 
   evaluate(context: IQueryContext): any {
     if (this.left instanceof ValueNode) {
-      return this.left.compare(context, this.right) !== 0;
+      const compareResult = this.left.compare(context, this.right);
+      return compareResult !== 0 && !isNaN(compareResult);
     }
 
     if (this.right instanceof ValueNode) {
-      return this.right.compare(context, this.left) !== 0;
+      const compareResult = this.right.compare(context, this.left);
+      return compareResult !== 0 && !isNaN(compareResult);
     }
 
     const left = this.left.evaluate(context);

--- a/src/table/persistence/QueryInterpreter/QueryNodes/ValueNode.ts
+++ b/src/table/persistence/QueryInterpreter/QueryNodes/ValueNode.ts
@@ -14,12 +14,14 @@ export default abstract class ValueNode implements IQueryNode {
   }
 
   compare(context: IQueryContext, other: IQueryNode): number {
+    const thisValue = this.evaluate(context);
     const otherValue = other.evaluate(context);
-    if (this.value === undefined || otherValue === undefined) {
+
+    if (thisValue === undefined || otherValue === undefined || otherValue === null) {
       return NaN;
-    } else if (this.value < otherValue) {
+    } else if (thisValue < otherValue) {
       return -1;
-    } else if (this.value > otherValue) {
+    } else if (thisValue > otherValue) {
       return 1;
     } else {
       return 0;

--- a/src/table/persistence/QueryInterpreter/QueryNodes/ValueNode.ts
+++ b/src/table/persistence/QueryInterpreter/QueryNodes/ValueNode.ts
@@ -15,7 +15,9 @@ export default abstract class ValueNode implements IQueryNode {
 
   compare(context: IQueryContext, other: IQueryNode): number {
     const otherValue = other.evaluate(context);
-    if (this.value < otherValue) {
+    if (this.value === undefined || otherValue === undefined) {
+      return NaN;
+    } else if (this.value < otherValue) {
       return -1;
     } else if (this.value > otherValue) {
       return 1;

--- a/tests/table/apis/table.entity.query.test.ts
+++ b/tests/table/apis/table.entity.query.test.ts
@@ -1087,7 +1087,7 @@ describe("table Entity APIs test - using Azure/data-tables", () => {
         assert.strictEqual(
           all.length,
           queryTest.expectedResult,
-          `Failed with query ${queryTest.queryOptions.filter}`
+          `Failed with query ${queryTest.queryOptions.filter} (got ${all.length} entries, expected ${queryTest.expectedResult})`
         );
         if (all[0] !== undefined) {
           all.sort((a, b) => {
@@ -1326,7 +1326,7 @@ describe("table Entity APIs test - using Azure/data-tables", () => {
     assert.strictEqual(all.length, 1);
 
     await tableClient.deleteTable();
-  });  
+  });
 
   it("21. should work correctly when query filter is empty string, @loki", async () => {
     const tableClient = createAzureDataTablesClient(

--- a/tests/table/unit/query.interpreter.unit.test.ts
+++ b/tests/table/unit/query.interpreter.unit.test.ts
@@ -47,7 +47,8 @@ describe("Query Interpreter", () => {
       guid: Buffer.from("00000000-0000-0000-0000-000000000000").toString("base64"),
       guidLegacy: "00000000-0000-0000-0000-000000000000",
       binary: Buffer.from("binaryData").toString("base64"),
-      emptyString: ""
+      emptyString: "",
+      nullValue: null
     }
   };
 
@@ -269,6 +270,21 @@ describe("Query Interpreter", () => {
         originalQuery:
           "guidLegacy ne guid'22222222-2222-2222-2222-222222222222'",
         expectedResult: true
+      },
+      {
+        name: "GUID compare against missing property",
+        originalQuery: "missingProperty eq guid'00000000-0000-0000-0000-000000000000'",
+        expectedResult: false
+      },
+      {
+        name: " GUID compare against null property",
+        originalQuery: "nullValue eq guid'00000000-0000-0000-0000-000000000000'",
+        expectedResult: false
+      },
+      {
+        name: "GUID compare against empty string",
+        originalQuery: "emptyString eq guid'00000000-0000-0000-0000-000000000000'",
+        expectedResult: false
       }
     ])
 
@@ -391,6 +407,21 @@ describe("Query Interpreter", () => {
       {
         name: "DateTime less than or equal (microseconds) (doesn't match)",
         originalQuery: "microsecondDate le datetime'2022-12-31T23:59:59.999999Z'",
+        expectedResult: false
+      },
+      {
+        name: "DateTime compare against null value",
+        originalQuery: "nullValue eq datetime'2020-01-01T00:00:00.000000Z'",
+        expectedResult: false
+      },
+      {
+        name: "DateTime compare against empty string",
+        originalQuery: "emptyString eq datetime'2020-01-01T00:00:00.000000Z'",
+        expectedResult: false
+      },
+      {
+        name: "DateTime compare against missing property",
+        originalQuery: "missingProperty eq datetime'2020-01-01T00:00:00.000000Z'",
         expectedResult: false
       }
     ])

--- a/tests/table/unit/query.interpreter.unit.test.ts
+++ b/tests/table/unit/query.interpreter.unit.test.ts
@@ -450,5 +450,23 @@ describe("Query Interpreter", () => {
         expectedResult: false
       }
     ]);
+
+    describe("Issue #2169: Querying null/missing properties with type annotations", () => {
+      // NOTE(notheotherben): This generates a dynamic set of test to validate that all of our query operators return `false` for
+      //                      comparisons between values of the given type and the list of appropriate properties (null/missing/empty values).
+      const testCases: { [key: string]: string[] } = {
+        "datetime'2023-01-01T00:00:00.000000Z'": ["nullValue", "missingProperty", "emptyString"],
+        "binary'000000000000'": ["nullValue", "missingProperty"],
+        "guid'00000000-0000-0000-0000-000000000000'": ["nullValue", "missingProperty", "emptyString"],
+      };
+
+      for (const referenceValue of Object.keys(testCases)) {
+        runTestCases(referenceValue, referenceEntity, Array.prototype.concat.apply([], ["eq", "ne", "lt", "le", "gt", "ge"].map((operator) => testCases[referenceValue].map(property => ({
+          name: `Should not match ${property} with ${operator}`,
+          originalQuery: `${property} ${operator} ${referenceValue}`,
+          expectedResult: false
+        })))));
+      }
+    });
   });
 });


### PR DESCRIPTION
This PR fixes the issues raised in #2169 which pertain to the comparison between empty (and by extension, null and missing) properties and GUIDs. This issue was reproduced with the included test suite additions, and fixed by handling the `null`/`undefined`/empty case explicitly for GUID comparisons.