### PR TITLE
Download 0 size blob with range > 0 should has header "Content-Range: bytes \*/0" in returned error

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,13 +7,14 @@
 Blob:
 
 - Fixed an issue where all blob APIs allowed metadata names which were not valid C# identifiers.
+- Fixed issue of download 0 size blob with range > 0 should has header "Content-Range: bytes \*/0" in returned error. (issue #2458)
 
 ## 2024.08 Version 3.32.0
 
 General:
 
 - Bump mysql2 to resolve to 3.10.1 for security patches
-- Fixed an issue where premature client disconnections led to all following requests failing with a 500 error. (issue #1346) 
+- Fixed an issue where premature client disconnections led to all following requests failing with a 500 error. (issue #1346)
 - Bump up service API version to 2024-11-04
 
 Blob:

--- a/src/blob/errors/StorageErrorFactory.ts
+++ b/src/blob/errors/StorageErrorFactory.ts
@@ -199,13 +199,18 @@ export default class StorageErrorFactory {
     );
   }
 
-  public static getInvalidPageRange2(contextID: string): StorageError {
-    return new StorageError(
+  public static getInvalidPageRange2(contextID: string, contentRange?: string): StorageError {
+    let returnValue = new StorageError(
       416,
       "InvalidRange",
       "The range specified is invalid for the current size of the resource.",
       contextID
-    );
+    ); 
+    if(contentRange)
+    {
+      returnValue.headers!["Content-Range"] = contentRange;
+    }
+    return returnValue;
   }
 
   public static getInvalidLeaseDuration(

--- a/src/blob/handlers/BlobHandler.ts
+++ b/src/blob/handlers/BlobHandler.ts
@@ -1010,14 +1010,14 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
 
     // Start Range is bigger than blob length
     if (rangeStart > blob.properties.contentLength!) {
-      throw StorageErrorFactory.getInvalidPageRange(context.contextId!);
+      throw StorageErrorFactory.getInvalidPageRange2(context.contextId!,`bytes */${blob.properties.contentLength}`);
     }
 
     // Will automatically shift request with longer data end than blob size to blob size
     if (rangeEnd + 1 >= blob.properties.contentLength!) {
       // report error is blob size is 0, and rangeEnd is specified but not 0 
       if (blob.properties.contentLength == 0 && rangeEnd !== 0 && rangeEnd !== Infinity) {
-        throw StorageErrorFactory.getInvalidPageRange2(context.contextId!);
+        throw StorageErrorFactory.getInvalidPageRange2(context.contextId!,`bytes */${blob.properties.contentLength}`);
       }
       else {
         rangeEnd = blob.properties.contentLength! - 1;
@@ -1141,14 +1141,14 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
 
     // Start Range is bigger than blob length
     if (rangeStart > blob.properties.contentLength!) {
-      throw StorageErrorFactory.getInvalidPageRange(context.contextId!);
+      throw StorageErrorFactory.getInvalidPageRange2(context.contextId!,`bytes */${blob.properties.contentLength}`);
     }
 
     // Will automatically shift request with longer data end than blob size to blob size
     if (rangeEnd + 1 >= blob.properties.contentLength!) {
       // report error is blob size is 0, and rangeEnd is specified but not 0 
       if (blob.properties.contentLength == 0 && rangeEnd !== 0 && rangeEnd !== Infinity) {
-        throw StorageErrorFactory.getInvalidPageRange2(context.contextId!);
+        throw StorageErrorFactory.getInvalidPageRange2(context.contextId!,`bytes */${blob.properties.contentLength}`);
       }
       else {
         rangeEnd = blob.properties.contentLength! - 1;

--- a/tests/blob/apis/blockblob.test.ts
+++ b/tests/blob/apis/blockblob.test.ts
@@ -372,6 +372,7 @@ describe("BlockBlobAPIs", () => {
       await blockBlobClient.download(0, 3);
     } catch (error) {
       assert.deepStrictEqual(error.statusCode, 416);
+      assert.deepStrictEqual(error.response.headers.get("content-range"), 'bytes */0')
       return;
     }
     assert.fail();

--- a/tests/blob/apis/pageblob.test.ts
+++ b/tests/blob/apis/pageblob.test.ts
@@ -303,6 +303,7 @@ describe("PageBlobAPIs", () => {
       await pageBlobClient.download(0, 3);
     } catch (error) {
       assert.deepStrictEqual(error.statusCode, 416);
+      assert.deepStrictEqual(error.response.headers.get("content-range"), 'bytes */0')
       return;
     }
     assert.fail();


### PR DESCRIPTION
Thanks for contribution! Please go through following checklist before sending PR.

Fix https://github.com/Azure/Azurite/issues/2458

### PR Branch Destination

- For Azurite V3, please send PR to `main` branch.
- For legacy Azurite V2, please send PR to `legacy-dev` branch.

### Always Add Test Cases

Make sure test cases are added to cover the code change.

### Add Change Log

Add change log for the code change in `Upcoming Release` section in `ChangeLog.md`.

### Development Guideline

Please go to CONTRIBUTION.md for steps about setting up development environment and recommended Visual Studio Code extensions.
