### PR TITLE
Handle getting zero-length blobs with `Content-Range`

### DIFF
--- a/src/blob/errors/StorageError.ts
+++ b/src/blob/errors/StorageError.ts
@@ -29,7 +29,8 @@ export default class StorageError extends MiddlewareError {
     storageErrorCode: string,
     storageErrorMessage: string,
     storageRequestID: string,
-    storageAdditionalErrorMessages: { [key: string]: string } = {}
+    storageAdditionalErrorMessages: { [key: string]: string } = {},
+    additionalHeaders: { [key: string]: string } = {}
   ) {
     const bodyInJSON: any = {
       Code: storageErrorCode,
@@ -51,7 +52,8 @@ export default class StorageError extends MiddlewareError {
       storageErrorMessage,
       {
         "x-ms-error-code": storageErrorCode,
-        "x-ms-request-id": storageRequestID
+        "x-ms-request-id": storageRequestID,
+        ...additionalHeaders
       },
       bodyInXML,
       "application/xml"

--- a/src/blob/errors/StorageErrorFactory.ts
+++ b/src/blob/errors/StorageErrorFactory.ts
@@ -199,12 +199,14 @@ export default class StorageErrorFactory {
     );
   }
 
-  public static getInvalidPageRange2(contextID: string): StorageError {
+  public static getInvalidPageRange2(contextID: string, additionalHeaders?: { [key: string]: string }): StorageError {
     return new StorageError(
       416,
       "InvalidRange",
       "The range specified is invalid for the current size of the resource.",
-      contextID
+      contextID,
+      {},
+      additionalHeaders
     );
   }
 

--- a/src/blob/handlers/BlobHandler.ts
+++ b/src/blob/handlers/BlobHandler.ts
@@ -1017,7 +1017,10 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
     if (rangeEnd + 1 >= blob.properties.contentLength!) {
       // report error is blob size is 0, and rangeEnd is specified but not 0 
       if (blob.properties.contentLength == 0 && rangeEnd !== 0 && rangeEnd !== Infinity) {
-        throw StorageErrorFactory.getInvalidPageRange2(context.contextId!);
+        throw StorageErrorFactory.getInvalidPageRange2(context.contextId!, { "content-range": "bytes * /0" });
+      }
+      else if (blob.properties.contentLength == 0 && rangeEnd <= 0) {
+        rangeEnd = 0;
       }
       else {
         rangeEnd = blob.properties.contentLength! - 1;
@@ -1084,7 +1087,7 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
     }
 
     const response: Models.BlobDownloadResponse = {
-      statusCode: contentRange ? 206 : 200,
+      statusCode: (rangeStart != 0 && rangeEnd != 0 && contentRange) ? 206 : 200,
       body,
       metadata: blob.metadata,
       eTag: blob.properties.etag,
@@ -1148,7 +1151,7 @@ export default class BlobHandler extends BaseHandler implements IBlobHandler {
     if (rangeEnd + 1 >= blob.properties.contentLength!) {
       // report error is blob size is 0, and rangeEnd is specified but not 0 
       if (blob.properties.contentLength == 0 && rangeEnd !== 0 && rangeEnd !== Infinity) {
-        throw StorageErrorFactory.getInvalidPageRange2(context.contextId!);
+        throw StorageErrorFactory.getInvalidPageRange2(context.contextId!, { "content-range": "bytes * /0" });
       }
       else {
         rangeEnd = blob.properties.contentLength! - 1;

--- a/src/blob/utils/utils.ts
+++ b/src/blob/utils/utils.ts
@@ -54,7 +54,7 @@ export function deserializeRangeHeader(
     );
   }
 
-  parts = parts[1].split("-");
+  parts = parts[1].split("-", 2);
   if (parts === undefined || parts.length < 1 || parts.length > 2) {
     throw new RangeError(
       `deserializeRangeHeader: raw range value ${range} is wrong.`


### PR DESCRIPTION
This behavior matches Azure.  AWS Java SDK probes for a zero-length blob when a request with a Content-Range fails.