### PR TITLE
Throwing error message if oauth argument set to anything other than basic for usse #2525

### DIFF
--- a/src/blob/BlobEnvironment.ts
+++ b/src/blob/BlobEnvironment.ts
@@ -132,7 +132,14 @@ export default class BlobEnvironment implements IBlobEnvironment {
   }
 
   public oauth(): string | undefined {
-    return this.flags.oauth;
+    if (this.flags.oauth !== undefined) {
+      if (this.flags.oauth !== "basic") {
+        throw RangeError(
+          `Must provide a valid value for parameter --oauth, only 'basic' is supported.`
+        );
+      }
+      return this.flags.oauth;
+    }
   }
 
   public disableProductStyleUrl(): boolean {

--- a/src/common/ConfigurationBase.ts
+++ b/src/common/ConfigurationBase.ts
@@ -91,7 +91,7 @@ export default abstract class ConfigurationBase {
   }
 
   public getOAuthLevel(): undefined | OAuthLevel {
-    if (this.oauth) {
+    if (this.oauth && typeof this.oauth === "string") {
       if (this.oauth.toLowerCase() === "basic") {
         return OAuthLevel.BASIC;
       }

--- a/src/common/Environment.ts
+++ b/src/common/Environment.ts
@@ -201,7 +201,14 @@ export default class Environment implements IEnvironment {
   }
 
   public oauth(): string | undefined {
-    return this.flags.oauth;
+    if (this.flags.oauth !== undefined) {
+      if (this.flags.oauth !== "basic") {
+        throw RangeError(
+          `Must provide a valid value for parameter --oauth, only 'basic' is supported.`
+        );
+      }
+      return this.flags.oauth;
+    }
   }
 
   public inMemoryPersistence(): boolean {

--- a/src/queue/QueueEnvironment.ts
+++ b/src/queue/QueueEnvironment.ts
@@ -116,7 +116,14 @@ export default class QueueEnvironment implements IQueueEnvironment {
   }
 
   public oauth(): string | undefined {
-    return this.flags.oauth;
+    if (this.flags.oauth !== undefined) {
+      if (this.flags.oauth !== "basic") {
+        throw RangeError(
+          `Must provide a valid value for parameter --oauth, only 'basic' is supported.`
+        );
+      }
+      return this.flags.oauth;
+    }
   }
 
   public disableProductStyleUrl(): boolean {

--- a/src/table/TableEnvironment.ts
+++ b/src/table/TableEnvironment.ts
@@ -153,7 +153,14 @@ export default class TableEnvironment implements ITableEnvironment {
   }
 
   public oauth(): string | undefined {
-    return this.flags.oauth;
+    if (this.flags.oauth !== undefined) {
+      if (this.flags.oauth !== "basic") {
+        throw RangeError(
+          `Must provide a valid value for parameter --oauth, only 'basic' is supported.`
+        );
+      }
+      return this.flags.oauth;
+    }
   }
 
   public cert(): string | undefined {


### PR DESCRIPTION
This pull request introduces stricter validation for the `oauth` flag across multiple environment classes and improves type safety in the `ConfigurationBase` class as highlighted in #2525 . The main changes ensure that only the value `"basic"` is accepted for the `oauth` flag, with an appropriate error thrown for invalid values.

### Stricter validation for `oauth` flag:

* [`src/blob/BlobEnvironment.ts`](diffhunk://#diff-56fdff4a5dc4d9d8f36522bb4a24fd302eebae9f19716ff4f5ca8d05ba8bd4feR135-R143): Added validation in the `oauth` method to ensure that only `"basic"` is accepted as a valid value for the `oauth` flag, throwing a `RangeError` otherwise.
* [`src/common/Environment.ts`](diffhunk://#diff-228379cf1c30321ce7c0346d6cf069a6df7b65896326ef717d1b152431d21b35R204-R212): Applied the same validation logic in the `oauth` method for the `Environment` class.
* [`src/queue/QueueEnvironment.ts`](diffhunk://#diff-9eea57d39c1deb9efc262355f2319dbd530490fc2ca36dca032fc228d1d9dd94R119-R127): Implemented the same validation in the `oauth` method for the `QueueEnvironment` class.
* [`src/table/TableEnvironment.ts`](diffhunk://#diff-455d420138770ed90dfd6fb548b76013bd2bc67992f0ec1480a4f9c6c95b13a0R156-R164): Added the same validation in the `oauth` method for the `TableEnvironment` class.

### Improved type safety:

* [`src/common/ConfigurationBase.ts`](diffhunk://#diff-ad5434dcf8c1ef2e3e062017e76ba23ed5830b56aa24f66dd50130287b0911c6L94-R94): Updated the `getOAuthLevel` method to explicitly check that `this.oauth` is a string before processing it, improving type safety.