### PR TITLE
Fix hang when closing connections under load

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@ Blob:
 - Added support for sealing append blobs. (issue #810)
 - Added support for delegation sas with version of 2015-07-05.
 - Fix issue on SQL: Delete a container with blob, then create container/blob with same name, and delete container will fail. (issue #2563)
+- Fixed hang in blob operations when a client disconnects before the OperationQueue processes the request. (issue #2575)
 
 Table:
 

--- a/src/common/persistence/FSExtentStore.ts
+++ b/src/common/persistence/FSExtentStore.ts
@@ -518,6 +518,18 @@ export default class FSExtentStore implements IExtentStore {
       let count: number = 0;
       let wsEnd = false;
 
+      if (!rs.readable) {
+        this.logger.debug(
+          `FSExtentStore:streamPipe() Readable stream is not readable, rejecting streamPipe.`,
+          contextId
+        );
+        reject(
+          new Error(
+            `FSExtentStore:streamPipe() Readable stream is not readable.`
+          ));
+        return;
+      }
+
       rs.on("data", data => {
         count += data.length;
         if (!ws.write(data)) {


### PR DESCRIPTION
    fix: Prevent hang when client disconnects under load

    In Azurite, all operations are managed through concurrent operation
    queues. A bug was identified where operations could hang indefinitely if
    the client disconnected before the operation was processed.

    This occurred because Azurite would attempt to attach event handlers to
    the request's readable stream (body) after it had already been closed by
    the client's disconnection. Since a closed stream emits no further
    events (like 'data', 'close', or 'error'), the operation would never
    complete, causing a permanent hang.

    This fix addresses the issue by checking if the request stream is still
    readable before attaching any event handlers. This ensures that we only
    process requests that are still active, preventing the hang and allowing
    the queues to continue processing other operations.

Thanks for contribution! Please go through following checklist before sending PR.

### PR Branch Destination

- For Azurite V3, please send PR to `main` branch.
- For legacy Azurite V2, please send PR to `legacy-dev` branch.

### Always Add Test Cases

Make sure test cases are added to cover the code change.

### Add Change Log

Add change log for the code change in `Upcoming Release` section in `ChangeLog.md`.

### Development Guideline

Please go to CONTRIBUTION.md for steps about setting up development environment and recommended Visual Studio Code extensions.
