### PR TITLE
Activate only on command or Azurite file presence

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,9 @@
     "vsce": "^2.7.0"
   },
   "activationEvents": [
-    "*",
+    "workspaceContains:__azurite*.json",
+    "workspaceContains:__blobstorage__",
+    "workspaceContains:__queuestroage__",
     "onCommand:azurite.start",
     "onCommand:azurite.close",
     "onCommand:azurite.clean",

--- a/package.json
+++ b/package.json
@@ -89,21 +89,7 @@
     "vsce": "^2.7.0"
   },
   "activationEvents": [
-    "workspaceContains:__azurite*.json",
-    "workspaceContains:__blobstorage__",
-    "workspaceContains:__queuestroage__",
-    "onCommand:azurite.start",
-    "onCommand:azurite.close",
-    "onCommand:azurite.clean",
-    "onCommand:azurite.start_blob",
-    "onCommand:azurite.close_blob",
-    "onCommand:azurite.clean_blob",
-    "onCommand:azurite.start_queue",
-    "onCommand:azurite.close_queue",
-    "onCommand:azurite.clean_queue",
-    "onCommand:azurite.start_table",
-    "onCommand:azurite.close_table",
-    "onCommand:azurite.clean_table"
+    "onStartupFinished"
   ],
   "contributes": {
     "commands": [


### PR DESCRIPTION
Closes https://github.com/Azure/Azurite/issues/2467

## Note
Optionally this could additionally add `onStartupFinished` and that will at least minimise the performance impact of Azurite on vscode startup, however if you're going to do that, no point in having any of the other activation events and they should all be removed.

Potentially considered a breaking change because a "new" workspace won't activate the extension and people may be used to seeing the blob/table/etc. links in the bottom status tray and they won't show up until you run an azurite command. Once run however and the azurite files are present in the workspace, it will auto-start from then on for the project.