### PR TITLE
Queue test fix

### DIFF
--- a/tests/queue/apis/messageid.test.ts
+++ b/tests/queue/apis/messageid.test.ts
@@ -163,7 +163,7 @@ describe("MessageId APIs test", () => {
       eResult.messageId,
       eResult.popReceipt,
       newMessage,
-      5
+      2
     );
     assert.ok(uResult.version);
     assert.ok(uResult.nextVisibleOn);
@@ -182,7 +182,7 @@ describe("MessageId APIs test", () => {
       pResult.clientRequestId
     );
 
-    await sleep(6 * 1000);
+    await sleep(3 * 1000);
 
     let pResult2 = await queueClient.peekMessages();
     assert.equal(pResult2.peekedMessageItems.length, 1);


### PR DESCRIPTION
Fix the test case failed like https://github.com/Azure/Azurite/actions/runs/11097981740/job/30830329538?pr=2428
>   1) MessageId APIs test
>        update and delete message with all parameters @loki:
>      FetchError: request to http://127.0.0.1:11001/devstoreaccount1/queue172766217678200480/messages?peekonly=true&timeout=30 failed, reason: socket hang up
>       at ClientRequest.<anonymous> (node_modules/node-fetch/lib/index.js:1491:11)
>       at ClientRequest.emit (node:events:519:28)
>       at ClientRequest.emit (node:domain:488:12)
>       at emitErrorEvent (node:_http_client:103:11)
>       at Socket.socketOnEnd (node:_http_client:530:5)
>       at Socket.emit (node:events:531:35)
>       at Socket.emit (node:domain:488:12)
>       at endReadableNT (node:internal/streams/readable:1698:12)
>       at processTicksAndRejections (node:internal/process/task_queues:90:21)

### PR Branch Destination

- For Azurite V3, please send PR to `main` branch.
- For legacy Azurite V2, please send PR to `legacy-dev` branch.

### Always Add Test Cases

Make sure test cases are added to cover the code change.

### Add Change Log

Add change log for the code change in `Upcoming Release` section in `ChangeLog.md`.

### Development Guideline

Please go to CONTRIBUTION.md for steps about setting up development environment and recommended Visual Studio Code extensions.
