### PR TITLE
Ignore invalid range in blob download

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,8 @@
 Blob:
 
 - Fixed an issue where all blob APIs allowed metadata names which were not valid C# identifiers.
-- Fixed issue of download 0 size blob with range > 0 should has header "Content-Range: bytes \*/0" in returned error. (issue #2458)
+- Fixed issue of download 0 size blob with range > 0 should have header "Content-Range: bytes \*/0" in returned error. (issue #2458)
+- Aligned behavior with Azure to ignore invalid range requests for blob downloads. (issue #2458)
 
 ## 2024.08 Version 3.32.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,13 +7,14 @@
 Blob:
 
 - Fixed an issue where all blob APIs allowed metadata names which were not valid C# identifiers.
+- Fixed issue of download 0 size blob with range > 0 should has header "Content-Range: bytes \*/0" in returned error. (issue #2458)
 
 ## 2024.08 Version 3.32.0
 
 General:
 
 - Bump mysql2 to resolve to 3.10.1 for security patches
-- Fixed an issue where premature client disconnections led to all following requests failing with a 500 error. (issue #1346) 
+- Fixed an issue where premature client disconnections led to all following requests failing with a 500 error. (issue #1346)
 - Bump up service API version to 2024-11-04
 
 Blob:

--- a/src/blob/errors/StorageErrorFactory.ts
+++ b/src/blob/errors/StorageErrorFactory.ts
@@ -199,13 +199,18 @@ export default class StorageErrorFactory {
     );
   }
 
-  public static getInvalidPageRange2(contextID: string): StorageError {
-    return new StorageError(
+  public static getInvalidPageRange2(contextID: string, contentRange?: string): StorageError {
+    let returnValue = new StorageError(
       416,
       "InvalidRange",
       "The range specified is invalid for the current size of the resource.",
       contextID
-    );
+    ); 
+    if(contentRange)
+    {
+      returnValue.headers!["Content-Range"] = contentRange;
+    }
+    return returnValue;
   }
 
   public static getInvalidLeaseDuration(

--- a/src/blob/handlers/BlobHandler.ts
+++ b/src/blob/handlers/BlobHandler.ts
@@ -1010,14 +1010,14 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
 
     // Start Range is bigger than blob length
     if (rangeStart > blob.properties.contentLength!) {
-      throw StorageErrorFactory.getInvalidPageRange(context.contextId!);
+      throw StorageErrorFactory.getInvalidPageRange2(context.contextId!,`bytes */${blob.properties.contentLength}`);
     }
 
     // Will automatically shift request with longer data end than blob size to blob size
     if (rangeEnd + 1 >= blob.properties.contentLength!) {
       // report error is blob size is 0, and rangeEnd is specified but not 0 
       if (blob.properties.contentLength == 0 && rangeEnd !== 0 && rangeEnd !== Infinity) {
-        throw StorageErrorFactory.getInvalidPageRange2(context.contextId!);
+        throw StorageErrorFactory.getInvalidPageRange2(context.contextId!,`bytes */${blob.properties.contentLength}`);
       }
       else {
         rangeEnd = blob.properties.contentLength! - 1;
@@ -1141,14 +1141,14 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
 
     // Start Range is bigger than blob length
     if (rangeStart > blob.properties.contentLength!) {
-      throw StorageErrorFactory.getInvalidPageRange(context.contextId!);
+      throw StorageErrorFactory.getInvalidPageRange2(context.contextId!,`bytes */${blob.properties.contentLength}`);
     }
 
     // Will automatically shift request with longer data end than blob size to blob size
     if (rangeEnd + 1 >= blob.properties.contentLength!) {
       // report error is blob size is 0, and rangeEnd is specified but not 0 
       if (blob.properties.contentLength == 0 && rangeEnd !== 0 && rangeEnd !== Infinity) {
-        throw StorageErrorFactory.getInvalidPageRange2(context.contextId!);
+        throw StorageErrorFactory.getInvalidPageRange2(context.contextId!,`bytes */${blob.properties.contentLength}`);
       }
       else {
         rangeEnd = blob.properties.contentLength! - 1;

--- a/src/blob/utils/utils.ts
+++ b/src/blob/utils/utils.ts
@@ -40,10 +40,10 @@ export async function streamToLocalFile(
 export function deserializeRangeHeader(
   rangeHeaderValue?: string,
   xMsRangeHeaderValue?: string
-): [number, number] {
+): [number, number] | undefined {
   const range = xMsRangeHeaderValue || rangeHeaderValue;
   if (!range) {
-    return [0, Infinity];
+    return undefined;
   }
 
   let parts = range.split("=");
@@ -93,8 +93,8 @@ export function deserializePageBlobRangeHeader(
   force512boundary = true
 ): [number, number] {
   const ranges = deserializeRangeHeader(rangeHeaderValue, xMsRangeHeaderValue);
-  const startInclusive = ranges[0];
-  const endInclusive = ranges[1];
+  const startInclusive = ranges ? ranges[0] : 0;
+  const endInclusive = ranges ? ranges[1] : Infinity;
 
   if (force512boundary && startInclusive % 512 !== 0) {
     throw new RangeError(

--- a/tests/blob/RequestPolicy/RangePolicyFactory.ts
+++ b/tests/blob/RequestPolicy/RangePolicyFactory.ts
@@ -1,0 +1,35 @@
+import { BaseRequestPolicy, WebResource } from "@azure/storage-blob";
+
+// Create a policy factory with create() method provided
+// In TypeScript, following factory class needs to implement Azure.RequestPolicyFactory type
+export default class RangePolicyFactory {
+  // Constructor to accept parameters
+  private range: string;
+
+  constructor(range: any) {
+    this.range = range;
+  }
+
+  // create() method needs to create a new RequestIDPolicy object
+  create(nextPolicy: any, options: any) {
+    return new RangePolicy(nextPolicy, options, this.range);
+  }
+}
+
+// Create a policy by extending from Azure.BaseRequestPolicy
+class RangePolicy extends BaseRequestPolicy {
+  private range: string;
+
+  constructor(nextPolicy: any, options: any, range: any) {
+    super(nextPolicy, options);
+    this.range = range;
+  }
+
+  // Customize HTTP requests and responses by overriding sendRequest
+  // Parameter request is Azure.WebResource type
+  async sendRequest(request: WebResource) {
+    request.headers.set("Range", `${this.range}`);
+
+    return await this._nextPolicy.sendRequest(request);
+  }
+}

--- a/tests/blob/apis/blob.test.ts
+++ b/tests/blob/apis/blob.test.ts
@@ -18,6 +18,7 @@ import {
   getUniqueName,
   sleep
 } from "../../testutils";
+import RangePolicyFactory from "../RequestPolicy/RangePolicyFactory";
 
 // Set true to enable debug log
 configLogger(false);
@@ -300,6 +301,62 @@ describe("BlobAPIs", () => {
       return;
     }
     assert.fail();
+  });
+
+  it("download invalid range @loki @sql", async () => {
+    const pipeline = newPipeline(
+      new StorageSharedKeyCredential(
+        EMULATOR_ACCOUNT_NAME,
+        EMULATOR_ACCOUNT_KEY
+      ),
+      {
+        retryOptions: { maxTries: 1 },
+        // Make sure socket is closed once the operation is done.
+        keepAliveOptions: { enable: false }
+      }
+    );
+    pipeline.factories.unshift(
+      new RangePolicyFactory("bytes=0--1")
+    );
+    const serviceClient = new BlobServiceClient(baseURL, pipeline);
+    const containerClient = serviceClient.getContainerClient(containerName);
+    const blobClient = containerClient.getBlobClient(blobName);
+
+    const result = await blobClient.download(0);
+    assert.deepStrictEqual(await bodyToString(result, content.length), content);
+    assert.equal(result.contentRange, undefined);
+    assert.equal(
+      result._response.request.headers.get("x-ms-client-request-id"),
+      result.clientRequestId
+    );
+  });
+
+  it("download partial range (via custom policy) @loki @sql", async () => {
+    const pipeline = newPipeline(
+      new StorageSharedKeyCredential(
+        EMULATOR_ACCOUNT_NAME,
+        EMULATOR_ACCOUNT_KEY
+      ),
+      {
+        retryOptions: { maxTries: 1 },
+        // Make sure socket is closed once the operation is done.
+        keepAliveOptions: { enable: false }
+      }
+    );
+    pipeline.factories.unshift(
+      new RangePolicyFactory("bytes=0-4")
+    );
+    const serviceClient = new BlobServiceClient(baseURL, pipeline);
+    const containerClient = serviceClient.getContainerClient(containerName);
+    const blobClient = containerClient.getBlobClient(blobName);
+
+    const result = await blobClient.download(0);
+    assert.deepStrictEqual(await bodyToString(result, content.length), content.substring(0, 5));
+    assert.equal(result.contentRange, `bytes 0-4/${content.length}`);
+    assert.equal(
+      result._response.request.headers.get("x-ms-client-request-id"),
+      result.clientRequestId
+    );
   });
 
   it("get properties response should not set content-type @loki @sql", async () => {

--- a/tests/blob/apis/blockblob.test.ts
+++ b/tests/blob/apis/blockblob.test.ts
@@ -372,6 +372,7 @@ describe("BlockBlobAPIs", () => {
       await blockBlobClient.download(0, 3);
     } catch (error) {
       assert.deepStrictEqual(error.statusCode, 416);
+      assert.deepStrictEqual(error.response.headers.get("content-range"), 'bytes */0')
       return;
     }
     assert.fail();

--- a/tests/blob/apis/pageblob.test.ts
+++ b/tests/blob/apis/pageblob.test.ts
@@ -303,6 +303,7 @@ describe("PageBlobAPIs", () => {
       await pageBlobClient.download(0, 3);
     } catch (error) {
       assert.deepStrictEqual(error.statusCode, 416);
+      assert.deepStrictEqual(error.response.headers.get("content-range"), 'bytes */0')
       return;
     }
     assert.fail();


### PR DESCRIPTION
Fix #2458, based on #2461

I'm not sure how to provoke an invalid range header in the unit tests; @blueww can you give me a hint?