### PR TITLE
Fixed failing test on Windows caused by #2433

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ General:
 
 - Bump mysql2 to resolve to 3.10.1 for security patches
 - Fixed an issue where premature client disconnections led to all following requests failing with a 500 error. (issue #1346) 
+- Fixed an issue on Windows where the file position was not being reset following a premature client disconnection.
 
 Blob:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,6 @@ General:
 
 - Bump mysql2 to resolve to 3.10.1 for security patches
 - Fixed an issue where premature client disconnections led to all following requests failing with a 500 error. (issue #1346) 
-- Fixed an issue on Windows where the file position was not being reset following a premature client disconnection.
 
 Blob:
 


### PR DESCRIPTION
On Windows to truncate the file, which is opened in append mode, the file first needs to be closed. Expanded the test case to include another valid extent, this time prior to failed update.

This addresses the [comment](https://github.com/Azure/Azurite/pull/2433#issuecomment-2262591113) in #2433.

Thanks for contribution! Please go through following checklist before sending PR.

### PR Branch Destination

- For Azurite V3, please send PR to `main` branch.
- For legacy Azurite V2, please send PR to `legacy-dev` branch.

### Always Add Test Cases

Make sure test cases are added to cover the code change.

### Add Change Log

Add change log for the code change in `Upcoming Release` section in `ChangeLog.md`.

### Development Guideline

Please go to CONTRIBUTION.md for steps about setting up development environment and recommended Visual Studio Code extensions.
