### PR TITLE
Fix manual test failure with mocha upgrade, and remove the build status link since the pipeline is removed.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -152,7 +152,7 @@
       "args": [
         "${workspaceFolder}/node_modules/mocha/bin/_mocha",
         "-u",
-        "tdd",
+        "bdd",
         "--timeout",
         "999999",
         "--colors",
@@ -179,7 +179,7 @@
       "args": [
         "${workspaceFolder}/node_modules/mocha/bin/_mocha",
         "-u",
-        "tdd",
+        "bdd",
         "--timeout",
         "999999",
         "--colors",
@@ -203,7 +203,7 @@
       "args": [
         "${workspaceFolder}/node_modules/mocha/bin/_mocha",
         "-u",
-        "tdd",
+        "bdd",
         "--timeout",
         "999999",
         "--colors",
@@ -226,7 +226,7 @@
       "args": [
         "${workspaceFolder}/node_modules/mocha/bin/_mocha",
         "-u",
-        "tdd",
+        "bdd",
         "--timeout",
         "999999",
         "--colors",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Azurite V3
 
 [![npm version](https://badge.fury.io/js/azurite.svg)](https://badge.fury.io/js/azurite)
-[![Build Status](https://dev.azure.com/azure/Azurite/_apis/build/status/Azure.Azurite?branchName=main)](https://dev.azure.com/azure/Azurite/_build/latest?definitionId=105&branchName=main)
 
 > Note:
 > The latest Azurite V3 code, which supports Blob, Queue, and Table (preview) is in the main branch.


### PR DESCRIPTION
Azurite Unit test style is "BDD" instead of "TDD", but launch.json use "TDD" . Althrough it works in before macha version, after upgrade mocha the manual test fail with "ReferenceError: describe is not defined", since macha can't recognize the test file.

See [BDD](https://mochajs.org/#bdd)

- The BDD interface provides describe(), context(), it(), specify(), before(), after(), beforeEach(), and afterEach().
- The TDD interface provides suite(), test(), suiteSetup(), suiteTeardown(), setup(), and teardown()

Thanks for contribution! Please go through following checklist before sending PR.

### PR Branch Destination

- For Azurite V3, please send PR to `main` branch.
- For legacy Azurite V2, please send PR to `legacy-dev` branch.

### Always Add Test Cases

Make sure test cases are added to cover the code change.

### Add Change Log

Add change log for the code change in `Upcoming Release` section in `ChangeLog.md`.

### Development Guideline

Please go to CONTRIBUTION.md for steps about setting up development environment and recommended Visual Studio Code extensions.
