### PR TITLE
add blobKeepAliveTimeout, queueKeepAliveTimeout, tableKeepAliveTimeout

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,15 @@ Blob:
 - Fixed issue of download a blob range without header x-ms-range-get-content-md5, should not return content-md5. (issue #2409)
 - Fixed issue of list container without include=metadata should not clear container metadata on server. (issue #2416)
 - Supported x-ms-copy-source-tag-option in copy blob from Uri. (issue #2398)
+- Added blobKeepAliveTimeout option (issue #2053)
+
+Table:
+
+- Added tableKeepAliveTimeout option (issue #2053)
+
+Queue:
+
+- Added queueKeepAliveTimeout option (issue #2053)
 
 ## 2024.06 Version 3.31.0
 

--- a/README.mcr.md
+++ b/README.mcr.md
@@ -80,6 +80,12 @@ Above command will try to start Azurite image with configurations:
 
 Please refer to this [document](https://github.com/Azure/Azurite/blob/master/README.md) for **More supported parameters** like HTTPS or OAuth.
 
+**Customize HTTP Keep-Alive behavior**
+
+```bash
+docker run azurite --blobHost 0.0.0.0 --blobKeepAliveTimeout 300 --queueHost 0.0.0.0 --queueKeepAliveTimeout 300  --tableHost 0.0.0.0 --tableKeepAliveTimeout 300
+```
+
 ## Documentation
 
 Please refer to this [document](https://github.com/Azure/Azurite/blob/master/README.md).

--- a/README.md
+++ b/README.md
@@ -186,10 +186,13 @@ Following extension configurations are supported:
 
 - `azurite.blobHost` Blob service listening endpoint, by default 127.0.0.1
 - `azurite.blobPort` Blob service listening port, by default 10000
+- `azurite.blobKeepAliveTimeout` Blob service keep alive timeout, by default 5
 - `azurite.queueHost` Queue service listening endpoint, by default 127.0.0.1
 - `azurite.queuePort` Queue service listening port, by default 10001
+- `azurite.queueKeepAliveTimeout` Queue service keep alive timeout, by default 5
 - `azurite.tableHost` Table service listening endpoint, by default 127.0.0.1
 - `azurite.tablePort` Table service listening port, by default 10002
+- `azurite.tableKeepAliveTimeout` Queue service keep alive timeout, by default 5
 - `azurite.location` Workspace location folder path (can be relative or absolute). By default, in the VS Code extension, the currently opened folder is used. If launched from the command line, the current process working directory is the default. Relative paths are resolved relative to the default folder.
 - `azurite.silent` Silent mode to disable access log in Visual Studio channel, by default false
 - `azurite.debug` Output debug log into Azurite channel, by default false

--- a/package.json
+++ b/package.json
@@ -219,6 +219,11 @@
             "default": 10000,
             "description": "Blob service listening port, by default 10000"
           },
+          "azurite.blobKeepAliveTimeout": {
+            "type": "number",
+            "default": 5,
+            "description": "Blob service keep alive timeout, by default 5"
+          },
           "azurite.queueHost": {
             "type": "string",
             "default": "127.0.0.1",
@@ -229,6 +234,11 @@
             "default": 10001,
             "description": "Queue service listening port, by default 10001"
           },
+          "azurite.queueKeepAliveTimeout": {
+            "type": "number",
+            "default": 5,
+            "description": "Queue service keep alive timeout, by default 5"
+          },
           "azurite.tableHost": {
             "type": "string",
             "default": "127.0.0.1",
@@ -238,6 +248,11 @@
             "type": "number",
             "default": 10002,
             "description": "Table service listening port, by default 10002"
+          },
+          "azurite.tableKeepAliveTimeout": {
+            "type": "number",
+            "default": 5,
+            "description": "Table service keep alive timeout, by default 5"
           },
           "azurite.skipApiVersionCheck": {
             "type": "boolean",

--- a/src/azurite.ts
+++ b/src/azurite.ts
@@ -86,6 +86,7 @@ async function main() {
   const queueConfig = new QueueConfiguration(
     env.queueHost(),
     env.queuePort(),
+    env.queueKeepAliveTimeout(),
     join(location, DEFAULT_QUEUE_LOKI_DB_PATH),
     join(location, DEFAULT_QUEUE_EXTENT_LOKI_DB_PATH),
     DEFAULT_QUEUE_PERSISTENCE_ARRAY,
@@ -106,6 +107,7 @@ async function main() {
   const tableConfig = new TableConfiguration(
     env.tableHost(),
     env.tablePort(),
+    env.tableKeepAliveTimeout(),
     join(location, DEFAULT_TABLE_LOKI_DB_PATH),
     env.debug() !== undefined,
     !env.silent(),

--- a/src/blob/BlobConfiguration.ts
+++ b/src/blob/BlobConfiguration.ts
@@ -8,7 +8,8 @@ import {
   DEFAULT_BLOB_PERSISTENCE_ARRAY,
   DEFAULT_BLOB_SERVER_HOST_NAME,
   DEFAULT_ENABLE_ACCESS_LOG,
-  DEFAULT_ENABLE_DEBUG_LOG
+  DEFAULT_ENABLE_DEBUG_LOG,
+  DEFAULT_BLOB_KEEP_ALIVE_TIMEOUT
 } from "./utils/constants";
 
 /**
@@ -27,6 +28,7 @@ export default class BlobConfiguration extends ConfigurationBase {
   public constructor(
     host: string = DEFAULT_BLOB_SERVER_HOST_NAME,
     port: number = DEFAULT_BLOB_LISTENING_PORT,
+    keepAliveTimeout: number = DEFAULT_BLOB_KEEP_ALIVE_TIMEOUT,
     public readonly metadataDBPath: string = DEFAULT_BLOB_LOKI_DB_PATH,
     public readonly extentDBPath: string = DEFAULT_BLOB_EXTENT_LOKI_DB_PATH,
     public readonly persistencePathArray: StoreDestinationArray = DEFAULT_BLOB_PERSISTENCE_ARRAY,
@@ -47,6 +49,7 @@ export default class BlobConfiguration extends ConfigurationBase {
     super(
       host,
       port,
+      keepAliveTimeout,
       enableAccessLog,
       accessLogWriteStream,
       enableDebugLog,

--- a/src/blob/BlobEnvironment.ts
+++ b/src/blob/BlobEnvironment.ts
@@ -5,7 +5,8 @@ import { dirname } from "path";
 import IBlobEnvironment from "./IBlobEnvironment";
 import {
   DEFAULT_BLOB_LISTENING_PORT,
-  DEFAULT_BLOB_SERVER_HOST_NAME, DEFAULT_BLOB_KEEP_ALIVE_TIMEOUT
+  DEFAULT_BLOB_SERVER_HOST_NAME,
+  DEFAULT_BLOB_KEEP_ALIVE_TIMEOUT
 } from "./utils/constants";
 
 if (!(args as any).config.name) {

--- a/src/blob/BlobEnvironment.ts
+++ b/src/blob/BlobEnvironment.ts
@@ -5,7 +5,7 @@ import { dirname } from "path";
 import IBlobEnvironment from "./IBlobEnvironment";
 import {
   DEFAULT_BLOB_LISTENING_PORT,
-  DEFAULT_BLOB_SERVER_HOST_NAME
+  DEFAULT_BLOB_SERVER_HOST_NAME, DEFAULT_BLOB_KEEP_ALIVE_TIMEOUT
 } from "./utils/constants";
 
 if (!(args as any).config.name) {
@@ -19,6 +19,11 @@ if (!(args as any).config.name) {
       ["", "blobPort"],
       "Optional. Customize listening port for blob",
       DEFAULT_BLOB_LISTENING_PORT
+    )
+    .option(
+      ["", "blobKeepAliveTimeout"],
+      "Optional. Customize http keep alive timeout for blob",
+      DEFAULT_BLOB_KEEP_ALIVE_TIMEOUT,
     )
     .option(
       ["l", "location"],
@@ -73,6 +78,10 @@ export default class BlobEnvironment implements IBlobEnvironment {
 
   public blobPort(): number | undefined {
     return this.flags.blobPort;
+  }
+
+  public blobKeepAliveTimeout(): number | undefined {
+    return this.flags.keepAliveTimeout;
   }
 
   public async location(): Promise<string> {

--- a/src/blob/BlobServerFactory.ts
+++ b/src/blob/BlobServerFactory.ts
@@ -52,6 +52,7 @@ export class BlobServerFactory {
         const config = new SqlBlobConfiguration(
           env.blobHost(),
           env.blobPort(),
+          env.blobKeepAliveTimeout(),
           databaseConnectionString!,
           DEFAULT_SQL_OPTIONS,
           DEFAULT_BLOB_PERSISTENCE_ARRAY,
@@ -73,6 +74,7 @@ export class BlobServerFactory {
         const config = new BlobConfiguration(
           env.blobHost(),
           env.blobPort(),
+          env.blobKeepAliveTimeout(),
           join(location, DEFAULT_BLOB_LOKI_DB_PATH),
           join(location, DEFAULT_BLOB_EXTENT_LOKI_DB_PATH),
           DEFAULT_BLOB_PERSISTENCE_ARRAY,

--- a/src/blob/IBlobEnvironment.ts
+++ b/src/blob/IBlobEnvironment.ts
@@ -1,6 +1,7 @@
 export default interface IBlobEnvironment {
   blobHost(): string | undefined;
   blobPort(): number | undefined;
+  blobKeepAliveTimeout(): number | undefined;
   location(): Promise<string>;
   silent(): boolean;
   loose(): boolean;

--- a/src/blob/SqlBlobConfiguration.ts
+++ b/src/blob/SqlBlobConfiguration.ts
@@ -8,7 +8,8 @@ import {
   DEFAULT_BLOB_PERSISTENCE_ARRAY,
   DEFAULT_BLOB_SERVER_HOST_NAME,
   DEFAULT_ENABLE_ACCESS_LOG,
-  DEFAULT_ENABLE_DEBUG_LOG
+  DEFAULT_ENABLE_DEBUG_LOG,
+  DEFAULT_BLOB_KEEP_ALIVE_TIMEOUT
 } from "./utils/constants";
 
 /**
@@ -22,6 +23,7 @@ export default class SqlBlobConfiguration extends ConfigurationBase {
   public constructor(
     host: string = DEFAULT_BLOB_SERVER_HOST_NAME,
     port: number = DEFAULT_BLOB_LISTENING_PORT,
+    keepAliveTimeout: number = DEFAULT_BLOB_KEEP_ALIVE_TIMEOUT,
     public readonly sqlURL: string,
     public readonly sequelizeOptions: SequelizeOptions = DEFAULT_SQL_OPTIONS,
     public readonly persistenceArray: StoreDestinationArray = DEFAULT_BLOB_PERSISTENCE_ARRAY,
@@ -40,6 +42,7 @@ export default class SqlBlobConfiguration extends ConfigurationBase {
     super(
       host,
       port,
+      keepAliveTimeout,
       enableAccessLog,
       accessLogWriteStream,
       enableDebugLog,

--- a/src/blob/utils/constants.ts
+++ b/src/blob/utils/constants.ts
@@ -31,6 +31,8 @@ export const EMULATOR_ACCOUNT_KEY = Buffer.from(
 export const EMULATOR_ACCOUNT_SKUNAME = Models.SkuName.StandardRAGRS;
 export const EMULATOR_ACCOUNT_KIND = Models.AccountKind.StorageV2;
 export const EMULATOR_ACCOUNT_ISHIERARCHICALNAMESPACEENABLED = false;
+export const DEFAULT_BLOB_KEEP_ALIVE_TIMEOUT = 5;
+
 
 export const HeaderConstants = {
   AUTHORIZATION: "authorization",

--- a/src/common/ConfigurationBase.ts
+++ b/src/common/ConfigurationBase.ts
@@ -48,6 +48,7 @@ export default abstract class ConfigurationBase {
   public constructor(
     public readonly host: string,
     public readonly port: number,
+    public readonly keepAliveTimeout: number,
     public readonly enableAccessLog: boolean = false,
     public readonly accessLogWriteStream?: NodeJS.WritableStream,
     public readonly enableDebugLog: boolean = false,

--- a/src/common/Environment.ts
+++ b/src/common/Environment.ts
@@ -1,16 +1,19 @@
 import args from "args";
 
 import {
+  DEFAULT_BLOB_KEEP_ALIVE_TIMEOUT,
   DEFAULT_BLOB_LISTENING_PORT,
   DEFAULT_BLOB_SERVER_HOST_NAME
 } from "../blob/utils/constants";
 
 import {
+  DEFAULT_QUEUE_KEEP_ALIVE_TIMEOUT,
   DEFAULT_QUEUE_LISTENING_PORT,
   DEFAULT_QUEUE_SERVER_HOST_NAME
 } from "../queue/utils/constants";
 
 import {
+  DEFAULT_TABLE_KEEP_ALIVE_TIMEOUT,
   DEFAULT_TABLE_LISTENING_PORT,
   DEFAULT_TABLE_SERVER_HOST_NAME
 } from "../table/utils/constants";
@@ -29,6 +32,11 @@ args
     DEFAULT_BLOB_LISTENING_PORT
   )
   .option(
+    ["", "blobKeepAliveTimeout"],
+    "Optional. Customize http keep alive timeout for blob",
+    DEFAULT_BLOB_KEEP_ALIVE_TIMEOUT,
+  )
+  .option(
     ["", "queueHost"],
     "Optional. Customize listening address for queue",
     DEFAULT_QUEUE_SERVER_HOST_NAME
@@ -39,6 +47,11 @@ args
     DEFAULT_QUEUE_LISTENING_PORT
   )
   .option(
+    ["", "queueKeepAliveTimeout"],
+    "Optional. Customize http keep alive timeout for queue",
+    DEFAULT_QUEUE_KEEP_ALIVE_TIMEOUT,
+  )
+  .option(
     ["", "tableHost"],
     "Optional. Customize listening address for table",
     DEFAULT_TABLE_SERVER_HOST_NAME
@@ -47,6 +60,11 @@ args
     ["", "tablePort"],
     "Optional. Customize listening port for table",
     DEFAULT_TABLE_LISTENING_PORT
+  )
+  .option(
+    ["", "tableKeepAliveTimeout"],
+    "Optional. Customize http keep alive timeout for table",
+    DEFAULT_TABLE_KEEP_ALIVE_TIMEOUT,
   )
   .option(
     ["l", "location"],
@@ -99,6 +117,10 @@ export default class Environment implements IEnvironment {
     return this.flags.blobPort;
   }
 
+  public blobKeepAliveTimeout(): number | undefined {
+    return this.flags.blobKeepAliveTimeout;
+  }
+
   public queueHost(): string | undefined {
     return this.flags.queueHost;
   }
@@ -107,12 +129,20 @@ export default class Environment implements IEnvironment {
     return this.flags.queuePort;
   }
 
+  public queueKeepAliveTimeout(): number | undefined {
+    return this.flags.queueKeepAliveTimeout;
+  }
+
   public tableHost(): string | undefined {
     return this.flags.tableHost;
   }
 
   public tablePort(): number | undefined {
     return this.flags.tablePort;
+  }
+
+  public tableKeepAliveTimeout(): number | undefined {
+    return this.flags.tableKeepAliveTimeout;
   }
 
   public async location(): Promise<string> {

--- a/src/common/ServerBase.ts
+++ b/src/common/ServerBase.ts
@@ -36,6 +36,7 @@ export default abstract class ServerBase implements ICleaner {
    * @param {number} port Server port, for example, 10000
    * @param {http.Server | https.Server} httpServer A HTTP or HTTPS server instance without request listener bound
    * @param {IRequestListenerFactory} requestListenerFactory A request listener factory
+   * @param config ConfigurationBase configuration
    * @memberof ServerBase
    */
   public constructor(
@@ -45,6 +46,9 @@ export default abstract class ServerBase implements ICleaner {
     requestListenerFactory: IRequestListenerFactory,
     public readonly config: ConfigurationBase
   ) {
+    if (this.config.keepAliveTimeout > 0) {
+      httpServer.keepAliveTimeout = this.config.keepAliveTimeout;
+    }
     // Remove predefined request listeners to avoid double request handling
     this.httpServer = stoppable(httpServer);
     this.httpServer.removeAllListeners("request");

--- a/src/common/VSCEnvironment.ts
+++ b/src/common/VSCEnvironment.ts
@@ -15,6 +15,10 @@ export default class VSCEnvironment implements IEnvironment {
     return this.workspaceConfiguration.get<number>("blobPort");
   }
 
+  public blobKeepAliveTimeout(): number | undefined {
+    return this.workspaceConfiguration.get<number>("blobKeepAliveTimeout");
+  }
+
   public queueHost(): string | undefined {
     return this.workspaceConfiguration.get<string>("queueHost");
   }
@@ -23,12 +27,20 @@ export default class VSCEnvironment implements IEnvironment {
     return this.workspaceConfiguration.get<number>("queuePort");
   }
 
+  public queueKeepAliveTimeout(): number | undefined {
+    return this.workspaceConfiguration.get<number>("queueKeepAliveTimeout");
+  }
+
   public tableHost(): string | undefined {
     return this.workspaceConfiguration.get<string>("tableHost");
   }
 
   public tablePort(): number | undefined {
     return this.workspaceConfiguration.get<number>("tablePort");
+  }
+
+  public tableKeepAliveTimeout(): number | undefined {
+    return this.workspaceConfiguration.get<number>("tableKeepAliveTimeout");
   }
 
   public async location(): Promise<string> {

--- a/src/common/VSCServerManagerBlob.ts
+++ b/src/common/VSCServerManagerBlob.ts
@@ -74,6 +74,7 @@ export default class VSCServerManagerBlob extends VSCServerManagerBase {
     const config = new BlobConfiguration(
       env.blobHost(),
       env.blobPort(),
+      env.blobKeepAliveTimeout(),
       join(location, DEFAULT_BLOB_LOKI_DB_PATH),
       join(location, DEFAULT_BLOB_EXTENT_LOKI_DB_PATH),
       DEFAULT_BLOB_PERSISTENCE_ARRAY,

--- a/src/common/VSCServerManagerQueue.ts
+++ b/src/common/VSCServerManagerQueue.ts
@@ -77,6 +77,7 @@ export default class VSCServerManagerBlob extends VSCServerManagerBase {
     const config = new QueueConfiguration(
       env.queueHost(),
       env.queuePort(),
+      env.blobKeepAliveTimeout(),
       join(location, DEFAULT_QUEUE_LOKI_DB_PATH),
       join(location, DEFAULT_QUEUE_EXTENT_LOKI_DB_PATH),
       DEFAULT_QUEUE_PERSISTENCE_ARRAY,

--- a/src/common/VSCServerManagerTable.ts
+++ b/src/common/VSCServerManagerTable.ts
@@ -66,6 +66,7 @@ export default class VSCServerManagerTable extends VSCServerManagerBase {
     const config = new TableConfiguration(
       env.tableHost(),
       env.tablePort(),
+      env.tableKeepAliveTimeout(),
       join(location, DEFAULT_TABLE_LOKI_DB_PATH),
       (await env.debug()) === true,
       !env.silent(),

--- a/src/queue/IQueueEnvironment.ts
+++ b/src/queue/IQueueEnvironment.ts
@@ -1,6 +1,7 @@
 export default interface IQueueEnvironment {
   queueHost(): string | undefined;
   queuePort(): number | undefined;
+  queueKeepAliveTimeout(): number | undefined;
   location(): Promise<string>;
   silent(): boolean;
   loose(): boolean;

--- a/src/queue/QueueConfiguration.ts
+++ b/src/queue/QueueConfiguration.ts
@@ -8,7 +8,8 @@ import {
   DEFAULT_QUEUE_LISTENING_PORT,
   DEFAULT_QUEUE_LOKI_DB_PATH,
   DEFAULT_QUEUE_PERSISTENCE_ARRAY,
-  DEFAULT_QUEUE_SERVER_HOST_NAME
+  DEFAULT_QUEUE_SERVER_HOST_NAME,
+  DEFAULT_QUEUE_KEEP_ALIVE_TIMEOUT,
 } from "./utils/constants";
 
 /**
@@ -27,6 +28,7 @@ export default class QueueConfiguration extends ConfigurationBase {
   public constructor(
     host: string = DEFAULT_QUEUE_SERVER_HOST_NAME,
     port: number = DEFAULT_QUEUE_LISTENING_PORT,
+    keepAliveTimeout: number = DEFAULT_QUEUE_KEEP_ALIVE_TIMEOUT,
     public readonly metadataDBPath: string = DEFAULT_QUEUE_LOKI_DB_PATH,
     public readonly extentDBPath: string = DEFAULT_QUEUE_EXTENT_LOKI_DB_PATH,
     public readonly persistencePathArray: StoreDestinationArray = DEFAULT_QUEUE_PERSISTENCE_ARRAY,
@@ -47,6 +49,7 @@ export default class QueueConfiguration extends ConfigurationBase {
     super(
       host,
       port,
+      keepAliveTimeout,
       enableAccessLog,
       accessLogWriteStream,
       enableDebugLog,

--- a/src/queue/QueueEnvironment.ts
+++ b/src/queue/QueueEnvironment.ts
@@ -68,6 +68,10 @@ export default class QueueEnvironment implements IQueueEnvironment {
     return this.flags.queuePort;
   }
 
+  public queueKeepAliveTimeout(): number | undefined {
+    return this.flags.keepAliveTimeout;
+  }
+
   public async location(): Promise<string> {
     return this.flags.location || process.cwd();
   }

--- a/src/queue/QueueServer.ts
+++ b/src/queue/QueueServer.ts
@@ -70,6 +70,10 @@ export default class QueueServer extends ServerBase {
         httpServer = http.createServer();
     }
 
+    if (configuration.keepAliveTimeout > 0) {
+      httpServer.keepAliveTimeout = configuration.keepAliveTimeout
+    }
+
     // We can change the persistency layer implementation by
     // creating a new XXXDataStore class implementing IBlobDataStore interface
     // and replace the default LokiBlobDataStore

--- a/src/queue/main.ts
+++ b/src/queue/main.ts
@@ -52,6 +52,7 @@ async function main() {
   const config = new QueueConfiguration(
     env.queueHost(),
     env.queuePort(),
+    env.queueKeepAliveTimeout(),
     join(location, DEFAULT_QUEUE_LOKI_DB_PATH),
     join(location, DEFAULT_QUEUE_EXTENT_LOKI_DB_PATH),
     DEFAULT_QUEUE_PERSISTENCE_ARRAY,

--- a/src/queue/utils/constants.ts
+++ b/src/queue/utils/constants.ts
@@ -33,6 +33,7 @@ export const MESSAGETTL_MIN = 1;
 export const DEFAULT_UPDATE_VISIBILITYTIMEOUT = 30; // 30s as default.
 export const UPDATE_VISIBILITYTIMEOUT_MIN = 0;
 export const UPDATE_VISIBILITYTIMEOUT_MAX = 604800;
+export const DEFAULT_QUEUE_KEEP_ALIVE_TIMEOUT = 5;
 
 export const EMPTY_EXTENT_CHUNK = { id: "", offset: 0, count: 0 };
 

--- a/src/table/ITableEnvironment.ts
+++ b/src/table/ITableEnvironment.ts
@@ -8,6 +8,8 @@ export default interface ITableEnvironment {
   tableHost(): string | undefined;
   /** Optional. Customize listening port for table */
   tablePort(): number | undefined;
+  /** Optional. Customize keep alive timeout for table */
+  tableKeepAliveTimeout(): number | undefined;
   /** Optional. Use an existing folder as workspace path, default is current working directory */
   location(): Promise<string>;
   /** Optional. Disable access log displayed in console */

--- a/src/table/TableConfiguration.ts
+++ b/src/table/TableConfiguration.ts
@@ -4,7 +4,8 @@ import {
   DEFAULT_ENABLE_DEBUG_LOG,
   DEFAULT_TABLE_LISTENING_PORT,
   DEFAULT_TABLE_LOKI_DB_PATH,
-  DEFAULT_TABLE_SERVER_HOST_NAME
+  DEFAULT_TABLE_SERVER_HOST_NAME,
+  DEFAULT_TABLE_KEEP_ALIVE_TIMEOUT
 } from "./utils/constants";
 
 /**
@@ -24,6 +25,7 @@ export default class TableConfiguration extends ConfigurationBase {
   public constructor(
     host: string = DEFAULT_TABLE_SERVER_HOST_NAME,
     port: number = DEFAULT_TABLE_LISTENING_PORT,
+    keepAliveTimeout: number = DEFAULT_TABLE_KEEP_ALIVE_TIMEOUT,
     public readonly /* Store metadata */ metadataDBPath: string = DEFAULT_TABLE_LOKI_DB_PATH,
     enableDebugLog: boolean = DEFAULT_ENABLE_DEBUG_LOG,
     enableAccessLog: boolean = DEFAULT_ENABLE_ACCESS_LOG,
@@ -41,6 +43,7 @@ export default class TableConfiguration extends ConfigurationBase {
     super(
       host,
       port,
+      keepAliveTimeout,
       enableAccessLog,
       accessLogWriteStream,
       enableDebugLog,

--- a/src/table/TableEnvironment.ts
+++ b/src/table/TableEnvironment.ts
@@ -6,7 +6,8 @@ import args from "args";
 import ITableEnvironment from "./ITableEnvironment";
 import {
   DEFAULT_TABLE_LISTENING_PORT,
-  DEFAULT_TABLE_SERVER_HOST_NAME
+  DEFAULT_TABLE_SERVER_HOST_NAME,
+  DEFAULT_TABLE_KEEP_ALIVE_TIMEOUT
 } from "./utils/constants";
 
 args
@@ -19,6 +20,11 @@ args
     ["", "tablePort"],
     "Optional. Customize listening port for table",
     DEFAULT_TABLE_LISTENING_PORT
+  )
+  .option(
+    ["", "tableKeepAliveTimeout"],
+    "Optional. Customize http keep alive timeout for table",
+    DEFAULT_TABLE_KEEP_ALIVE_TIMEOUT,
   )
   .option(
     ["l", "location"],
@@ -68,6 +74,10 @@ export default class TableEnvironment implements ITableEnvironment {
 
   public tablePort(): number | undefined {
     return this.flags.tablePort;
+  }
+
+  public tableKeepAliveTimeout(): number | undefined {
+    return this.flags.tableKeepAvlieTimeout;
   }
 
   public async location(): Promise<string> {

--- a/src/table/main.ts
+++ b/src/table/main.ts
@@ -33,6 +33,7 @@ async function main() {
   const config = new TableConfiguration(
     env.tableHost(),
     env.tablePort(),
+    env.tableKeepAliveTimeout(),
     join(location, DEFAULT_TABLE_LOKI_DB_PATH),
     (await env.debug()) !== undefined,
     !env.silent(),

--- a/src/table/utils/constants.ts
+++ b/src/table/utils/constants.ts
@@ -6,6 +6,7 @@ export const DEFAULT_TABLE_LOKI_DB_PATH = "__azurite_db_table__.json";
 
 export const DEFAULT_TABLE_SERVER_HOST_NAME = "127.0.0.1"; // Change to 0.0.0.0 when needs external access
 export const DEFAULT_TABLE_LISTENING_PORT = 10002;
+export const DEFAULT_TABLE_KEEP_ALIVE_TIMEOUT = 5;
 export const DEFAULT_ENABLE_ACCESS_LOG = true;
 export const DEFAULT_ENABLE_DEBUG_LOG = true;
 export const DEFAULT_TABLE_PERSISTENCE_PATH = "__tablestorage__";

--- a/tests/BlobTestServerFactory.ts
+++ b/tests/BlobTestServerFactory.ts
@@ -4,6 +4,7 @@ import SqlBlobConfiguration from "../src/blob/SqlBlobConfiguration";
 import SqlBlobServer from "../src/blob/SqlBlobServer";
 import { StoreDestinationArray } from "../src/common/persistence/IExtentStore";
 import { DEFAULT_SQL_OPTIONS } from "../src/common/utils/constants";
+import { DEFAULT_BLOB_KEEP_ALIVE_TIMEOUT } from "../src/blob/utils/constants";
 
 export default class BlobTestServerFactory {
   public createServer(
@@ -36,6 +37,7 @@ export default class BlobTestServerFactory {
       const config = new SqlBlobConfiguration(
         host,
         port,
+        DEFAULT_BLOB_KEEP_ALIVE_TIMEOUT,
         databaseConnectionString!,
         DEFAULT_SQL_OPTIONS,
         persistenceArray,
@@ -59,6 +61,7 @@ export default class BlobTestServerFactory {
       const config = new BlobConfiguration(
         host,
         port,
+        DEFAULT_BLOB_KEEP_ALIVE_TIMEOUT,
         lokiMetadataDBPath,
         lokiExtentDBPath,
         persistenceArray,

--- a/tests/queue/utils/QueueTestServerFactory.ts
+++ b/tests/queue/utils/QueueTestServerFactory.ts
@@ -1,6 +1,7 @@
 import { StoreDestinationArray } from "../../../src/common/persistence/IExtentStore"
 import QueueConfiguration from "../../../src/queue/QueueConfiguration"
 import QueueServer from "../../../src/queue/QueueServer"
+import { DEFAULT_QUEUE_KEEP_ALIVE_TIMEOUT } from "../../../src/queue/utils/constants";
 
 export interface IQueueTestServerFactoryParams {
   metadataDBPath: string
@@ -27,6 +28,7 @@ export default class QueueTestServerFactory {
     const config = new QueueConfiguration(
       host,
       port,
+      DEFAULT_QUEUE_KEEP_ALIVE_TIMEOUT,
       params.metadataDBPath,
       params.extentDBPath,
       params.persistencePathArray,

--- a/tests/table/utils/TableTestServerFactory.ts
+++ b/tests/table/utils/TableTestServerFactory.ts
@@ -1,5 +1,6 @@
 import TableConfiguration from "../../../src/table/TableConfiguration";
 import TableServer from "../../../src/table/TableServer";
+import { DEFAULT_TABLE_KEEP_ALIVE_TIMEOUT } from "../../../src/table/utils/constants";
 
 export interface ITableTestServerFactoryParams {
   metadataDBPath: string
@@ -28,6 +29,7 @@ export default class TableTestServerFactory {
     const config = new TableConfiguration(
       host,
       port,
+      DEFAULT_TABLE_KEEP_ALIVE_TIMEOUT,
       params.metadataDBPath,
       params.enableDebugLog,
       false,


### PR DESCRIPTION
fix https://github.com/Azure/Azurite/issues/2053 
workaround for https://github.com/ClickHouse/ClickHouse/issues/60447

we use azurite for Azure BLOB storage in our integration tests
Azure CPP Sdk (or it usage on clickhouse-server side) don't respect `Keep-Alive: 5` header which sent from azurite side, and continue to make request to already closed connection after 5 seconds, this header sent from standard nodejs http library

We are going to fix this behavior in the next version of `clickhouse-server`
but currently to allow pass e2e tests, we would like to propose adding cli option and config settings to allow increase value for Keep-Alive header

we tested these changes and it actually works, hope your CI/CD pipelines also will pass
