### PR TITLE
Fix HTTP header parsing in SubmitBatch request

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ General:
 Blob:
 
 - Fixed issue of not requiring SAS permission for some specific operations. (issue #2299)
+- Fix HTTP header parsing of `SubmitBatch()`. If a HTTP header has HTTP header delimiter (`:`) in its value, `SubmitBatch()` returns "400 One of the request inputs is not valid". For example, if `user-agent` header is `azsdk-cpp-storage-blobs/12.10.0-beta.1 (Darwin 23.1.0 arm64 Darwin Kernel Version 23.1.0: Mon Oct  9 21:28:12 PDT 2023; root:xnu-10002.41.9~6/RELEASE_ARM64_T8103)`, all `SubmitBatch()` requests are failed.
 
 Table:
 

--- a/src/blob/handlers/BlobBatchHandler.ts
+++ b/src/blob/handlers/BlobBatchHandler.ts
@@ -354,7 +354,7 @@ export class BlobBatchHandler {
 
       while (lineIndex < requestLines.length) {
         if (requestLines[lineIndex] === '') break;
-        const header = requestLines[lineIndex].split(HTTP_HEADER_DELIMITER);
+        const header = requestLines[lineIndex].split(HTTP_HEADER_DELIMITER, 2);
 
         if (header.length !== 2) throw new Error("Bad Request");
 
@@ -384,7 +384,7 @@ export class BlobBatchHandler {
       ++lineIndex;
       while (lineIndex < requestLines.length) {
         if (requestLines[lineIndex] === '') break; // Last line
-        const header = requestLines[lineIndex].split(HTTP_HEADER_DELIMITER);
+        const header = requestLines[lineIndex].split(HTTP_HEADER_DELIMITER, 2);
 
         if (header.length !== 2) throw new Error("Bad Request");
         blobBatchSubRequest.setHeader(header[0], header[1]);


### PR DESCRIPTION
If a SubmitBatch request has a HTTP header that has a HTTP header
delimiter (":") in its value, the SubmitBatch request is failed as
"400 One of the request inputs is not valid."

For example, if `user-agent` header is `azsdk-cpp-storage-blobs/12.10.0-beta.1 (Darwin 23.1.0 arm64 Darwin Kernel Version 23.1.0: Mon Oct 9 21:28:12 PDT 2023; root:xnu-10002.41.9~6/RELEASE_ARM64_T8103)`, all `SubmitBatch()` requests are failed.
