### PR TITLE
Expose start/stop/clean commands as tasks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-16-bullseye"
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+	,
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.vscode-typescript-tslint-plugin",
+				"esbenp.prettier-vscode",
+				"joelday.docthis",
+				"mike-co.import-sorter"
+			]
+		}
+	}
+}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 ## Upcoming Release
 
+General:
+
+- Expose start/stop/clean commands as tasks in VS Code extension.
+
 Blob:
 
 - Fix validation of Blob SAS token when using the second key for an account in `AZURITE_ACCOUNTS`

--- a/README.md
+++ b/README.md
@@ -199,6 +199,40 @@ Following extension configurations are supported:
 - `azurite.skipApiVersionCheck` Skip the request API version check, by default false.
 - `azurite.disableProductStyleUrl` Force parsing storage account name from request Uri path, instead of from request Uri host.
 
+The following custom tasks are provided and can be used in `tasks.json` (e.g. to automatically start Azurite when launching a debug session or opening a workspace):
+
+- `azurite: start` Start all Azurite services
+- `azurite: close` Close all Azurite services
+- `azurite: clean` Reset all Azurite services persistency data
+- `azurite: blob.start` Start blob service
+- `azurite: blob.close` Close blob service
+- `azurite: blob.clean` Clean blob service
+- `azurite: queue.start` Start queue service
+- `azurite: queue.close` Close queue service
+- `azurite: queue.clean` Clean queue service
+- `azurite: table.start` Start table service
+- `azurite: table.close` Close table service
+- `azurite: table.clean` Clean table service
+
+To ensure that all services are started before launching a debug configuration, add `"preLaunchTask": "azurite: start"` to the configuration in `launch.json` (see [the docs](https://code.visualstudio.com/Docs/editor/debugging#_launchjson-attributes) for more details).
+
+To auto-start the blob service when opening a workspace, use the `runOptions` in `task.json` as shown in the example below:
+
+```json
+{
+  "tasks" : [
+    {
+      "type": "azurite",
+      "action": "blob.start",
+      "problemMatcher": [],
+      "runOptions": {
+        "runOn": "folderOpen"
+      }
+    }
+  ]
+}
+```
+
 ### [DockerHub](https://hub.docker.com/_/microsoft-azure-storage-azurite)
 
 #### Run Azurite V3 docker image

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "stoppable": "^1.1.0",
         "tedious": "^16.0.0",
         "to-readable-stream": "^2.1.0",
-        "tslib": "^2.3.0",
+        "tslib": "^2.6.2",
         "uri-templates": "^0.2.0",
         "uuid": "^3.3.2",
         "winston": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "stoppable": "^1.1.0",
     "tedious": "^16.0.0",
     "to-readable-stream": "^2.1.0",
-    "tslib": "^2.3.0",
+    "tslib": "^2.6.2",
     "uri-templates": "^0.2.0",
     "uuid": "^3.3.2",
     "winston": "^3.1.0",
@@ -248,6 +248,20 @@
             "type": "boolean",
             "default": false,
             "description": "Disable getting account name from the host of request Uri, always get account name from the first path segment of request Uri."
+          }
+        }
+      }
+    ],
+    "taskDefinitions": [
+      {
+        "type": "azurite",
+        "required": [
+          "action"
+        ],
+        "properties": {
+          "action": {
+            "type": "string",
+            "description": "Action to perform. Should be one of: start_blob, stop_blob, clean_blob"
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,10 @@
-import { commands, ExtensionContext, StatusBarAlignment, window } from "vscode";
+import {
+  commands,
+  ExtensionContext,
+  StatusBarAlignment,
+  tasks,
+  window
+} from "vscode";
 
 import VSCAccessLog from "./common/VSCAccessLog";
 import VSCNotification from "./common/VSCNotification";
@@ -7,6 +13,7 @@ import VSCServerManagerBlob from "./common/VSCServerManagerBlob";
 import VSCServerManagerQueue from "./common/VSCServerManagerQueue";
 import VSCServerManagerTable from "./common/VSCServerManagerTable";
 import VSCStatusBarItem from "./common/VSCStatusBarItem";
+import { AzuriteTaskProvider } from "./tasks";
 
 export function activate(context: ExtensionContext) {
   // Initialize server managers
@@ -52,6 +59,15 @@ export function activate(context: ExtensionContext) {
   );
   tableServerManager.addEventListener(
     new VSCAccessLog(tableServerManager.accessChannelStream)
+  );
+
+  tasks.registerTaskProvider(
+    AzuriteTaskProvider.AzuriteTaskType,
+    new AzuriteTaskProvider(
+      blobServerManager,
+      queueServerManager,
+      tableServerManager
+    )
   );
 
   context.subscriptions.push(

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1,0 +1,203 @@
+import * as vscode from "vscode";
+
+import VSCServerManagerBlob from "./common/VSCServerManagerBlob";
+import VSCServerManagerQueue from "./common/VSCServerManagerQueue";
+import VSCServerManagerTable from "./common/VSCServerManagerTable";
+import { ServerStatus } from "./common/ServerBase";
+import VSCServerManagerBase from "./common/VSCServerManagerBase";
+
+interface Action {
+  name: string;
+  command: string;
+  preCheck?: (writeEmitter: vscode.EventEmitter<string>) => Promise<boolean>;
+}
+
+interface AzuriteTaskDefinition extends vscode.TaskDefinition {
+  action: string;
+}
+
+export class AzuriteTaskProvider implements vscode.TaskProvider {
+  static AzuriteTaskType = "azurite";
+
+  private tasks: vscode.Task[] | undefined;
+  private actions: Record<string, Action>;
+
+  constructor(
+    blobManager: VSCServerManagerBlob,
+    queueManager: VSCServerManagerQueue,
+    tableManager: VSCServerManagerTable
+  ) {
+    this.actions = {
+      start: {
+        name: "Start All",
+        command: "azurite.start"
+        // NOTE no pre-check here as starting all services doesn't give an error if they're already running
+      },
+      close: {
+        name: "Close All",
+        command: "azurite.close"
+      },
+      clean: {
+        name: "Clean All",
+        command: "azurite.clean"
+      },
+      "blob.start": {
+        name: "Start Blob Server",
+        command: blobManager.getStartCommand(),
+        preCheck: this.createPreCheck(
+          blobManager,
+          ServerStatus.Running,
+          "Blob server is already running.\r\n"
+        )
+      },
+      "blob.close": {
+        name: "Close Blob Server",
+        command: blobManager.getCloseCommand(),
+        preCheck: this.createPreCheck(
+          blobManager,
+          ServerStatus.Closed,
+          "Blob server is already closed.\r\n"
+        )
+      },
+      "blob.clean": {
+        name: "Clean Blob Server",
+        command: blobManager.getCleanCommand()
+      },
+      "queue.start": {
+        name: "Start Queue Server",
+        command: queueManager.getStartCommand(),
+        preCheck: this.createPreCheck(
+          queueManager,
+          ServerStatus.Running,
+          "Queue server is already running.\r\n"
+        )
+      },
+      "queue.close": {
+        name: "Close Queue Server",
+        command: queueManager.getCloseCommand(),
+        preCheck: this.createPreCheck(
+          queueManager,
+          ServerStatus.Closed,
+          "Queue server is already closed.\r\n"
+        )
+      },
+      "queue.clean": {
+        name: "Clean Queue Server",
+        command: queueManager.getCleanCommand()
+      },
+      "table.start": {
+        name: "Start Table Server",
+        command: tableManager.getStartCommand(),
+        preCheck: this.createPreCheck(
+          tableManager,
+          ServerStatus.Running,
+          "Table server is already running.\r\n"
+        )
+      },
+      "table.close": {
+        name: "Close Table Server",
+        command: tableManager.getCloseCommand(),
+        preCheck: this.createPreCheck(
+          tableManager,
+          ServerStatus.Closed,
+          "Table server is already closed.\r\n"
+        )
+      },
+      "table.clean": {
+        name: "Clean Table Server",
+        command: tableManager.getCleanCommand()
+      }
+    };
+  }
+
+  /**
+   * Create a pre-check function for a task. Used to avoid showing an error when starting a service that is already running.
+   * @param manager
+   * @param checkStatus
+   * @param message
+   * @returns
+   */
+  private createPreCheck(
+    manager: VSCServerManagerBase,
+    checkStatus: ServerStatus,
+    message: string
+  ) {
+    return async (writeEmitter: vscode.EventEmitter<string>) => {
+      const server = manager.getServer();
+      if (server?.getStatus() === checkStatus) {
+        writeEmitter.fire(message);
+        return false;
+      }
+      return true;
+    };
+  }
+
+  provideTasks(): vscode.ProviderResult<vscode.Task[]> {
+    return this.getTasks();
+  }
+  private getTasks() {
+    if (!this.tasks) {
+      this.tasks = Object.keys(this.actions).map((actionKey) => {
+        const definition: AzuriteTaskDefinition = {
+          type: AzuriteTaskProvider.AzuriteTaskType,
+          action: actionKey
+        };
+        const action = this.actions[actionKey];
+        return new vscode.Task(
+          definition,
+          vscode.TaskScope.Workspace,
+          actionKey,
+          AzuriteTaskProvider.AzuriteTaskType,
+          new vscode.CustomExecution(
+            async (): Promise<vscode.Pseudoterminal> => {
+              return new AzuriteTaskTerminal(action);
+            }
+          )
+        );
+      });
+    }
+    return this.tasks;
+  }
+
+  resolveTask(task: vscode.Task): vscode.ProviderResult<vscode.Task> {
+    const actionName = task.definition.action as string;
+    if (!actionName) {
+      return undefined;
+    }
+    const resolvedTask = this.getTasks().find(
+      (t) => t.definition.action === actionName
+    );
+    return resolvedTask;
+  }
+}
+
+class AzuriteTaskTerminal implements vscode.Pseudoterminal {
+  private writeEmitter = new vscode.EventEmitter<string>();
+  onDidWrite: vscode.Event<string> = this.writeEmitter.event;
+  private closeEmitter = new vscode.EventEmitter<number>();
+  onDidClose?: vscode.Event<number> = this.closeEmitter.event;
+
+  private action: Action;
+
+  constructor(action: Action) {
+    this.action = action;
+  }
+  open(initialDimensions: vscode.TerminalDimensions | undefined): void {
+    this.start();
+  }
+  close(): void {}
+
+  private async start(): Promise<void> {
+    if (this.action.preCheck) {
+      const shouldContinue = await this.action.preCheck(this.writeEmitter);
+      if (!shouldContinue) {
+        this.closeEmitter.fire(0);
+        return;
+      }
+    }
+    this.writeEmitter.fire(this.action.name + "\r\n");
+    await vscode.commands.executeCommand(this.action.command);
+    this.writeEmitter.fire("Done!\r\n");
+    this.closeEmitter.fire(0);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,13 +16,25 @@
     "declarationMap": true,
     "importHelpers": true,
     "declarationDir": "./typings",
-    "lib": ["es5", "es6", "es7", "esnext", "dom"],
+    "lib": [
+      "es5",
+      "es6",
+      "es7",
+      "esnext",
+      "dom"
+    ],
     "esModuleInterop": true,
     "downlevelIteration": true,
     "useUnknownInCatchVariables": false,
     "skipLibCheck": true,
   },
   "compileOnSave": true,
-  "exclude": ["node_modules"],
-  "include": ["./src/**/*.ts", "./tests/**/*.ts"]
+  "exclude": [
+    "node_modules"
+  ],
+  "include": [
+    "./src/**/*.ts",
+    "./tests/**/*.ts",
+    "src/tasks.ts.tmp"
+  ]
 }


### PR DESCRIPTION
This PR to the VS Code extension adds tasks that expose the start/stop/clean commands. This allows a user to automate the starting of Azurite services

Launch configurations in VS Code allow you to specify a task that should be run before launching the app/debugger. For example, tTo ensure that all services are started before launching a debug configuration, add `"preLaunchTask": "azurite: start"` to the configuration in `launch.json` (see [the docs](https://code.visualstudio.com/Docs/editor/debugging#_launchjson-attributes) for more details).

Tasks can also be set to run when a folder opens (e.g. start the blob service when the folder opens):

```json
{
  "tasks" : [
    {
      "type": "azurite",
      "action": "blob.start",
      "problemMatcher": [],
      "runOptions": {
        "runOn": "folderOpen"
      }
    }
  ]
}
```


---
Thanks for contribution! Please go through following checklist before sending PR.

### PR Branch Destination

- For Azurite V3, please send PR to `main` branch.
- For legacy Azurite V2, please send PR to `legacy-dev` branch.

### Always Add Test Cases

Make sure test cases are added to cover the code change.

### Add Change Log

Add change log for the code change in `Upcoming Release` section in `ChangeLog.md`.

### Development Guideline

Please go to CONTRIBUTION.md for steps about setting up development environment and recommended Visual Studio Code extensions.
