### PR TITLE
fix 1359: table sas failure with upper case table name

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,7 @@ Table:
 - Fixed the errorCode returned, when malformed Etag is provided for table Update/Delete calls. (issue #2013)
 - Fixed an issue when comparing `'' eq guid'00000000-0000-0000-0000-000000000000'` which would erroneously report these as equal. (issue #2169)
 - Fixed authentication error in production style URL for secondary location (issue #2208)
+- Fixed table sas request failure with table name include upper case letter (Issue #1359)
 
 ## 2023.08 Version 3.26.0
 

--- a/src/table/authentication/ITableSASSignatureValues.ts
+++ b/src/table/authentication/ITableSASSignatureValues.ts
@@ -245,5 +245,5 @@ function generateTableSASSignature20150405(
 }
 
 function getCanonicalName(accountName: string, tableName: string): string {
-  return `/table/${accountName}/${tableName}`;
+  return `/table/${accountName}/${tableName.toLowerCase()}`;
 }

--- a/tests/table/auth/sas.test.ts
+++ b/tests/table/auth/sas.test.ts
@@ -68,7 +68,8 @@ describe("Shared Access Signature (SAS) authentication", () => {
   });
 
   it("1. insertEntity with Query permission should not work @loki", (done) => {
-    const tableName: string = getUniqueName("sas1");
+    // Use table name include upper case letter to validate SAS signature should calculate from lower case table name (Issue #1359)
+    const tableName: string = getUniqueName("Sas1");
     tableService.createTable(tableName, (error, result, response) => {
       // created table for tests
       const expiry = new Date();


### PR DESCRIPTION
Fix #1359 
According to [link](https://learn.microsoft.com/en-us/rest/api/storageservices/create-service-sas#:~:text=Table%20names%20must%20be%20lowercase.), Table names must be lowercase in canonicalizedResource in the stringToSign of SAS.


### PR Branch Destination

- For Azurite V3, please send PR to `main` branch.
- For legacy Azurite V2, please send PR to `legacy-dev` branch.

### Always Add Test Cases

Make sure test cases are added to cover the code change.

### Add Change Log

Add change log for the code change in `Upcoming Release` section in `ChangeLog.md`.

### Development Guideline

Please go to CONTRIBUTION.md for steps about setting up development environment and recommended Visual Studio Code extensions.
