### PR TITLE
Fixed an issue where premature client disconnections led to all following requests failing with a 500 error #1346

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@
 General:
 
 - Bump mysql2 to resolve to 3.10.1 for security patches
+- Fixed an issue where premature client disconnections led to all following requests failing with a 500 error. (issue #1346) 
 
 Blob:
 

--- a/tests/blob/fsStore.test.ts
+++ b/tests/blob/fsStore.test.ts
@@ -1,0 +1,38 @@
+import assert from "assert";
+import { Readable } from "stream";
+import FSExtentStore from "../../src/common/persistence/FSExtentStore";
+import IExtentMetadataStore from "../../src/common/persistence/IExtentMetadataStore";
+import { DEFAULT_BLOB_PERSISTENCE_ARRAY } from "../../src/blob/utils/constants";
+import logger from "../../src/common/Logger";
+
+import { mock } from "ts-mockito";
+
+describe("FSExtentStore", () => {
+
+  const metadataStore: IExtentMetadataStore = mock<IExtentMetadataStore>();
+  metadataStore.getExtentLocationId = () => Promise.resolve("Default");
+
+  it("should handle input stream error gracefully during appendExtent @loki", async () => {
+    const store = new FSExtentStore(metadataStore, DEFAULT_BLOB_PERSISTENCE_ARRAY, logger);
+    await store.init();
+
+    // A null value within the Readable.from array causes the stream to emit an error.
+    const stream1 = Readable.from(["deadbeef", null], { objectMode: false });
+    await assert.rejects(store.appendExtent(stream1));
+
+    // Write a valid stream to the store.
+    const stream2 = Readable.from("Test", { objectMode: false });
+    const extent = await store.appendExtent(stream2);
+    assert.strictEqual(extent.offset, 0);
+    assert.strictEqual(extent.count, 4);
+
+    // Check that the extent is readable.
+    let readable = await store.readExtent(extent);
+    const chunks: Buffer[] = [];
+    for await (const chunk of readable) {
+      chunks.push(chunk as Buffer);
+    }
+    const data = Buffer.concat(chunks);
+    assert.strictEqual(data.toString(), "Test");
+  });
+});


### PR DESCRIPTION
Fixes #1346

The underlying file, where the data is saved was closed if any error occurred while reading from the client connection. Subsequently, the file was attempted to be used again, but it is closed.

Thanks for contribution! Please go through following checklist before sending PR.

### PR Branch Destination

- For Azurite V3, please send PR to `main` branch.
- For legacy Azurite V2, please send PR to `legacy-dev` branch.

### Always Add Test Cases

Make sure test cases are added to cover the code change.

### Add Change Log

Add change log for the code change in `Upcoming Release` section in `ChangeLog.md`.

### Development Guideline

Please go to CONTRIBUTION.md for steps about setting up development environment and recommended Visual Studio Code extensions.
