### PR TITLE
Fix 2410/2409: fix issue of download blob range.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@
 
 ## Upcoming Release
 
+Blob:
+
+- Fixed issue of download 0 size blob with range > 0 should report error. (issue #2410)
+- Fixed issue of download a blob range without header x-ms-range-get-content-md5, should not return content-md5. (issue #2409)
+
 ## 2024.06 Version 3.31.0
 
 General:

--- a/src/blob/errors/StorageErrorFactory.ts
+++ b/src/blob/errors/StorageErrorFactory.ts
@@ -199,6 +199,15 @@ export default class StorageErrorFactory {
     );
   }
 
+  public static getInvalidPageRange2(contextID: string): StorageError {
+    return new StorageError(
+      416,
+      "InvalidRange",
+      "The range specified is invalid for the current size of the resource.",
+      contextID
+    );
+  }
+
   public static getInvalidLeaseDuration(
     contextID: string = DefaultID
   ): StorageError {

--- a/src/blob/handlers/BlobHandler.ts
+++ b/src/blob/handlers/BlobHandler.ts
@@ -1018,7 +1018,13 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
 
     // Will automatically shift request with longer data end than blob size to blob size
     if (rangeEnd + 1 >= blob.properties.contentLength!) {
-      rangeEnd = blob.properties.contentLength! - 1;
+      // report error is blob size is 0, and rangeEnd is specified but not 0 
+      if (blob.properties.contentLength == 0 && rangeEnd !== 0 && rangeEnd !== Infinity) {
+        throw StorageErrorFactory.getInvalidPageRange2(context.contextId!);
+      }
+      else {
+        rangeEnd = blob.properties.contentLength! - 1;
+      }
     }
 
     const contentLength = rangeEnd - rangeStart + 1;
@@ -1098,7 +1104,7 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
       acceptRanges: "bytes",
       contentLength,
       contentRange,
-      contentMD5,
+      contentMD5: contentRange ? (context.request!.getHeader("x-ms-range-get-content-md5") ? contentMD5: undefined) : contentMD5,
       tagCount: getBlobTagsCount(blob.blobTags),
       isServerEncrypted: true,
       clientRequestId: options.requestId,
@@ -1143,7 +1149,13 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
 
     // Will automatically shift request with longer data end than blob size to blob size
     if (rangeEnd + 1 >= blob.properties.contentLength!) {
-      rangeEnd = blob.properties.contentLength! - 1;
+      // report error is blob size is 0, and rangeEnd is specified but not 0 
+      if (blob.properties.contentLength == 0 && rangeEnd !== 0 && rangeEnd !== Infinity) {
+        throw StorageErrorFactory.getInvalidPageRange2(context.contextId!);
+      }
+      else {
+        rangeEnd = blob.properties.contentLength! - 1;
+      }
     }
 
     const contentLength = rangeEnd - rangeStart + 1;
@@ -1228,7 +1240,7 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
       contentType: context.request!.getQuery("rsct") ?? blob.properties.contentType,
       contentLength,
       contentRange,
-      contentMD5,
+      contentMD5: contentRange ? (context.request!.getHeader("x-ms-range-get-content-md5") ? contentMD5: undefined) : contentMD5,
       blobContentMD5: blob.properties.contentMD5,
       tagCount: getBlobTagsCount(blob.blobTags),
       isServerEncrypted: true,

--- a/tests/blob/apis/appendblob.test.ts
+++ b/tests/blob/apis/appendblob.test.ts
@@ -387,7 +387,7 @@ describe("AppendBlobAPIs", () => {
     await appendBlobClient.appendBlock("T", 1);
     await appendBlobClient.appendBlock("@", 2);
 
-    const response = await snapshotAppendBlobURL.download(3);
+    const response = await snapshotAppendBlobURL.download(3, undefined, {rangeGetContentMD5: true});
     const string = await bodyToString(response);
     assert.deepStrictEqual(string, "def");
     assert.deepEqual(response.contentMD5, await getMD5FromString("def"));
@@ -404,7 +404,7 @@ describe("AppendBlobAPIs", () => {
 
     await appendBlobClient.delete();
 
-    const response = await copiedAppendBlobClient.download(3);
+    const response = await copiedAppendBlobClient.download(3, undefined, {rangeGetContentMD5: true});
     const string = await bodyToString(response);
     assert.deepStrictEqual(string, "def");
     assert.deepEqual(response.contentMD5, await getMD5FromString("def"));

--- a/tests/blob/apis/pageblob.test.ts
+++ b/tests/blob/apis/pageblob.test.ts
@@ -269,7 +269,7 @@ describe("PageBlobAPIs", () => {
     );
   });
 
-  it("download a 0 size page blob with range > 0 will get error @loki @sql", async () => {  
+  it("download a 0 size page blob with range > 0 will get error @loki", async () => {  
     pageBlobClient.deleteIfExists();      
     await pageBlobClient.create(0);
 
@@ -282,7 +282,7 @@ describe("PageBlobAPIs", () => {
     assert.fail();
   });
 
-  it("Download a blob range should only return ContentMD5 when has request header x-ms-range-get-content-md5  @loki @sql", async () => {
+  it("Download a blob range should only return ContentMD5 when has request header x-ms-range-get-content-md5  @loki", async () => {
     pageBlobClient.deleteIfExists();    
     
     await pageBlobClient.create(512, {blobHTTPHeaders: {blobContentMD5: await getMD5FromString("a".repeat(512))}});    

--- a/tests/blob/apis/pageblob.test.ts
+++ b/tests/blob/apis/pageblob.test.ts
@@ -14,6 +14,7 @@ import {
   EMULATOR_ACCOUNT_NAME,
   getUniqueName
 } from "../../testutils";
+import { getMD5FromString } from "../../../src/common/utils/utils";
 
 // Set true to enable debug log
 configLogger(false);
@@ -266,6 +267,47 @@ describe("PageBlobAPIs", () => {
       await bodyToString(result, length),
       "\u0000".repeat(length)
     );
+  });
+
+  it("download a 0 size page blob with range > 0 will get error @loki @sql", async () => {  
+    pageBlobClient.deleteIfExists();      
+    await pageBlobClient.create(0);
+
+    try {
+      await pageBlobClient.download(0, 3);
+    } catch (error) {
+      assert.deepStrictEqual(error.statusCode, 416);
+      return;
+    }
+    assert.fail();
+  });
+
+  it("Download a blob range should only return ContentMD5 when has request header x-ms-range-get-content-md5  @loki @sql", async () => {
+    pageBlobClient.deleteIfExists();    
+    
+    await pageBlobClient.create(512, {blobHTTPHeaders: {blobContentMD5: await getMD5FromString("a".repeat(512))}});    
+    await pageBlobClient.uploadPages("a".repeat(512), 0, 512);
+
+    const properties1 = await pageBlobClient.getProperties();
+    assert.deepEqual(properties1.contentMD5, await getMD5FromString("a".repeat(512)));
+    
+    let result = await pageBlobClient.download(0, 1024);
+    assert.deepStrictEqual(await bodyToString(result, 512), "a".repeat(512));
+    assert.deepStrictEqual(result.contentLength, 512);
+    assert.deepEqual(result.contentMD5, undefined);
+    assert.deepEqual(result.blobContentMD5, await getMD5FromString("a".repeat(512)));
+
+    result = await pageBlobClient.download();
+    assert.deepStrictEqual(await bodyToString(result, 512), "a".repeat(512));
+    assert.deepStrictEqual(result.contentLength, 512);
+    assert.deepEqual(properties1.contentMD5, await getMD5FromString("a".repeat(512)));
+    assert.deepEqual(result.blobContentMD5, await getMD5FromString("a".repeat(512)));
+
+    result = await pageBlobClient.download(0, 3, {rangeGetContentMD5: true});
+    assert.deepStrictEqual(await bodyToString(result, 3), "aaa");
+    assert.deepStrictEqual(result.contentLength, 3);
+    assert.deepEqual(result.contentMD5, await getMD5FromString("aaa"));
+    assert.deepEqual(result.blobContentMD5, await getMD5FromString("a".repeat(512)));
   });
 
   it("uploadPages @loki", async () => {


### PR DESCRIPTION
Thanks for contribution! Please go through following checklist before sending PR.

Fix 2 issues of download blob range:
#2410: Download rang > 0 from 0 size blob should report error
#2409: Download blob range only return ContentMD5 when request has header `x-ms-range-get-content-md5`

### PR Branch Destination

- For Azurite V3, please send PR to `main` branch.
- For legacy Azurite V2, please send PR to `legacy-dev` branch.

### Always Add Test Cases

Make sure test cases are added to cover the code change.

### Add Change Log

Add change log for the code change in `Upcoming Release` section in `ChangeLog.md`.

### Development Guideline

Please go to CONTRIBUTION.md for steps about setting up development environment and recommended Visual Studio Code extensions.
