### PR TITLE
Fixed `Unexpected EOF` error when batch InsertReplace table entities with Go SDK (issue #2519)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,10 @@ Blob:
 
 - GetBlob on Archive tier blobs now fails as expected.
 
+Table:
+
+- Fixed "Unexpected EOF" error when batch InsertReplace entities with Go SDK (issue #2519)
+
 ## 2024.10 Version 3.33.0
 
 General:

--- a/src/table/batch/TableBatchSerialization.ts
+++ b/src/table/batch/TableBatchSerialization.ts
@@ -176,7 +176,7 @@ export class TableBatchSerialization extends BatchSerialization {
       this.SerializeEntityPath(serializedResponses, request);
 
     if (null !== response.eTag && undefined !== response.eTag) {
-      serializedResponses += "ETag: " + response.eTag;
+      serializedResponses += "ETag: " + response.eTag + "\r\n";
     }
     return serializedResponses;
   }
@@ -251,7 +251,7 @@ export class TableBatchSerialization extends BatchSerialization {
     );
 
     if (null !== response.eTag && undefined !== response.eTag) {
-      serializedResponses += "ETag: " + response.eTag;
+      serializedResponses += "ETag: " + response.eTag + "\r\n";
     }
     return serializedResponses;
   }

--- a/tests/table/go/main.go
+++ b/tests/table/go/main.go
@@ -1,28 +1,29 @@
 package main
 
 import (
-    "context"
-    "encoding/json"
+	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
-    "fmt"
-    "time"
-    "github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-    "github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
-	"github.com/google/uuid"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
 	"github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/google/uuid"
 )
 
 /*
 This simple test written in go uses the Azure Table Storage SDK for Go to create a table,
 insert some entities as a batch, and query the table for those entities.
 This is to reproduce and ensure that we have not introduced any MIME Serialization bugs for
-the Azure Go SDK.  
+the Azure Go SDK.
 I use the modified samples from the SDK and the Go SDK team to create this test and validate
 the behavior of Azurite:
 https://github.com/Azure/azure-sdk-for-go/tree/sdk/data/aztables/v1.0.1/sdk/data/aztables/
 */
 func main() {
-	var svc *aztables.ServiceClient 
+	var svc *aztables.ServiceClient
 	// use a unique table name for each test run
 	tableName := "go" + strings.Replace(uuid.New().String(), "-", "", -1)
 	svc = login()
@@ -36,24 +37,24 @@ func main() {
 /*
 Creates the service client for Azurite
 */
-func login() (*aztables.ServiceClient) {
-    connStr := "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;"
-    svc, err := aztables.NewServiceClientFromConnectionString(connStr, nil)
-    handle(err)
+func login() *aztables.ServiceClient {
+	connStr := "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;"
+	svc, err := aztables.NewServiceClientFromConnectionString(connStr, nil)
+	handle(err)
 	return svc
 }
 
 func createTable(svc *aztables.ServiceClient, tableName string) {
 	_, err := svc.CreateTable(context.TODO(), tableName, nil)
-    handle(err)
+	handle(err)
 }
 
 /*
 Create a client for the table to be able to create entities etc.
 */
-func createTableClient(service *aztables.ServiceClient, tableName string) (*aztables.Client) {
+func createTableClient(service *aztables.ServiceClient, tableName string) *aztables.Client {
 	client := service.NewClient(tableName)
-	
+
 	return client
 }
 
@@ -61,25 +62,25 @@ func createTableClient(service *aztables.ServiceClient, tableName string) (*azta
 Inserts several entities, using SDK's aztables modules for Go
 */
 func insertSimple(client *aztables.Client) {
-	
+
 	for i := 0; i < 10; i++ {
-		
+
 		entity := createEntity(i)
-	
+
 		marshalled, err := json.Marshal(entity)
 		handle(err)
-		
+
 		_, err = client.AddEntity(context.TODO(), marshalled, nil)
 		handle(err)
 	}
-    
+
 }
 
-func createEntity(i int)(aztables.EDMEntity){
+func createEntity(i int) aztables.EDMEntity {
 	return aztables.EDMEntity{
 		Entity: aztables.Entity{
-		PartitionKey: "pencils",
-		RowKey:       fmt.Sprintf("%d", i),
+			PartitionKey: "pencils",
+			RowKey:       fmt.Sprintf("%d", i),
 		},
 		Properties: map[string]interface{}{
 			"Product":      "Ticonderoga Pencils",
@@ -108,6 +109,17 @@ func insertBatch(tableName string, partitionkey string, rowkey string) {
 
 	t := ts.GetTableReference("InsertBatchTestTable")
 
+	tb := t.NewBatch()
+
+	// insert
+	entity1 := t.GetEntityReference(partitionkey, "rowkey1")
+	tb.InsertEntity(entity1)
+
+	// InsertOrReplace
+	entity2 := t.GetEntityReference(partitionkey, `rowkey2`)
+	tb.InsertOrReplaceEntity(entity2, true)
+
+	//InsertOrMerge
 	entity := t.GetEntityReference(partitionkey, rowkey)
 
 	props := map[string]interface{}{
@@ -119,8 +131,6 @@ func insertBatch(tableName string, partitionkey string, rowkey string) {
 	}
 
 	entity.Properties = props
-
-	tb := t.NewBatch()
 
 	tb.InsertOrMergeEntity(entity, true)
 
@@ -144,29 +154,29 @@ func insertBatch(tableName string, partitionkey string, rowkey string) {
 func query(client *aztables.Client) {
 
 	filter := "PartitionKey eq 'pencils'"
-    options := &aztables.ListEntitiesOptions{
-        Filter: &filter,
-        Select: to.Ptr("RowKey,Value,Product,Available"),
-        Top: to.Ptr(int32(15)),
-    }
+	options := &aztables.ListEntitiesOptions{
+		Filter: &filter,
+		Select: to.Ptr("RowKey,Value,Product,Available"),
+		Top:    to.Ptr(int32(15)),
+	}
 
-    pager := client.NewListEntitiesPager(options)
-    pageCount := 0
-    for pager.More() {
-        response, err := pager.NextPage(context.TODO())
-        handle(err)
+	pager := client.NewListEntitiesPager(options)
+	pageCount := 0
+	for pager.More() {
+		response, err := pager.NextPage(context.TODO())
+		handle(err)
 
-        fmt.Printf("There are %d entities in page #%d\n", len(response.Entities), pageCount)
-        pageCount += 1
+		fmt.Printf("There are %d entities in page #%d\n", len(response.Entities), pageCount)
+		pageCount += 1
 
-        for _, entity := range response.Entities {
-            var myEntity aztables.EDMEntity
-            err = json.Unmarshal(entity, &myEntity)
-            handle(err)
+		for _, entity := range response.Entities {
+			var myEntity aztables.EDMEntity
+			err = json.Unmarshal(entity, &myEntity)
+			handle(err)
 
-            fmt.Printf("Received: %v, %v, %v, %v\n", myEntity.RowKey, myEntity.Properties["Value"], myEntity.Properties["Product"], myEntity.Properties["Available"])
-        }
-    }
+			fmt.Printf("Received: %v, %v, %v, %v\n", myEntity.RowKey, myEntity.Properties["Value"], myEntity.Properties["Product"], myEntity.Properties["Available"])
+		}
+	}
 }
 
 func handle(err error) {


### PR DESCRIPTION
Fix issue : https://github.com/Azure/Azurite/issues/2519

currently latest Go SDK will fail with "Unexpected EOF" when run table batch TransactionTypeInsertReplace or TransactionTypeAdd.  (TransactionTypeInsertMerge won't fail)

The root cause is : There are 3 "\r\n" after etag in responds from product Azure, but only 2 "\r\n" in the responds from Azurite.

**Responds from product Azure:**
```
358
--batchresponse_4d6c18c7-3a5f-4e71-96be-5ab90f68bf16
Content-Type: multipart/mixed; boundary=changesetresponse_d9a53c97-d6eb-4038-929f-6ffc409948e5

--changesetresponse_d9a53c97-d6eb-4038-929f-6ffc409948e5
Content-Type: application/http
Content-Transfer-Encoding: binary

HTTP/1.1 204 No Content
X-Content-Type-Options: nosniff
Cache-Control: no-cache
DataServiceVersion: 1.0;
ETag: W/"datetime'2024-12-23T09%3A20%3A10.1623783Z'"


--changesetresponse_d9a53c97-d6eb-4038-929f-6ffc409948e5
Content-Type: application/http
Content-Transfer-Encoding: binary

HTTP/1.1 204 No Content
X-Content-Type-Options: nosniff
Cache-Control: no-cache
DataServiceVersion: 1.0;
ETag: W/"datetime'2024-12-23T09%3A20%3A10.1623783Z'"


--changesetresponse_d9a53c97-d6eb-4038-929f-6ffc409948e5--
--batchresponse_4d6c18c7-3a5f-4e71-96be-5ab90f68bf16--

0

```

**Responds from Azurite:**
```
--batchresponse_615a699f-840f-4061-9bee-000c1e53dc10
Content-Type: multipart/mixed; boundary=changesetresponse_a0eae326-3560-4221-9149-5c8fce619643

--changesetresponse_a0eae326-3560-4221-9149-5c8fce619643
Content-Type: application/http
Content-Transfer-Encoding: binary

HTTP/1.1 204 No Content
X-Content-Type-Options: nosniff
Cache-Control: no-cache
DataServiceVersion: 3.0;
ETag: W/\"datetime'2024-12-23T09%3A21%3A30.3112261Z'\"

--changesetresponse_a0eae326-3560-4221-9149-5c8fce619643
Content-Type: application/http
Content-Transfer-Encoding: binary

HTTP/1.1 204 No Content
X-Content-Type-Options: nosniff
Cache-Control: no-cache
DataServiceVersion: 3.0;
ETag: W/\"datetime'2024-12-23T09%3A21%3A30.3112265Z'\"

--changesetresponse_a0eae326-3560-4221-9149-5c8fce619643--

--batchresponse_615a699f-840f-4061-9bee-000c1e53dc10--

```

From https://github.com/Azure/Azurite/blob/main/src/table/batch/TableBatchSerialization.ts we can see:
Following 2 functions has 1 addtional "\r\n" after Etag, so they works with Go SDK.

- serializeTableMergeEntityBatchResponse()
- serializeTableQueryEntityWithPartitionAndRowKeyBatchResponse()

Following 2 functions doesn't have additional "\r\n" after Etag, so they doesn't work.

- serializeTableInsertEntityBatchResponse()
- serializeTableUpdateEntityBatchResponse()

After add additional "\r\n" after Etag in serializeTableInsertEntityBatchResponse() and serializeTableUpdateEntityBatchResponse(), the issue if fixed with Go SDK in my manual test.

This PR fix this issue, and manually validated it works. 

As the issue only repro with Go SDK, it's not easy to add test case to cover this scenario.

===========================================

Thanks for contribution! Please go through following checklist before sending PR.

### PR Branch Destination

- For Azurite V3, please send PR to `main` branch.
- For legacy Azurite V2, please send PR to `legacy-dev` branch.

### Always Add Test Cases

Make sure test cases are added to cover the code change.

### Add Change Log

Add change log for the code change in `Upcoming Release` section in `ChangeLog.md`.

### Development Guideline

Please go to CONTRIBUTION.md for steps about setting up development environment and recommended Visual Studio Code extensions.
