### PR TITLE
Change the responds status code for not implemented API from 500 to 501 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 ## Upcoming Release
 
+General:
+
+- Changed the responds status code of not implemented API from 500 to 501.
+
 Blob:
 
 - GetBlob on Archive tier blobs now fails as expected.

--- a/src/blob/errors/NotImplementedError.ts
+++ b/src/blob/errors/NotImplementedError.ts
@@ -10,9 +10,27 @@ import StorageError from "./StorageError";
 export default class NotImplementedError extends StorageError {
   public constructor(requestID: string = "") {
     super(
-      500,
+      501,
       "APINotImplemented",
       "Current API is not implemented yet. Please vote your wanted features to https://github.com/azure/azurite/issues",
+      requestID
+    );
+  }
+}
+
+/**
+ * Create customized error types by inheriting ServerError
+ *
+ * @export
+ * @class UnimplementedError
+ * @extends {StorageError}
+ */
+export class NotImplementedinSQLError extends StorageError {
+  public constructor(requestID: string = "") {
+    super(
+      501,
+      "APINotImplemented",
+      "Current API is not implemented yet when use a SQL database based metadata storage. Please vote your wanted features to https://github.com/azure/azurite/issues",
       requestID
     );
   }

--- a/src/blob/persistence/SqlBlobMetadataStore.ts
+++ b/src/blob/persistence/SqlBlobMetadataStore.ts
@@ -71,6 +71,7 @@ import PageWithDelimiter from "./PageWithDelimiter";
 import FilterBlobPage from "./FilterBlobPage";
 import { getBlobTagsCount, getTagsFromString, toBlobTags } from "../utils/utils";
 import { generateQueryBlobWithTagsWhereFunction } from "./QueryInterpreter/QueryInterpreter";
+import { NotImplementedinSQLError } from "../errors/NotImplementedError";
 
 // tslint:disable: max-classes-per-file
 class ServicesModel extends Model { }
@@ -1831,7 +1832,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
   }
 
   public undeleteBlob(): Promise<void> {
-    throw new Error("Method not implemented.");
+    throw new NotImplementedinSQLError();
   }
 
   public async createSnapshot(
@@ -2756,7 +2757,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     copySource: string,
     metadata: Models.BlobMetadata | undefined
   ): Promise<Models.BlobPropertiesInternal> {
-    throw new Error("Method not implemented.");
+    throw new NotImplementedinSQLError(context.contextId);
   }
 
   public setTier(
@@ -2866,7 +2867,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     leaseAccessConditions?: Models.LeaseAccessConditions,
     modifiedAccessConditions?: Models.ModifiedAccessConditions
   ): Promise<Models.BlobPropertiesInternal> {
-    throw new Error("Method not implemented.");
+    throw new NotImplementedinSQLError(context.contextId);
   }
 
   public clearRange(
@@ -2877,7 +2878,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     leaseAccessConditions?: Models.LeaseAccessConditions,
     modifiedAccessConditions?: Models.ModifiedAccessConditions
   ): Promise<Models.BlobPropertiesInternal> {
-    throw new Error("Method not implemented.");
+    throw new NotImplementedinSQLError(context.contextId);
   }
 
   public getPageRanges(
@@ -2889,7 +2890,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     leaseAccessConditions?: Models.LeaseAccessConditions,
     modifiedAccessConditions?: Models.ModifiedAccessConditions
   ): Promise<GetPageRangeResponse> {
-    throw new Error("Method not implemented.");
+    throw new NotImplementedinSQLError(context.contextId);
   }
 
   public resizePageBlob(
@@ -2901,7 +2902,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     leaseAccessConditions?: Models.LeaseAccessConditions,
     modifiedAccessConditions?: Models.ModifiedAccessConditions
   ): Promise<Models.BlobPropertiesInternal> {
-    throw new Error("Method not implemented.");
+    throw new NotImplementedinSQLError(context.contextId);
   }
 
   public updateSequenceNumber(
@@ -2912,7 +2913,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     sequenceNumberAction: Models.SequenceNumberActionType,
     blobSequenceNumber: number | undefined
   ): Promise<Models.BlobPropertiesInternal> {
-    throw new Error("Method not implemented.");
+    throw new NotImplementedinSQLError(context.contextId);
   }
 
   public appendBlock(
@@ -2924,7 +2925,7 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
       | Models.AppendPositionAccessConditions
       | undefined
   ): Promise<Models.BlobPropertiesInternal> {
-    throw new Error("Method not implemented.");
+    throw new NotImplementedinSQLError(context.contextId);
   }
 
   public async listUncommittedBlockPersistencyChunks(

--- a/src/queue/errors/NotImplementedError.ts
+++ b/src/queue/errors/NotImplementedError.ts
@@ -10,7 +10,7 @@ import StorageError from "./StorageError";
 export default class NotImplementedError extends StorageError {
   public constructor(requestID: string = "") {
     super(
-      500,
+      501,
       "APINotImplemented",
       "Current API is not implemented yet. Please vote your wanted features to https://github.com/azure/azurite/issues",
       requestID


### PR DESCRIPTION
Per the suggestion of https://github.com/Azure/Azurite/issues/810#issuecomment-2545435163, change the responds status code for not implemented API from 500 to 501. (only change B/Q, since Table already use 501)

I have tested with .net SDK, after the change, .net SDK won't retry on the not implemented API and will fail faster.


Thanks for contribution! Please go through following checklist before sending PR.

### PR Branch Destination

- For Azurite V3, please send PR to `main` branch.
- For legacy Azurite V2, please send PR to `legacy-dev` branch.

### Always Add Test Cases

Make sure test cases are added to cover the code change.

### Add Change Log

Add change log for the code change in `Upcoming Release` section in `ChangeLog.md`.

### Development Guideline

Please go to CONTRIBUTION.md for steps about setting up development environment and recommended Visual Studio Code extensions.
