### PR TITLE
Add Blob Copy & Page Blob support to by SQL based metadata implementation in Blob API and Sync Loki and SQL metadata stores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ azurite.exe
 .pkg-cache
 release
 querydb*.json
+.idea

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@ Blob:
 - Fixed startCopyFromURL, copyFromURL API to return 400 (InvalidHeaderValue) when copy source has invalid format. (issue #1954)
 - Fixed CommitBlockList API to return 400 (InvalidXmlDocument) when the request is sent with JSON body. (issue #1955)
 - Added "x-ms-is-hns-enabled" header in x-ms-is-hns-enabled API responds (issue #1810)
+- Blob Copy & Page Blob are now supported by SQL based metadata implementation. This making the SQL based metadata implementation in sync with File based one. (issue #2224)
 
 Queue:
 

--- a/README.md
+++ b/README.md
@@ -488,8 +488,6 @@ This feature is in preview, when Azurite changes database table schema, you need
 
 > Note. Need to manually create database before starting Azurite instance.
 
-> Note. Blob Copy & Page Blob are not supported by SQL based metadata implementation.
-
 > Tips. Create database instance quickly with docker, for example `docker run --name mysql -p 3306:3306 -e MYSQL_ROOT_PASSWORD=my-secret-pw -d mysql:latest`. Grant external access and create database `azurite_blob` using `docker exec mysql mysql -u root -pmy-secret-pw -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION; FLUSH PRIVILEGES; create database azurite_blob;"`. Notice that, above commands are examples, you need to carefully define the access permissions in your production environment.
 
 ## HTTPS Setup

--- a/src/blob/persistence/SqlBlobMetadataStore.ts
+++ b/src/blob/persistence/SqlBlobMetadataStore.ts
@@ -2632,14 +2632,190 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     });
   }
 
-  public copyFromURL(
+  public async copyFromURL(
     context: Context,
     source: BlobId,
     destination: BlobId,
     copySource: string,
-    metadata: Models.BlobMetadata | undefined
+    metadata: Models.BlobMetadata | undefined,
+    tier: Models.AccessTier | undefined,
+    options: Models.BlobCopyFromURLOptionalParams = {}
   ): Promise<Models.BlobPropertiesInternal> {
-    throw new Error("Method not implemented.");
+    return await this.sequelize.transaction(async (t) => {
+      const sourceBlob = await this.getBlobWithLeaseUpdated(
+        source.account,
+        source.container,
+        source.blob,
+        source.snapshot,
+        context,
+        true,
+        true
+      );
+
+      options.sourceModifiedAccessConditions =
+        options.sourceModifiedAccessConditions || {};
+      validateReadConditions(
+        context,
+        {
+          ifModifiedSince:
+            options.sourceModifiedAccessConditions.sourceIfModifiedSince,
+          ifUnmodifiedSince:
+            options.sourceModifiedAccessConditions.sourceIfUnmodifiedSince,
+          ifMatch: options.sourceModifiedAccessConditions.sourceIfMatch,
+          ifNoneMatch: options.sourceModifiedAccessConditions.sourceIfNoneMatch
+        },
+        sourceBlob
+      );
+
+      const destBlob = await this.getBlobWithLeaseUpdated(
+        destination.account,
+        destination.container,
+        destination.blob,
+        undefined,
+        context,
+        false
+      );
+
+      validateWriteConditions(
+        context,
+        options.modifiedAccessConditions,
+        destBlob
+      );
+
+      // Copy if not exists
+      if (
+        options.modifiedAccessConditions &&
+        options.modifiedAccessConditions.ifNoneMatch === "*" &&
+        destBlob
+      ) {
+        throw StorageErrorFactory.getBlobAlreadyExists(context.contextId);
+      }
+
+      if (destBlob) {
+        const lease = new BlobLeaseAdapter(destBlob);
+        new BlobWriteLeaseSyncer(destBlob).sync(lease);
+        new BlobWriteLeaseValidator(options.leaseAccessConditions).validate(
+          lease,
+          context
+        );
+      }
+
+      // If source is uncommitted or deleted
+      if (
+        sourceBlob === undefined ||
+        sourceBlob.deleted ||
+        !sourceBlob.isCommitted
+      ) {
+        throw StorageErrorFactory.getBlobNotFound(context.contextId);
+      }
+
+      if (sourceBlob.properties.accessTier === Models.AccessTier.Archive) {
+        throw StorageErrorFactory.getBlobArchived(context.contextId);
+      }
+
+      await this.checkContainerExist(
+        context,
+        destination.account,
+        destination.container
+      );
+
+      // Deep clone a copied blob
+      const copiedBlob: BlobModel = {
+        name: destination.blob,
+        deleted: false,
+        snapshot: "",
+        properties: {
+          ...sourceBlob.properties,
+          creationTime: context.startTime!,
+          lastModified: context.startTime!,
+          etag: newEtag(),
+          leaseStatus:
+            destBlob !== undefined
+              ? destBlob.properties.leaseStatus
+              : Models.LeaseStatusType.Unlocked,
+          leaseState:
+            destBlob !== undefined
+              ? destBlob.properties.leaseState
+              : Models.LeaseStateType.Available,
+          leaseDuration:
+            destBlob !== undefined
+              ? destBlob.properties.leaseDuration
+              : undefined,
+          copyId: uuid(),
+          copyStatus: Models.CopyStatusType.Success,
+          copySource,
+          copyProgress: sourceBlob.properties.contentLength
+            ? `${sourceBlob.properties.contentLength}/${sourceBlob.properties.contentLength}`
+            : undefined,
+          copyCompletionTime: context.startTime,
+          copyStatusDescription: undefined,
+          incrementalCopy: false,
+          destinationSnapshot: undefined,
+          deletedTime: undefined,
+          remainingRetentionDays: undefined,
+          archiveStatus: undefined,
+          accessTierChangeTime: undefined
+        },
+        metadata:
+          metadata === undefined || Object.keys(metadata).length === 0
+            ? { ...sourceBlob.metadata }
+            : metadata,
+        accountName: destination.account,
+        containerName: destination.container,
+        pageRangesInOrder: sourceBlob.pageRangesInOrder,
+        isCommitted: sourceBlob.isCommitted,
+        leaseDurationSeconds:
+          destBlob !== undefined ? destBlob.leaseDurationSeconds : undefined,
+        leaseId: destBlob !== undefined ? destBlob.leaseId : undefined,
+        leaseExpireTime:
+          destBlob !== undefined ? destBlob.leaseExpireTime : undefined,
+        leaseBreakTime:
+          destBlob !== undefined ? destBlob.leaseBreakTime : undefined,
+        committedBlocksInOrder: sourceBlob.committedBlocksInOrder,
+        persistency: sourceBlob.persistency,
+        blobTags: options.blobTagsString === undefined ? undefined : getTagsFromString(options.blobTagsString, context.contextId!)
+      };
+
+      if (
+        copiedBlob.properties.blobType === Models.BlobType.BlockBlob &&
+        tier !== undefined
+      ) {
+        copiedBlob.properties.accessTier = this.parseTier(tier);
+        if (copiedBlob.properties.accessTier === undefined) {
+          throw StorageErrorFactory.getInvalidHeaderValue(context.contextId, {
+            HeaderName: "x-ms-access-tier",
+            HeaderValue: `${tier}`
+          });
+        }
+      }
+
+      if (
+        copiedBlob.properties.blobType === Models.BlobType.PageBlob &&
+        tier !== undefined
+      ) {
+        throw StorageErrorFactory.getInvalidHeaderValue(context.contextId, {
+          HeaderName: "x-ms-access-tier",
+          HeaderValue: `${tier}`
+        });
+      }
+
+      if (destBlob) {
+        await BlobsModel.destroy({
+          where: {
+            accountName: destBlob.accountName,
+            containerName: destBlob.containerName,
+            blobName: destBlob.name
+          },
+          transaction: t
+        });
+      }
+
+      await BlobsModel.upsert(this.convertBlobModelToDbModel(copiedBlob), {
+        transaction: t
+      });
+
+      return copiedBlob.properties;
+    });
   }
 
   public async setTier(

--- a/src/blob/persistence/SqlBlobMetadataStore.ts
+++ b/src/blob/persistence/SqlBlobMetadataStore.ts
@@ -3069,7 +3069,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     };
   }
 
-  public resizePageBlob(
+  public async resizePageBlob(
     context: Context,
     account: string,
     container: string,
@@ -3078,7 +3078,53 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     leaseAccessConditions?: Models.LeaseAccessConditions,
     modifiedAccessConditions?: Models.ModifiedAccessConditions
   ): Promise<Models.BlobPropertiesInternal> {
-    throw new Error("Method not implemented.");
+    return await this.sequelize.transaction(async (t) => {
+      const doc = await this.getBlobWithLeaseUpdated(
+        account,
+        container,
+        blob,
+        undefined,
+        context,
+        false,
+        true,
+        t
+      );
+
+      validateWriteConditions(context, modifiedAccessConditions, doc);
+
+      if (!doc) {
+        throw StorageErrorFactory.getBlobNotFound(context.contextId);
+      }
+
+      if (doc.properties.blobType !== Models.BlobType.PageBlob) {
+        throw StorageErrorFactory.getInvalidOperation(
+          context.contextId,
+          "Resize could only be against a page blob."
+        );
+      }
+
+      const lease = new BlobLeaseAdapter(doc);
+      new BlobWriteLeaseValidator(leaseAccessConditions).validate(lease, context);
+
+      doc.pageRangesInOrder = doc.pageRangesInOrder || [];
+      if (doc.properties.contentLength! > blobContentLength) {
+        const start = blobContentLength;
+        const end = doc.properties.contentLength! - 1;
+        this.pageBlobRangesManager.clearRange(doc.pageRangesInOrder || [], {
+          start,
+          end
+        });
+      }
+
+      doc.properties.contentLength = blobContentLength;
+      doc.properties.lastModified = context.startTime || new Date();
+      doc.properties.etag = newEtag();
+
+      new BlobWriteLeaseSyncer(doc).sync(lease);
+
+      await BlobsModel.upsert(this.convertBlobModelToDbModel(doc), { transaction: t });
+      return doc.properties;
+    });
   }
 
   public updateSequenceNumber(

--- a/src/blob/persistence/SqlBlobMetadataStore.ts
+++ b/src/blob/persistence/SqlBlobMetadataStore.ts
@@ -2522,6 +2522,15 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
         destBlob
       );
 
+      // Copy if not exists
+      if (
+        options.modifiedAccessConditions &&
+        options.modifiedAccessConditions.ifNoneMatch === "*" &&
+        destBlob
+      ) {
+        throw StorageErrorFactory.getBlobAlreadyExists(context.contextId);
+      }
+
       if (destBlob) {
         new BlobWriteLeaseValidator(options.leaseAccessConditions).validate(
           new BlobLeaseAdapter(destBlob),

--- a/src/blob/persistence/SqlBlobMetadataStore.ts
+++ b/src/blob/persistence/SqlBlobMetadataStore.ts
@@ -37,7 +37,7 @@ import { ILease } from "../lease/ILeaseState";
 import LeaseFactory from "../lease/LeaseFactory";
 import {
   DEFAULT_LIST_BLOBS_MAX_RESULTS,
-  DEFAULT_LIST_CONTAINERS_MAX_RESULTS,
+  DEFAULT_LIST_CONTAINERS_MAX_RESULTS
 } from "../utils/constants";
 import BlobReferredExtentsAsyncIterator from "./BlobReferredExtentsAsyncIterator";
 import IBlobMetadataStore, {
@@ -360,7 +360,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     context: Context,
     serviceProperties: ServicePropertiesModel
   ): Promise<ServicePropertiesModel> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       const findResult = await ServicesModel.findByPk(
         serviceProperties.accountName,
         {
@@ -651,7 +651,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     leaseAccessConditions?: Models.LeaseAccessConditions,
     modifiedAccessConditions?: Models.ModifiedAccessConditions
   ): Promise<void> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       /* Transaction starts */
       const findResult = await ContainersModel.findOne({
         attributes: [
@@ -800,7 +800,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     container: string,
     options: Models.ContainerAcquireLeaseOptionalParams
   ): Promise<AcquireContainerLeaseResponse> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       /* Transaction starts */
       const findResult = await ContainersModel.findOne({
         where: {
@@ -854,7 +854,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     leaseId: string,
     options: Models.ContainerReleaseLeaseOptionalParams = {}
   ): Promise<Models.ContainerProperties> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       /* Transaction starts */
       const findResult = await ContainersModel.findOne({
         where: {
@@ -906,7 +906,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     leaseId: string,
     options: Models.ContainerRenewLeaseOptionalParams = {}
   ): Promise<RenewContainerLeaseResponse> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       /* Transaction starts */
       // TODO: Filter out unnecessary fields in select query
       const findResult = await ContainersModel.findOne({
@@ -962,7 +962,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     breakPeriod: number | undefined,
     options: Models.ContainerBreakLeaseOptionalParams = {}
   ): Promise<BreakContainerLeaseResponse> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       const findResult = await ContainersModel.findOne({
         where: {
           accountName: account,
@@ -1026,7 +1026,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     proposedLeaseId: string,
     options: Models.ContainerChangeLeaseOptionalParams = {}
   ): Promise<ChangeContainerLeaseResponse> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       const findResult = await ContainersModel.findOne({
         where: {
           accountName: account,
@@ -1086,7 +1086,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     leaseAccessConditions?: Models.LeaseAccessConditions,
     modifiedAccessConditions?: Models.ModifiedAccessConditions
   ): Promise<void> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(
         context,
         blob.accountName,
@@ -1155,7 +1155,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     leaseAccessConditions?: Models.LeaseAccessConditions,
     modifiedAccessConditions?: Models.ModifiedAccessConditions
   ): Promise<BlobModel> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(context, account, container, t);
 
       const blobFindResult = await BlobsModel.findOne({
@@ -1207,7 +1207,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     includeSnapshots?: boolean,
     includeUncommittedBlobs?: boolean
   ): Promise<[BlobModel[], BlobPrefixModel[], any | undefined]> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(context, account, container, t);
 
       const whereQuery: any = {
@@ -1407,7 +1407,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     });
   }
 
-  public getBlockList(
+  public async getBlockList(
     context: Context,
     account: string,
     container: string,
@@ -1416,7 +1416,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     isCommitted?: boolean,
     leaseAccessConditions?: Models.LeaseAccessConditions
   ): Promise<any> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(context, account, container, t);
 
       const blobFindResult = await BlobsModel.findOne({
@@ -1660,7 +1660,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     leaseAccessConditions?: Models.LeaseAccessConditions,
     modifiedAccessConditions?: Models.ModifiedAccessConditions
   ): Promise<GetBlobPropertiesRes> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(context, account, container, t);
 
       const blobFindResult = await BlobsModel.findOne({
@@ -1726,7 +1726,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     metadata?: Models.BlobMetadata,
     modifiedAccessConditions?: Models.ModifiedAccessConditions
   ): Promise<CreateSnapshotResponse> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(context, account, container, t);
 
       const blobFindResult = await BlobsModel.findOne({
@@ -1973,7 +1973,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     blobHTTPHeaders: Models.BlobHTTPHeaders | undefined,
     modifiedAccessConditions?: Models.ModifiedAccessConditions
   ): Promise<Models.BlobPropertiesInternal> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(context, account, container, t);
 
       const blobFindResult = await BlobsModel.findOne({
@@ -2040,7 +2040,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     });
   }
 
-  public setBlobMetadata(
+  public async setBlobMetadata(
     context: Context,
     account: string,
     container: string,
@@ -2049,7 +2049,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     metadata: Models.BlobMetadata | undefined,
     modifiedAccessConditions?: Models.ModifiedAccessConditions
   ): Promise<Models.BlobPropertiesInternal> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(context, account, container, t);
 
       const blobFindResult = await BlobsModel.findOne({
@@ -2122,7 +2122,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     proposedLeaseId?: string,
     options: Models.BlobAcquireLeaseOptionalParams = {}
   ): Promise<AcquireBlobLeaseResponse> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(context, account, container, t);
 
       const blobFindResult = await BlobsModel.findOne({
@@ -2179,7 +2179,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     leaseId: string,
     options: Models.BlobReleaseLeaseOptionalParams = {}
   ): Promise<ReleaseBlobLeaseResponse> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(context, account, container, t);
 
       const blobFindResult = await BlobsModel.findOne({
@@ -2236,7 +2236,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     leaseId: string,
     options: Models.BlobRenewLeaseOptionalParams = {}
   ): Promise<RenewBlobLeaseResponse> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(context, account, container, t);
 
       const blobFindResult = await BlobsModel.findOne({
@@ -2294,7 +2294,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     proposedLeaseId: string,
     options: Models.BlobChangeLeaseOptionalParams = {}
   ): Promise<ChangeBlobLeaseResponse> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(context, account, container, t);
 
       const blobFindResult = await BlobsModel.findOne({
@@ -2351,7 +2351,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     breakPeriod: number | undefined,
     options: Models.BlobBreakLeaseOptionalParams = {}
   ): Promise<BreakBlobLeaseResponse> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(context, account, container, t);
 
       const blobFindResult = await BlobsModel.findOne({
@@ -2464,7 +2464,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     return { blobType, isCommitted };
   }
 
-  public startCopyFromURL(
+  public async startCopyFromURL(
     context: Context,
     source: BlobId,
     destination: BlobId,
@@ -2473,7 +2473,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     tier: Models.AccessTier | undefined,
     options: Models.BlobStartCopyFromURLOptionalParams = {}
   ): Promise<Models.BlobPropertiesInternal> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       const sourceBlob = await this.getBlobWithLeaseUpdated(
         source.account,
         source.container,
@@ -2642,7 +2642,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     throw new Error("Method not implemented.");
   }
 
-  public setTier(
+  public async setTier(
     context: Context,
     account: string,
     container: string,
@@ -2650,7 +2650,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     tier: Models.AccessTier,
     leaseAccessConditions?: Models.LeaseAccessConditions
   ): Promise<200 | 202> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(context, account, container, t);
 
       const blobFindResult = await BlobsModel.findOne({
@@ -2813,7 +2813,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     marker: string = "-1",
     maxResults: number = 2000
   ): Promise<[IExtentChunk[], string | undefined]> {
-    return BlocksModel.findAll({
+    return await BlocksModel.findAll({
       attributes: ["id", "persistency"],
       where: {
         id: {
@@ -3230,7 +3230,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     return doc;
   }
 
-  public setBlobTag(
+  public async setBlobTag(
     context: Context,
     account: string,
     container: string,
@@ -3240,7 +3240,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     tags: Models.BlobTags | undefined,
     modifiedAccessConditions?: Models.ModifiedAccessConditions
   ): Promise<void> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(context, account, container, t);
 
       const blobFindResult = await BlobsModel.findOne({
@@ -3298,7 +3298,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     leaseAccessConditions?: Models.LeaseAccessConditions,
     modifiedAccessConditions?: Models.ModifiedAccessConditions
   ): Promise<Models.BlobTags | undefined> {
-    return this.sequelize.transaction(async (t) => {
+    return await this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(context, account, container, t);
 
       const blobFindResult = await BlobsModel.findOne({

--- a/src/blob/persistence/SqlBlobMetadataStore.ts
+++ b/src/blob/persistence/SqlBlobMetadataStore.ts
@@ -1698,8 +1698,6 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
         throw StorageErrorFactory.getBlobNotFound(context.contextId);
       }
 
-      // TODO: Return blobCommittedBlockCount for append blob
-
       let responds =  LeaseFactory.createLeaseState(
         new BlobLeaseAdapter(blobModel),
         context
@@ -1711,6 +1709,10 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
         properties : {
           ...responds.properties,
           tagCount: getBlobTagsCount(blobModel.blobTags),
+          blobCommittedBlockCount:
+            responds.properties.blobType === Models.BlobType.AppendBlob
+              ? (responds.committedBlocksInOrder || []).length
+              : undefined
         },
       }
     });

--- a/tests/blob/apis/appendblob.test.ts
+++ b/tests/blob/apis/appendblob.test.ts
@@ -68,7 +68,7 @@ describe("AppendBlobAPIs", () => {
     await containerClient.delete();
   });
 
-  it("Create append blob should work @loki", async () => {
+  it("Create append blob should work @loki @sql", async () => {
     await appendBlobClient.create();
     const properties = await appendBlobClient.getProperties();
     assert.deepStrictEqual(properties.blobType, "AppendBlob");
@@ -85,7 +85,7 @@ describe("AppendBlobAPIs", () => {
     assert.deepStrictEqual(properties.blobCommittedBlockCount, 0);
   });
 
-  it("Create append blob override existing pageblob @loki", async () => {
+  it("Create append blob override existing pageblob @loki @sql", async () => {
     const pageBlobClient = blobClient.getPageBlobClient();
     await pageBlobClient.create(512);
 
@@ -133,12 +133,12 @@ describe("AppendBlobAPIs", () => {
     assert.deepStrictEqual(properties.blobCommittedBlockCount, 0);
   });
 
-  it("Delete append blob should work @loki", async () => {
+  it("Delete append blob should work @loki @sql", async () => {
     await appendBlobClient.create();
     await appendBlobClient.delete();
   });
 
-  it("Create append blob snapshot should work @loki", async () => {
+  it("Create append blob snapshot should work @loki @sql", async () => {
     await appendBlobClient.create();
     const response = await appendBlobClient.createSnapshot();
     const appendBlobSnapshotClient = appendBlobClient.withSnapshot(
@@ -176,7 +176,7 @@ describe("AppendBlobAPIs", () => {
     assert.deepStrictEqual(properties.blobCommittedBlockCount, 0);
   });
 
-  it("Copy append blob snapshot should work @loki", async () => {
+  it("Copy append blob snapshot should work @loki @sql", async () => {
     await appendBlobClient.create();
     await appendBlobClient.appendBlock("hello", 5);
 
@@ -212,7 +212,7 @@ describe("AppendBlobAPIs", () => {
     assert.deepStrictEqual(properties.copyStatus, "success");
   });
 
-  it("Synchronized copy append blob snapshot should work @loki", async () => {
+  it("Synchronized copy append blob snapshot should work @loki @sql", async () => {
     await appendBlobClient.create();
     await appendBlobClient.appendBlock("hello", 5);
 
@@ -247,7 +247,7 @@ describe("AppendBlobAPIs", () => {
     assert.deepStrictEqual(properties.copySource, appendBlobSnapshotClient.url);
   });
 
-  it("Set append blob metadata should work @loki", async () => {
+  it("Set append blob metadata should work @loki @sql", async () => {
     await appendBlobClient.create();
 
     const metadata = {
@@ -260,7 +260,7 @@ describe("AppendBlobAPIs", () => {
     assert.deepStrictEqual(properties.metadata, metadata);
   });
 
-  it("Set append blob HTTP headers should work @loki", async () => {
+  it("Set append blob HTTP headers should work @loki @sql", async () => {
     await appendBlobClient.create();
 
     const md5 = new Uint8Array([1, 2, 3, 4, 5]);
@@ -292,7 +292,7 @@ describe("AppendBlobAPIs", () => {
     );
   });
 
-  it("Set tier should not work for append blob @loki", async function () {
+  it("Set tier should not work for append blob @loki @sql", async function () {
     await appendBlobClient.create();
     try {
       await blobClient.setAccessTier("hot");
@@ -302,7 +302,7 @@ describe("AppendBlobAPIs", () => {
     assert.fail();
   });
 
-  it("Append block should work @loki", async () => {
+  it("Append block should work @loki @sql", async () => {
     await appendBlobClient.create();
     let appendBlockResponse = await appendBlobClient.appendBlock("abcdef", 6);
     assert.deepStrictEqual(appendBlockResponse.blobAppendOffset, "0");
@@ -357,7 +357,7 @@ describe("AppendBlobAPIs", () => {
     assert.deepStrictEqual(string, "abcdef123456T@");
   });
 
-  it("Download append blob should work @loki", async () => {
+  it("Download append blob should work @loki @sql", async () => {
     await appendBlobClient.create();
     await appendBlobClient.appendBlock("abcdef", 6);
     await appendBlobClient.appendBlock("123456", 6);
@@ -374,7 +374,7 @@ describe("AppendBlobAPIs", () => {
     assert.deepStrictEqual(response.contentRange, "bytes 5-12/14");
   });
 
-  it("Download append blob should work for snapshot @loki", async () => {
+  it("Download append blob should work for snapshot @loki @sql", async () => {
     await appendBlobClient.create();
     await appendBlobClient.appendBlock("abcdef", 6);
 
@@ -393,7 +393,7 @@ describe("AppendBlobAPIs", () => {
     assert.deepEqual(response.contentMD5, await getMD5FromString("def"));
   });
 
-  it("Download append blob should work for copied blob @loki", async () => {
+  it("Download append blob should work for copied blob @loki @sql", async () => {
     await appendBlobClient.create();
     await appendBlobClient.appendBlock("abcdef", 6);
 
@@ -410,7 +410,7 @@ describe("AppendBlobAPIs", () => {
     assert.deepEqual(response.contentMD5, await getMD5FromString("def"));
   });
 
-  it("Append block with invalid blob type should not work @loki", async () => {
+  it("Append block with invalid blob type should not work @loki @sql", async () => {
     const pageBlobClient = appendBlobClient.getPageBlobClient();
     await pageBlobClient.create(512);
 
@@ -423,7 +423,7 @@ describe("AppendBlobAPIs", () => {
     assert.fail();
   });
 
-  it("Append block with content length 0 should not work @loki", async () => {
+  it("Append block with content length 0 should not work @loki @sql", async () => {
     await appendBlobClient.create();
 
     try {
@@ -435,7 +435,7 @@ describe("AppendBlobAPIs", () => {
     assert.fail();
   });
 
-  it("Append block append position access condition should work @loki", async () => {
+  it("Append block append position access condition should work @loki @sql", async () => {
     await appendBlobClient.create();
     await appendBlobClient.appendBlock("a", 1, {
       conditions: {
@@ -480,7 +480,7 @@ describe("AppendBlobAPIs", () => {
     assert.fail();
   });
 
-  it("Append block md5 validation should work @loki", async () => {
+  it("Append block md5 validation should work @loki @sql", async () => {
     await appendBlobClient.create();
     await appendBlobClient.appendBlock("aEf", 1, {
       transactionalContentMD5: await getMD5FromString("aEf")
@@ -498,7 +498,7 @@ describe("AppendBlobAPIs", () => {
     assert.fail();
   });
 
-  it("Append block access condition should work @loki", async () => {
+  it("Append block access condition should work @loki @sql", async () => {
     let response = await appendBlobClient.create();
     response = await appendBlobClient.appendBlock("a", 1, {
       conditions: {
@@ -538,7 +538,7 @@ describe("AppendBlobAPIs", () => {
     assert.fail();
   });
 
-  it("Append block lease condition should work @loki", async () => {
+  it("Append block lease condition should work @loki @sql", async () => {
     await appendBlobClient.create();
 
     const leaseId = "abcdefg";

--- a/tests/blob/apis/blob.test.ts
+++ b/tests/blob/apis/blob.test.ts
@@ -840,7 +840,7 @@ describe("BlobAPIs", () => {
     }
   });
   
-  it("Upload blob with accesstier should get accessTierInferred as false @loki", async () => {
+  it("Upload blob with accesstier should get accessTierInferred as false @loki @sql", async () => {
     const blobName = getUniqueName("blob");
 
     const blobClient = containerClient.getBlockBlobClient(blobName);
@@ -896,7 +896,7 @@ describe("BlobAPIs", () => {
     );
   });
 
-  it("Copy blob should work @loki", async () => {
+  it("Copy blob should work @loki @sql", async () => {
     const sourceBlob = getUniqueName("blob");
     const destBlob = getUniqueName("blob");
 
@@ -955,7 +955,7 @@ describe("BlobAPIs", () => {
     );
   });
 
-  it("Copy blob should work to override metadata @loki", async () => {
+  it("Copy blob should work to override metadata @loki @sql", async () => {
     const sourceBlob = getUniqueName("blob");
     const destBlob = getUniqueName("blob");
 
@@ -979,7 +979,7 @@ describe("BlobAPIs", () => {
     assert.deepStrictEqual(result.metadata, metadata2);
   });
 
-  it("Copy blob should work with source archive blob and accesstier header @loki, @sql", async () => {
+  it("Copy blob should work with source archive blob and accesstier header @loki @sql", async () => {
     const sourceBlob = getUniqueName("blob");
     const destBlob = getUniqueName("blob");
 
@@ -1014,7 +1014,7 @@ describe("BlobAPIs", () => {
     assert.deepStrictEqual(result.accessTier, "Hot");
   });
 
-  it("Copy blob should not override destination Lease status @loki", async () => {
+  it("Copy blob should not override destination Lease status @loki @sql", async () => {
     const sourceBlob = getUniqueName("blob");
     const destBlob = getUniqueName("blob");
 
@@ -1049,7 +1049,7 @@ describe("BlobAPIs", () => {
     await destLeaseClient.releaseLease();
   });
 
-  it("Copy blob should work for page blob @loki", async () => {
+  it("Copy blob should work for page blob @loki @sql", async () => {
     const sourceBlob = getUniqueName("blob");
     const destBlob = getUniqueName("blob");
 
@@ -1108,7 +1108,7 @@ describe("BlobAPIs", () => {
     );
   });
 
-  it("Copy blob should not work for page blob and set tier @loki", async () => {
+  it("Copy blob should not work for page blob and set tier @loki @sql", async () => {
     const sourceBlob = getUniqueName("blob");
     const destBlob = getUniqueName("blob");
 
@@ -1146,7 +1146,7 @@ describe("BlobAPIs", () => {
     assert.deepStrictEqual(err.statusCode, 400);
   });
 
-  it("Copy blob should fail with 400 when copy source is invalid @loki", async () => {
+  it("Copy blob should fail with 400 when copy source is invalid @loki @sql", async () => {
     const destBlob = getUniqueName("blob");
 
     const destBlobClient = containerClient.getBlockBlobClient(destBlob);
@@ -1163,7 +1163,7 @@ describe("BlobAPIs", () => {
     assert.fail();
   });
 
-  it("Copy blob should not work with  ifNoneMatch * when dest exist @loki", async () => {
+  it("Copy blob should not work with  ifNoneMatch * when dest exist @loki @sql", async () => {
     const sourceBlob = getUniqueName("blob");
     const destBlob = getUniqueName("blob");
 
@@ -1234,7 +1234,7 @@ describe("BlobAPIs", () => {
     assert.fail();
   });
 
-  it("Synchronized copy blob should work @loki", async () => {
+  it("Synchronized copy blob should work @loki @sql", async () => {
     const sourceBlob = getUniqueName("blob");
     const destBlob = getUniqueName("blob");
 
@@ -1292,7 +1292,7 @@ describe("BlobAPIs", () => {
     );
   });
 
-  it("Synchronized copy blob should work to override metadata @loki", async () => {
+  it("Synchronized copy blob should work to override metadata @loki @sql", async () => {
     const sourceBlob = getUniqueName("blob");
     const destBlob = getUniqueName("blob");
 
@@ -1316,7 +1316,7 @@ describe("BlobAPIs", () => {
     assert.deepStrictEqual(result.metadata, metadata2);
   });
 
-  it("Synchronized copy blob should not override destination Lease status @loki", async () => {
+  it("Synchronized copy blob should not override destination Lease status @loki @sql", async () => {
     const sourceBlob = getUniqueName("blob");
     const destBlob = getUniqueName("blob");
 
@@ -1351,7 +1351,7 @@ describe("BlobAPIs", () => {
     await destLeaseClient.releaseLease();
   });
 
-  it("Synchronized copy blob should work for page blob @loki", async () => {
+  it("Synchronized copy blob should work for page blob @loki @sql", async () => {
     const sourceBlob = getUniqueName("blob");
     const destBlob = getUniqueName("blob");
 
@@ -1590,7 +1590,7 @@ describe("BlobAPIs", () => {
     blockBlobClient2.delete();
   });
 
-  it("set blob tag should work in create page/append blob, copyFromURL. @loki", async () => {
+  it("set blob tag should work in create page/append blob, copyFromURL. @loki @sql", async () => {
     const tags = {
       tag1: "val1",
       tag2: "val2",

--- a/tests/blob/apis/container.test.ts
+++ b/tests/blob/apis/container.test.ts
@@ -563,8 +563,7 @@ describe("ContainerAPIs", () => {
     }
   });
 
-  // TODO: azure/storage-blob 12.9.0 will fail on  list uncimmited blob from container, will skip the case until this is fix in SDK or Azurite
-  it.skip("should only show uncommitted blobs in listBlobFlatSegment with uncommittedblobs option @loki @sql", async () => {
+  it("should only show uncommitted blobs in listBlobFlatSegment with uncommittedblobs option @loki @sql", async () => {
     const blobClient = containerClient.getBlobClient(
       getUniqueName("uncommittedblob")
     );

--- a/tests/blob/apis/container.test.ts
+++ b/tests/blob/apis/container.test.ts
@@ -1042,7 +1042,7 @@ describe("ContainerAPIs", () => {
       await blockBlobClient.upload("", 0);
       blobClients.push(blobClient);
     }
-    blobClients[0].createSnapshot();
+    await blobClients[0].createSnapshot();
 
     // create account sas
     const storageSharedKeyCredential = new StorageSharedKeyCredential(

--- a/tests/blob/apis/pageblob.test.ts
+++ b/tests/blob/apis/pageblob.test.ts
@@ -66,7 +66,7 @@ describe("PageBlobAPIs", () => {
     await containerClient.delete();
   });
 
-  it("create with default parameters @loki", async () => {
+  it("create with default parameters @loki @sql", async () => {
     const reuslt_create = await pageBlobClient.create(512);
     assert.equal(
       reuslt_create._response.request.headers.get("x-ms-client-request-id"),
@@ -84,7 +84,7 @@ describe("PageBlobAPIs", () => {
     );
   });
 
-  it("create with all parameters set @loki", async () => {
+  it("create with all parameters set @loki @sql", async () => {
     const options = {
       blobHTTPHeaders: {
         blobCacheControl: "blobCacheControl",
@@ -144,7 +144,7 @@ describe("PageBlobAPIs", () => {
     );
   });
 
-  it("download page blob with partial ranges @loki", async () => {
+  it("download page blob with partial ranges @loki @sql", async () => {
     const length = 512 * 10;
     await pageBlobClient.create(length);
 
@@ -171,7 +171,7 @@ describe("PageBlobAPIs", () => {
     assert.deepStrictEqual(result._response.status, 206);
   });
 
-  it("download page blob with no ranges uploaded @loki", async () => {
+  it("download page blob with no ranges uploaded @loki @sql", async () => {
     const length = 512 * 10;
     await pageBlobClient.create(length);
 
@@ -194,7 +194,7 @@ describe("PageBlobAPIs", () => {
     );
   });
 
-  it("download page blob with no ranges uploaded after resize to bigger size @loki", async () => {
+  it("download page blob with no ranges uploaded after resize to bigger size @loki @sql", async () => {
     let length = 512 * 10;
     await pageBlobClient.create(length);
 
@@ -237,7 +237,7 @@ describe("PageBlobAPIs", () => {
     );
   });
 
-  it("download page blob with no ranges uploaded after resize to smaller size @loki", async () => {
+  it("download page blob with no ranges uploaded after resize to smaller size @loki @sql", async () => {
     let length = 512 * 10;
     await pageBlobClient.create(length);
 
@@ -268,7 +268,7 @@ describe("PageBlobAPIs", () => {
     );
   });
 
-  it("uploadPages @loki", async () => {
+  it("uploadPages @loki @sql", async () => {
     await pageBlobClient.create(1024);
 
     const result = await blobClient.download(0);
@@ -292,7 +292,7 @@ describe("PageBlobAPIs", () => {
     assert.equal(await bodyToString(page2, 512), "b".repeat(512));
   });
 
-  it("uploadPages should work with sequence number conditions @loki", async () => {
+  it("uploadPages should work with sequence number conditions @loki @sql", async () => {
     await pageBlobClient.create(1024);
 
     await pageBlobClient.updateSequenceNumber(
@@ -327,7 +327,7 @@ describe("PageBlobAPIs", () => {
     assert.equal(await bodyToString(page2, 512), "b".repeat(512));
   });
 
-  it("uploadPages should not work if ifSequenceNumberEqualTo doesn't match @loki", async () => {
+  it("uploadPages should not work if ifSequenceNumberEqualTo doesn't match @loki @sql", async () => {
     await pageBlobClient.create(1024);
 
     await pageBlobClient.updateSequenceNumber(
@@ -349,7 +349,7 @@ describe("PageBlobAPIs", () => {
     assert.fail();
   });
 
-  it("uploadPages should not work if ifSequenceNumberLessThan doesn't match @loki", async () => {
+  it("uploadPages should not work if ifSequenceNumberLessThan doesn't match @loki @sql", async () => {
     await pageBlobClient.create(1024);
 
     await pageBlobClient.updateSequenceNumber(
@@ -382,7 +382,7 @@ describe("PageBlobAPIs", () => {
     assert.fail();
   });
 
-  it("uploadPages should not work if ifSequenceNumberLessThanOrEqualTo doesn't match @loki", async () => {
+  it("uploadPages should not work if ifSequenceNumberLessThanOrEqualTo doesn't match @loki @sql", async () => {
     await pageBlobClient.create(1024);
 
     await pageBlobClient.updateSequenceNumber(
@@ -410,7 +410,7 @@ describe("PageBlobAPIs", () => {
     assert.fail();
   });
 
-  it("uploadPages with sequential pages @loki", async () => {
+  it("uploadPages with sequential pages @loki @sql", async () => {
     const length = 512 * 3;
     await pageBlobClient.create(length);
 
@@ -443,7 +443,7 @@ describe("PageBlobAPIs", () => {
     assert.deepStrictEqual(ranges.pageRange![2], { offset: 1024, count: 511 });
   });
 
-  it("uploadPages with one big page range @loki", async () => {
+  it("uploadPages with one big page range @loki @sql", async () => {
     const length = 512 * 3;
     await pageBlobClient.create(length);
 
@@ -476,7 +476,7 @@ describe("PageBlobAPIs", () => {
     assert.deepStrictEqual(ranges.pageRange![0], { offset: 0, count: 1535 });
   });
 
-  it("uploadPages with non-sequential pages @loki", async () => {
+  it("uploadPages with non-sequential pages @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -515,7 +515,7 @@ describe("PageBlobAPIs", () => {
     assert.deepStrictEqual(ranges.pageRange![1], { offset: 1536, count: 511 });
   });
 
-  it("uploadPages to internally override a sequential range @loki", async () => {
+  it("uploadPages to internally override a sequential range @loki @sql", async () => {
     const length = 512 * 3;
     await pageBlobClient.create(length);
 
@@ -552,7 +552,7 @@ describe("PageBlobAPIs", () => {
     assert.deepStrictEqual(ranges.pageRange![2], { offset: 1024, count: 511 });
   });
 
-  it("uploadPages to internally right align override a sequential range @loki", async () => {
+  it("uploadPages to internally right align override a sequential range @loki @sql", async () => {
     const length = 512 * 3;
     await pageBlobClient.create(length);
 
@@ -588,7 +588,7 @@ describe("PageBlobAPIs", () => {
     assert.deepStrictEqual(ranges.pageRange![1], { offset: 1024, count: 511 });
   });
 
-  it("uploadPages to internally left align override a sequential range @loki", async () => {
+  it("uploadPages to internally left align override a sequential range @loki @sql", async () => {
     const length = 512 * 3;
     await pageBlobClient.create(length);
 
@@ -624,7 +624,7 @@ describe("PageBlobAPIs", () => {
     assert.deepStrictEqual(ranges.pageRange![1], { offset: 512, count: 1023 });
   });
 
-  it("uploadPages to totally override a sequential range @loki", async () => {
+  it("uploadPages to totally override a sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -678,7 +678,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("uploadPages to left override a sequential range @loki", async () => {
+  it("uploadPages to left override a sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -722,7 +722,7 @@ describe("PageBlobAPIs", () => {
     assert.deepStrictEqual(ranges.pageRange![1], { offset: 1024, count: 1023 });
   });
 
-  it("uploadPages to right override a sequential range @loki", async () => {
+  it("uploadPages to right override a sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -772,7 +772,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("resize override a sequential range @loki", async () => {
+  it("resize override a sequential range @loki @sql", async () => {
     let length = 512 * 3;
     await pageBlobClient.create(length);
 
@@ -815,7 +815,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("uploadPages to internally override a non-sequential range @loki", async () => {
+  it("uploadPages to internally override a non-sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -867,7 +867,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("uploadPages to internally insert into a non-sequential range @loki", async () => {
+  it("uploadPages to internally insert into a non-sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -919,7 +919,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("uploadPages to totally override a non-sequential range @loki", async () => {
+  it("uploadPages to totally override a non-sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -963,7 +963,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("uploadPages to left override a non-sequential range @loki", async () => {
+  it("uploadPages to left override a non-sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -1011,7 +1011,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("uploadPages to insert into a non-sequential range @loki", async () => {
+  it("uploadPages to insert into a non-sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -1063,7 +1063,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("uploadPages to right override a non-sequential range @loki", async () => {
+  it("uploadPages to right override a non-sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -1111,7 +1111,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("clearPages @loki", async () => {
+  it("clearPages @loki @sql", async () => {
     await pageBlobClient.create(1024);
     let result = await blobClient.download(0);
     assert.deepStrictEqual(
@@ -1135,7 +1135,7 @@ describe("PageBlobAPIs", () => {
     );
   });
 
-  it("clearPages should work with sequence number conditions @loki", async () => {
+  it("clearPages should work with sequence number conditions @loki @sql", async () => {
     await pageBlobClient.create(1024);
     await pageBlobClient.clearPages(0, 512, {
       conditions: {
@@ -1146,7 +1146,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("clearPages should not work with invalid ifSequenceNumberEqualTo @loki", async () => {
+  it("clearPages should not work with invalid ifSequenceNumberEqualTo @loki @sql", async () => {
     await pageBlobClient.create(1024);
     try {
       await pageBlobClient.clearPages(0, 512, {
@@ -1161,7 +1161,7 @@ describe("PageBlobAPIs", () => {
     assert.fail();
   });
 
-  it("clearPages should not work with invalid ifSequenceNumberLessThan @loki", async () => {
+  it("clearPages should not work with invalid ifSequenceNumberLessThan @loki @sql", async () => {
     await pageBlobClient.create(1024);
     await pageBlobClient.updateSequenceNumber(
       SequenceNumberActionType.Increment
@@ -1186,7 +1186,7 @@ describe("PageBlobAPIs", () => {
     assert.fail();
   });
 
-  it("clearPages should not work with invalid ifSequenceNumberLessThanOrEqualTo @loki", async () => {
+  it("clearPages should not work with invalid ifSequenceNumberLessThanOrEqualTo @loki @sql", async () => {
     await pageBlobClient.create(1024);
     await pageBlobClient.updateSequenceNumber(
       SequenceNumberActionType.Increment
@@ -1211,7 +1211,7 @@ describe("PageBlobAPIs", () => {
     assert.fail();
   });
 
-  it("clearPages to internally override a sequential range @loki", async () => {
+  it("clearPages to internally override a sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -1261,7 +1261,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("clearPages to totally override a sequential range @loki", async () => {
+  it("clearPages to totally override a sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -1303,7 +1303,7 @@ describe("PageBlobAPIs", () => {
     assert.deepStrictEqual((ranges.clearRange || []).length, 0);
   });
 
-  it("clearPages to left override a sequential range @loki", async () => {
+  it("clearPages to left override a sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -1349,7 +1349,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("clearPages to right override a sequential range @loki", async () => {
+  it("clearPages to right override a sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -1395,7 +1395,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("clearPages to internally override a non-sequential range @loki", async () => {
+  it("clearPages to internally override a non-sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -1443,7 +1443,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("clearPages to internally insert into a non-sequential range @loki", async () => {
+  it("clearPages to internally insert into a non-sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -1495,7 +1495,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("clearPages will fail when start range longer than blob length @loki", async () => {
+  it("clearPages will fail when start range longer than blob length @loki @sql", async () => {
     const length = 512 * 2;
     await pageBlobClient.create(length);
 
@@ -1515,7 +1515,7 @@ describe("PageBlobAPIs", () => {
     assert.fail();
   });
 
-  it("GetPageRanges will fail when start range longer than blob length @loki", async () => {
+  it("GetPageRanges will fail when start range longer than blob length @loki @sql", async () => {
     const length = 512 * 2;
     await pageBlobClient.create(length);
 
@@ -1535,7 +1535,7 @@ describe("PageBlobAPIs", () => {
     assert.fail();
   });
 
-  it("UploadPages will fail when start range longer than blob length @loki", async () => {
+  it("UploadPages will fail when start range longer than blob length @loki @sql", async () => {
     const length = 512 * 2;
     await pageBlobClient.create(length);
 
@@ -1554,7 +1554,7 @@ describe("PageBlobAPIs", () => {
     assert.fail();
   });
 
-  it("clearPages to totally override a non-sequential range @loki", async () => {
+  it("clearPages to totally override a non-sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -1594,7 +1594,7 @@ describe("PageBlobAPIs", () => {
     assert.deepStrictEqual((ranges.clearRange || []).length, 0);
   });
 
-  it("clearPages to left override a non-sequential range @loki", async () => {
+  it("clearPages to left override a non-sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -1641,7 +1641,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("clearPages to right override a non-sequential range @loki", async () => {
+  it("clearPages to right override a non-sequential range @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
 
@@ -1684,7 +1684,7 @@ describe("PageBlobAPIs", () => {
     });
   });
 
-  it("getPageRanges @loki", async () => {
+  it("getPageRanges @loki @sql", async () => {
     await pageBlobClient.create(1024);
 
     const result = await blobClient.download(0);
@@ -1704,7 +1704,7 @@ describe("PageBlobAPIs", () => {
     assert.equal(page2.pageRange![0].count, 511);
   });
 
-  it("updateSequenceNumber @loki", async () => {
+  it("updateSequenceNumber @loki @sql", async () => {
     await pageBlobClient.create(1024);
     let propertiesResponse = await pageBlobClient.getProperties();
 
@@ -1726,7 +1726,7 @@ describe("PageBlobAPIs", () => {
   });
 
   // devstoreaccount1 is standard storage account which doesn't support premium page blob tiers
-  it.skip("setAccessTier for Page blob @loki", async () => {
+  it.skip("setAccessTier for Page blob @loki @sql", async () => {
     const length = 512 * 5;
     await pageBlobClient.create(length);
     let propertiesResponse = await pageBlobClient.getProperties();

--- a/tests/blob/apis/service.test.ts
+++ b/tests/blob/apis/service.test.ts
@@ -459,7 +459,7 @@ describe("ServiceAPIs", () => {
     );
   });
 
-  it("Get Blob service stats negative @loki", async () => {
+  it("Get Blob service stats negative @loki @sql", async () => {
     await serviceClient.getStatistics()
       .catch((err) => {
         assert.strictEqual(err.statusCode, 400);
@@ -498,7 +498,7 @@ describe("ServiceAPIs - secondary location endpoint", () => {
     await server.clean();
   });
 
-  it("Get Blob service stats @loki", async () => {
+  it("Get Blob service stats @loki @sql", async () => {
 
     await serviceClient.getStatistics()
       .then((result) => {

--- a/tests/blob/handlers/AppendBlobHandler.test.ts
+++ b/tests/blob/handlers/AppendBlobHandler.test.ts
@@ -96,7 +96,7 @@ describe("AppendBlobHandler", () => {
   ).thenResolve(extent);
 
   describe("create", () => {
-    it("accepts requests withContent-Length == 0 @loki", async () => {
+    it("accepts requests withContent-Length == 0 @loki @sql", async () => {
       const handler = new AppendBlobHandler(
         instance(metadataStore),
         instance(extentStore),
@@ -108,7 +108,7 @@ describe("AppendBlobHandler", () => {
       });
     });
 
-    it("accepts requests with Content-Length != 0 in loose mode @loki", async () => {
+    it("accepts requests with Content-Length != 0 in loose mode @loki @sql", async () => {
       const handler = new AppendBlobHandler(
         instance(metadataStore),
         instance(extentStore),
@@ -120,7 +120,7 @@ describe("AppendBlobHandler", () => {
       });
     });
 
-    it("rejects requests with Content-Length != 0 @loki", async () => {
+    it("rejects requests with Content-Length != 0 @loki @sql", async () => {
       const handler = new AppendBlobHandler(
         instance(metadataStore),
         instance(extentStore),
@@ -146,7 +146,7 @@ describe("AppendBlobHandler", () => {
       bufferStream.end(buffer);
     });
 
-    it("accepts requests with Content-Length != 0 @loki", async () => {
+    it("accepts requests with Content-Length != 0 @loki @sql", async () => {
       const handler = new AppendBlobHandler(
         instance(metadataStore),
         instance(extentStore),
@@ -158,7 +158,7 @@ describe("AppendBlobHandler", () => {
       });
     });
 
-    it("rejects requests with Content-Length == 0 @loki", async () => {
+    it("rejects requests with Content-Length == 0 @loki @sql", async () => {
       const handler = new AppendBlobHandler(
         instance(metadataStore),
         instance(extentStore),
@@ -176,7 +176,7 @@ describe("AppendBlobHandler", () => {
       );
     });
 
-    it("accepts requests with valid MD5 checksum @loki", async () => {
+    it("accepts requests with valid MD5 checksum @loki @sql", async () => {
       when(request.getHeader(HeaderConstants.CONTENT_MD5)).thenReturn(
         "T0EkOEfaaTpPNWwEhhFLxg=="
       );
@@ -195,7 +195,7 @@ describe("AppendBlobHandler", () => {
       });
     });
 
-    it("rejects requests with invalid MD5 checksum @loki", async () => {
+    it("rejects requests with invalid MD5 checksum @loki @sql", async () => {
       when(request.getHeader(HeaderConstants.CONTENT_MD5)).thenReturn(
         "d3JvbmdfTUQ1X2NoZWNrc3VtCg=="
       );

--- a/tests/blob/pagewithdelimiter.test.ts
+++ b/tests/blob/pagewithdelimiter.test.ts
@@ -36,31 +36,31 @@ describe("PageWithDelimiter", () => {
       "e/2"
     ];
 
-    it("handles no blob results @loki", async () => {
+    it("handles no blob results @loki @sql", async () => {
       const page = new PageWithDelimiter<string>(5);
       const [items, prefixes, marker] = await page.fill(createReader([], 5), namer);
       checkResult(items, prefixes, marker, 0, 0, "");
     });
 
-    it("fills 1 result properly @loki", async () => {
+    it("fills 1 result properly @loki @sql", async () => {
       const page = new PageWithDelimiter<string>(1);
       const [items, prefixes, marker] = await page.fill(createReader(blobs, 1), namer);
       checkResult(items, prefixes, marker, 1, 0, "a");
     });
 
-    it("fills n results properly @loki", async () => {
+    it("fills n results properly @loki @sql", async () => {
       const page = new PageWithDelimiter<string>(5);
       const [items, prefixes, marker] = await page.fill(createReader(blobs, 5), namer);
       checkResult(items, prefixes, marker, 5, 0, "c/sub/1");
     });
 
-    it("fills exact count with no continuation @loki", async () => {
+    it("fills exact count with no continuation @loki @sql", async () => {
       const page = new PageWithDelimiter<string>(blobs.length);
       const [items, prefixes, marker] = await page.fill(createReader(blobs, blobs.length), namer);
       checkResult(items, prefixes, marker, blobs.length, 0, "");
     });
 
-    it("fills smaller than max page with no continuation @loki", async () => {
+    it("fills smaller than max page with no continuation @loki @sql", async () => {
       const page = new PageWithDelimiter<string>(blobs.length+1);
       const [items, prefixes, marker] = await page.fill(createReader(blobs, blobs.length+1), namer);
       checkResult(items, prefixes, marker, blobs.length, 0, "");
@@ -71,21 +71,21 @@ describe("PageWithDelimiter", () => {
 
     describe("and 1 item page size", () => {
 
-      it("handles no blob results @loki", async () => {
+      it("handles no blob results @loki @sql", async () => {
         const blobs: string[] = [];
         const page = new PageWithDelimiter<string>(1, "/");
         const [items, prefixes, marker] = await page.fill(createReader(blobs, 1), namer);
         checkResult(items, prefixes, marker, 0, 0, "");
       });
 
-      it("handles 1 blob results @loki", async () => {
+      it("handles 1 blob results @loki @sql", async () => {
         const blobs = ["a"];
         const page = new PageWithDelimiter<string>(1, "/");
         const [items, prefixes, marker] = await page.fill(createReader(blobs, 1), namer);
         checkResult(items, prefixes, marker, 1, 0, "");
       });
 
-      it("returns 1 of 2 items with proper continuation @loki", async () => {
+      it("returns 1 of 2 items with proper continuation @loki @sql", async () => {
         const blobs = ["a", "b"];
         const page = new PageWithDelimiter<string>(1, "/");
         let [items, prefixes, marker] = await page.fill(createReader(blobs, 1), namer);
@@ -97,14 +97,14 @@ describe("PageWithDelimiter", () => {
         checkResult(items, prefixes, marker, 1, 0, "");
       });
 
-      it("returns first item when prefixes exist @loki", async () => {
+      it("returns first item when prefixes exist @loki @sql", async () => {
         const blobs = ["a/1", "a/2", "a/3", "a/sub/1"];
         const page = new PageWithDelimiter<string>(1, "/", "a/");
         const [items, prefixes, marker] = await page.fill(createReader(blobs, 1), namer);
         checkResult(items, prefixes, marker, 1, 0, "a/1");
       });
 
-      it("returns first prefix when blobs exist @loki", async () => {
+      it("returns first prefix when blobs exist @loki @sql", async () => {
         const blobs = ["a/s0/1", "a/s0/2", "a/s0/3", "a/s1/1", "a/s2/2", "a/z"];
         const page = new PageWithDelimiter<string>(1, "/", "a/");
         const [items, prefixes, marker] = await page.fill(createReader(blobs, 1), namer);
@@ -114,21 +114,21 @@ describe("PageWithDelimiter", () => {
 
     describe("multiple item page size", () => {
 
-      it("squashes prefixes @loki", async () => {
+      it("squashes prefixes @loki @sql", async () => {
         const blobs = ["a/s0/1", "a/s0/2", "a/s0/3", "a/s1/1", "a/s1/2", "a/s2/2", "a/z"];
         const page = new PageWithDelimiter<string>(2, "/", "a/");
         const [items, prefixes, marker] = await page.fill(createReader(blobs, 2), namer);
         checkResult(items, prefixes, marker, 0, 2, "a/s1/2");
       });
 
-      it("squashes a mix @loki", async () => {
+      it("squashes a mix @loki @sql", async () => {
         const blobs = ["a/a", "a/s0/1", "a/s0/2", "a/s1/1", "a/s1/2", "a/z"];
         const page = new PageWithDelimiter<string>(2, "/", "a/");
         const [items, prefixes, marker] = await page.fill(createReader(blobs, 2), namer);
         checkResult(items, prefixes, marker, 1, 1, "a/s0/2");
       });
 
-      it("follows squashed pages @loki", async () => {
+      it("follows squashed pages @loki @sql", async () => {
         const blobs = ["a/a", "a/s0/1", "a/s0/2", "a/s1/1", "a/s1/2", "a/z"];
         const page = new PageWithDelimiter<string>(2, "/", "a/");
         let [items, prefixes, marker] = await page.fill(createReader(blobs, 2), namer);
@@ -140,7 +140,7 @@ describe("PageWithDelimiter", () => {
         checkResult(items, prefixes, marker, 1, 1, "");
       });
 
-      it("squashes within one larger page @loki", async () => {
+      it("squashes within one larger page @loki @sql", async () => {
         const blobs = ["a/a", "a/s0/1", "a/s0/2", "a/s1/1", "a/s1/2", "a/z"];
         const page = new PageWithDelimiter<string>(4, "/", "a/");
         let [items, prefixes, marker] = await page.fill(createReader(blobs, 4), namer);

--- a/tests/blob/sas.test.ts
+++ b/tests/blob/sas.test.ts
@@ -1894,7 +1894,7 @@ describe("Shared Access Signature (SAS) authentication", () => {
 
     const sourceBlob = sourceContainerClient.getBlockBlobClient(blobName);
     await sourceBlob.upload("hello", 5);
-    sourceBlob.setAccessTier("Archive");
+    await sourceBlob.setAccessTier("Archive");
 
     const targetBlob = targetContainerClient.getBlockBlobClient(blobName);
 

--- a/tests/blob/sas.test.ts
+++ b/tests/blob/sas.test.ts
@@ -115,7 +115,13 @@ describe("Shared Access Signature (SAS) authentication", () => {
     await server.clean();
   });
 
-  it("generateAccountSASQueryParameters should generate correct hashes", async () => {
+  // This has multiple issues:
+  // 1. It depends on timezone need to set "TZ=Etc/GMT-1".
+  // 2. Even when setting timezone it still fails.
+  // 3. It tests storage-blob sdk rather than Azurite.
+  // 4. Ground truth sig shouldn't be hardcoded.
+  // So should be removed but skipping for now.
+  it.skip("generateAccountSASQueryParameters should generate correct hashes", async () => {
     
     const startDate = new Date(2022, 3, 16, 14, 31, 48, 0);
     const endDate = new Date(2022, 3, 17, 14, 31, 48, 0);

--- a/tests/blob/sas.test.ts
+++ b/tests/blob/sas.test.ts
@@ -370,7 +370,7 @@ describe("Shared Access Signature (SAS) authentication", () => {
     assert.ok(error);
   });
 
-  it("Synchronized copy blob should work with write permission in account SAS to override an existing blob @loki", async () => {
+  it("Synchronized copy blob should work with write permission in account SAS to override an existing blob @loki @sql", async () => {
     const tmr = new Date();
     tmr.setDate(tmr.getDate() + 1);
 
@@ -418,7 +418,7 @@ describe("Shared Access Signature (SAS) authentication", () => {
     await blob2.syncCopyFromURL(blob1.url);
   });
 
-  it("Synchronized copy blob shouldn't work without write permission in account SAS to override an existing blob @loki", async () => {
+  it("Synchronized copy blob shouldn't work without write permission in account SAS to override an existing blob @loki @sql", async () => {
     const tmr = new Date();
     tmr.setDate(tmr.getDate() + 1);
 
@@ -473,7 +473,7 @@ describe("Shared Access Signature (SAS) authentication", () => {
     assert.ok(error !== undefined);
   });
 
-  it("Synchronized copy blob should work without write permission in account SAS to an nonexisting blob @loki", async () => {
+  it("Synchronized copy blob should work without write permission in account SAS to an nonexisting blob @loki @sql", async () => {
     const tmr = new Date();
     tmr.setDate(tmr.getDate() + 1);
 
@@ -520,7 +520,7 @@ describe("Shared Access Signature (SAS) authentication", () => {
     await blob2.syncCopyFromURL(blob1.url);
   });
 
-  it("Copy blob should work with write permission in account SAS to override an existing blob @loki", async () => {
+  it("Copy blob should work with write permission in account SAS to override an existing blob @loki @sql", async () => {
     const tmr = new Date();
     tmr.setDate(tmr.getDate() + 1);
 
@@ -568,7 +568,7 @@ describe("Shared Access Signature (SAS) authentication", () => {
     await blob2.beginCopyFromURL(blob1.url);
   });
 
-  it("Copy blob shouldn't work without write permission in account SAS to override an existing blob @loki", async () => {
+  it("Copy blob shouldn't work without write permission in account SAS to override an existing blob @loki @sql", async () => {
     const tmr = new Date();
     tmr.setDate(tmr.getDate() + 1);
 
@@ -623,7 +623,7 @@ describe("Shared Access Signature (SAS) authentication", () => {
     assert.ok(error !== undefined);
   });
 
-  it("Copy blob should work without write permission in account SAS to an nonexisting blob @loki", async () => {
+  it("Copy blob should work without write permission in account SAS to an nonexisting blob @loki @sql", async () => {
     const tmr = new Date();
     tmr.setDate(tmr.getDate() + 1);
 
@@ -1255,7 +1255,7 @@ describe("Shared Access Signature (SAS) authentication", () => {
     await containerClient.delete();
   });
 
-  it("Synchronized copy blob should work with write permission in blob SAS to override an existing blob @loki", async () => {
+  it("Synchronized copy blob should work with write permission in blob SAS to override an existing blob @loki @sql", async () => {
     const now = new Date();
     now.setMinutes(now.getMinutes() - 5); // Skip clock skew with server
 
@@ -1302,7 +1302,7 @@ describe("Shared Access Signature (SAS) authentication", () => {
     await blob2SAS.syncCopyFromURL(blob1.url);
   });
 
-  it("Synchronized copy blob shouldn't work without write permission in blob SAS to override an existing blob @loki", async () => {
+  it("Synchronized copy blob shouldn't work without write permission in blob SAS to override an existing blob @loki @sql", async () => {
     const now = new Date();
     now.setMinutes(now.getMinutes() - 5); // Skip clock skew with server
 
@@ -1356,7 +1356,7 @@ describe("Shared Access Signature (SAS) authentication", () => {
     assert.ok(error !== undefined);
   });
 
-  it("Synchronized copy blob should work without write permission in account SAS to an nonexisting blob @loki", async () => {
+  it("Synchronized copy blob should work without write permission in account SAS to an nonexisting blob @loki @sql", async () => {
     const now = new Date();
     now.setMinutes(now.getMinutes() - 5); // Skip clock skew with server
 
@@ -1903,7 +1903,7 @@ describe("Shared Access Signature (SAS) authentication", () => {
     assert.equal(error.details.code, "BlobArchived");
   });
 
-  it("Sync Copy blob across accounts should work and honor metadata when provided @loki", async () => {
+  it("Sync Copy blob across accounts should work and honor metadata when provided @loki @sql", async () => {
     const now = new Date();
     now.setMinutes(now.getMinutes() - 5); // Skip clock skew with server
 

--- a/tests/blob/specialnaming.test.ts
+++ b/tests/blob/specialnaming.test.ts
@@ -445,7 +445,9 @@ describe("SpecialNaming", () => {
     assert.notDeepEqual(response.segment.blobItems.length, 0);
   });
 
-  it(`Should work with production style URL when ${productionStyleHostName} is resolvable`, async () => {
+  // This now doesn't work (Error: Unable to extract accountName with provided information.).
+  // As the sdk expect an url in the form devstoreaccount1.blob.localhost instead of devstoreaccount1.localhost
+  it.skip(`Should work with production style URL when ${productionStyleHostName} is resolvable`, async () => {
     await dns.promises.lookup(productionStyleHostName).then(
       async (lookupAddress) => {
         const baseURLProductionStyle = `http://${productionStyleHostName}:${server.config.port}`;

--- a/tests/blob/utils.test.ts
+++ b/tests/blob/utils.test.ts
@@ -2,7 +2,7 @@ import assert = require("assert");
 import { convertRawHeadersToMetadata } from "../../src/common/utils/utils";
 
 describe("Utils", () => {
-  it("convertRawHeadersToMetadata should work", () => {
+  it("convertRawHeadersToMetadata should work @loki @sql", () => {
     // upper case, lower case keys/values
     const metadata = convertRawHeadersToMetadata([
       "x-ms-meta-Name1",
@@ -22,7 +22,7 @@ describe("Utils", () => {
     });
   });
 
-  it("convertRawHeadersToMetadata should work with duplicated metadata", () => {
+  it("convertRawHeadersToMetadata should work with duplicated metadata @loki @sql", () => {
     const metadata = convertRawHeadersToMetadata([
       "x-ms-meta-name1",
       "Value",
@@ -34,7 +34,7 @@ describe("Utils", () => {
     });
   });
 
-  it("convertRawHeadersToMetadata should work with empty metadata", () => {
+  it("convertRawHeadersToMetadata should work with empty metadata @loki @sql", () => {
     const metadata = convertRawHeadersToMetadata([
       "x-ms-meta-Name1",
       "",
@@ -47,12 +47,12 @@ describe("Utils", () => {
     });
   });
 
-  it("convertRawHeadersToMetadata should work with empty raw headers", () => {
+  it("convertRawHeadersToMetadata should work with empty raw headers @loki @sql", () => {
     const metadata = convertRawHeadersToMetadata();
     assert.deepStrictEqual(metadata, undefined);
   });
 
-  it("convertRawHeadersToMetadata should work with empty raw headers array", () => {
+  it("convertRawHeadersToMetadata should work with empty raw headers array @loki @sql", () => {
     const metadata = convertRawHeadersToMetadata([]);
     assert.deepStrictEqual(metadata, undefined);
   });


### PR DESCRIPTION
Add Blob Copy & Page Blob support to by SQL based metadata implementation in Blob API. This makes the SQL based metadata implementation in sync with File based one. (issue #2224)

I divided the PR into very small mini commits for better visibility but most of these commits are small either in scope or code.
 
Changes are as follows:

In code: ([SqlBlobMetadataStore.ts])

1. Changed properties from separate fields into a single one to allow serializing de-serializing of remaining properties as well.
2. Added missing await from some async functions in SqlBlobMetadataStore
3. Ported ```copyFromURL``` from Loki to SQL blobMeatadataStore
4. Ported ```appendBlock``` from Loki to SQL blobMeatadataStore
5. Ported ```clearRange``` from Loki to SQL blobMeatadataStore
6. Ported ```getPageRanges``` from Loki to SQL blobMeatadataStore
7. Ported ```resizePageBlob``` from Loki to SQL blobMeatadataStore
8. Ported ```updateSequenceNumber``` from Loki to SQL blobMeatadataStore
9. Return blobCommittedBlockCount for append blob in getBlobProperties in SQL blobMetadataStore
10. Check for CopyIfExists condition in startCopyFromURL in SQL blobMetadaStore

In Tests:

1. Add @sql to all @loki tests
2. Ignore ```generateAccountSASQueryParameters``` in sas blob tests as it depend on timezone and fails even then and test another component not Azurite
3. Skip production style URL test as it fails in new sdk //To be fixed
4. Remove skipping of "list uncimmited blob from container"  in blob api container test since now it is working
5. Added await to 2 async functions in 2 tests that was causing these 2 tests to be flaky

Others:

1. Changed readme and changelog to relfect sync btween Loki and SQL blob metadata stores.

Note: I recommend removing the @loki and @sql all together and run all test cases without grep for both loki and sql to avoid descync in the future but its your call.