### PR TITLE
Fix query performance by reordering property names

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ General:
 
 - Bump up service API version to 2025-11-05
 - Added support for service API version to 2025-07-05
+- General performance improvements for internal metadata access
 
 Blob:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,13 +4,16 @@
 
 ## Upcoming Release
 
+General:
+
+- Performance improvements for internal metadata access using in-memory metadata store
+
 ## 2025.07 Version 3.35.0
 
 General:
 
 - Bump up service API version to 2025-11-05
 - Added support for service API version to 2025-07-05
-- General performance improvements for internal metadata access
 
 Blob:
 

--- a/src/blob/persistence/LokiBlobMetadataStore.ts
+++ b/src/blob/persistence/LokiBlobMetadataStore.ts
@@ -383,8 +383,8 @@ export default class LokiBlobMetadataStore
   ): Promise<ContainerModel> {
     const coll = this.db.getCollection(this.CONTAINERS_COLLECTION);
     const doc = coll.findOne({
-      accountName: container.accountName,
-      name: container.name
+      name: container.name,
+      accountName: container.accountName
     });
 
     if (doc) {
@@ -817,7 +817,7 @@ export default class LokiBlobMetadataStore
     container: string
   ): Promise<void> {
     const coll = this.db.getCollection(this.CONTAINERS_COLLECTION);
-    const doc = coll.findOne({ accountName: account, name: container });
+    const doc = coll.findOne({ name: container, accountName: account });
     if (!doc) {
       const requestId = context ? context.contextId : undefined;
       throw StorageErrorFactory.getContainerNotFound(requestId);
@@ -1032,9 +1032,9 @@ export default class LokiBlobMetadataStore
     );
     const coll = this.db.getCollection(this.BLOBS_COLLECTION);
     const blobDoc = coll.findOne({
+      name: blob.name,
       accountName: blob.accountName,
       containerName: blob.containerName,
-      name: blob.name,
       snapshot: blob.snapshot
     });
 
@@ -1219,9 +1219,9 @@ export default class LokiBlobMetadataStore
   ): Promise<BlobModel | undefined> {
     const coll = this.db.getCollection(this.BLOBS_COLLECTION);
     const blobDoc = coll.findOne({
+      name: blob,
       accountName: account,
       containerName: container,
-      name: blob,
       snapshot
     });
 
@@ -1799,9 +1799,9 @@ export default class LokiBlobMetadataStore
 
     const coll = this.db.getCollection(this.BLOBS_COLLECTION);
     const doc = coll.findOne({
+      name: blob,
       accountName: account,
       containerName: container,
-      name: blob,
       snapshot
     });
 
@@ -1833,9 +1833,9 @@ export default class LokiBlobMetadataStore
   > {
     const coll = this.db.getCollection(this.BLOBS_COLLECTION);
     const doc = coll.findOne({
+      name: blob,
       accountName: account,
       containerName: container,
-      name: blob,
       snapshot
     });
     if (!doc) {
@@ -2323,9 +2323,9 @@ export default class LokiBlobMetadataStore
 
     const blobColl = this.db.getCollection(this.BLOBS_COLLECTION);
     const blobDoc = blobColl.findOne({
+      name: block.blobName,
       accountName: block.accountName,
-      containerName: block.containerName,
-      name: block.blobName
+      containerName: block.containerName
     });
 
     let blobExist = false;
@@ -2364,9 +2364,9 @@ export default class LokiBlobMetadataStore
     // If the new block ID does not have same length with before uncommitted block ID, return failure.
     if (blobExist) {
       const existBlockDoc = coll.findOne({
+        blobName: block.blobName,
         accountName: block.accountName,
         containerName: block.containerName,
-        blobName: block.blobName
       });
       if (existBlockDoc) {
         if (
@@ -2379,10 +2379,10 @@ export default class LokiBlobMetadataStore
     }
 
     const blockDoc = coll.findOne({
+      name: block.name,
       accountName: block.accountName,
       containerName: block.containerName,
       blobName: block.blobName,
-      name: block.name,
       isCommitted: block.isCommitted
     });
 
@@ -3207,7 +3207,7 @@ export default class LokiBlobMetadataStore
     forceExist?: boolean
   ): Promise<ContainerModel | undefined> {
     const coll = this.db.getCollection(this.CONTAINERS_COLLECTION);
-    const doc = coll.findOne({ accountName: account, name: container });
+    const doc = coll.findOne({ name: container, accountName: account });
 
     if (forceExist === undefined || forceExist === true) {
       if (!doc) {
@@ -3271,7 +3271,7 @@ export default class LokiBlobMetadataStore
     forceExist?: boolean
   ): Promise<ContainerModel | undefined> {
     const coll = this.db.getCollection(this.CONTAINERS_COLLECTION);
-    const doc = coll.findOne({ accountName: account, name: container });
+    const doc = coll.findOne({ name: container, accountName: account });
 
     if (!doc) {
       if (forceExist) {
@@ -3347,9 +3347,9 @@ export default class LokiBlobMetadataStore
 
     const coll = this.db.getCollection(this.BLOBS_COLLECTION);
     const doc = coll.findOne({
+      name: blob,
       accountName: account,
       containerName: container,
-      name: blob,
       snapshot
     });
 

--- a/src/queue/persistence/LokiQueueMetadataStore.ts
+++ b/src/queue/persistence/LokiQueueMetadataStore.ts
@@ -236,10 +236,10 @@ export default class LokiQueueMetadataStore implements IQueueMetadataStore {
       prefix === ""
         ? { $loki: { $gt: marker }, accountName: account }
         : {
-            name: { $regex: `^${this.escapeRegex(prefix)}` },
-            $loki: { $gt: marker },
-            accountName: account
-          };
+          name: { $regex: `^${this.escapeRegex(prefix)}` },
+          $loki: { $gt: marker },
+          accountName: account
+        };
 
     // Get one more item to help check if the query reach the tail of the collection.
     const docs = coll
@@ -283,7 +283,7 @@ export default class LokiQueueMetadataStore implements IQueueMetadataStore {
     context?: Context
   ): Promise<QueueModel> {
     const coll = this.db.getCollection(this.QUEUES_COLLECTION);
-    const doc = coll.findOne({ accountName: account, name: queue });
+    const doc = coll.findOne({ name: queue, accountName: account });
     if (!doc) {
       const requestId = context ? context.contextID : undefined;
       throw StorageErrorFactory.getQueueNotFound(requestId);
@@ -307,8 +307,8 @@ export default class LokiQueueMetadataStore implements IQueueMetadataStore {
   ): Promise<QUEUE_STATUSCODE> {
     const coll = this.db.getCollection(this.QUEUES_COLLECTION);
     const doc = coll.findOne({
-      accountName: queue.accountName,
-      name: queue.name
+      name: queue.name,
+      accountName: queue.accountName
     });
 
     // Check whether a conflict exists if there exist a queue with the given name.
@@ -386,7 +386,7 @@ export default class LokiQueueMetadataStore implements IQueueMetadataStore {
     context?: Context
   ): Promise<void> {
     const coll = this.db.getCollection(this.QUEUES_COLLECTION);
-    const doc = coll.findOne({ accountName: account, name: queue });
+    const doc = coll.findOne({ name: queue, accountName: account });
 
     if (!doc) {
       const requestId = context ? context.contextID : undefined;
@@ -418,7 +418,7 @@ export default class LokiQueueMetadataStore implements IQueueMetadataStore {
     context?: Context
   ): Promise<void> {
     const coll = this.db.getCollection(this.QUEUES_COLLECTION);
-    const doc = coll.findOne({ accountName: account, name: queue });
+    const doc = coll.findOne({ name: queue, accountName: account });
 
     if (!doc) {
       const requestId = context ? context.contextID : undefined;
@@ -446,7 +446,7 @@ export default class LokiQueueMetadataStore implements IQueueMetadataStore {
     context?: Context
   ): Promise<void> {
     const coll = this.db.getCollection(this.QUEUES_COLLECTION);
-    const doc = coll.findOne({ accountName: account, name: queue });
+    const doc = coll.findOne({ name: queue, accountName: account });
 
     if (!doc) {
       const requestId = context ? context.contextID : undefined;
@@ -472,7 +472,7 @@ export default class LokiQueueMetadataStore implements IQueueMetadataStore {
     context?: Context
   ): Promise<number> {
     const queueColl = this.db.getCollection(this.QUEUES_COLLECTION);
-    const doc = queueColl.findOne({ accountName: account, name: queue });
+    const doc = queueColl.findOne({ name: queue, accountName: account });
     if (!doc) {
       const requestId = context ? context.contextID : undefined;
       throw StorageErrorFactory.getQueueNotFound(requestId);
@@ -649,9 +649,9 @@ export default class LokiQueueMetadataStore implements IQueueMetadataStore {
 
     const coll = this.db.getCollection(this.MESSAGES_COLLECTION);
     const doc = coll.findOne({
+      messageId,
       accountName: account,
-      queueName: queue,
-      messageId
+      queueName: queue
     });
 
     if (!doc) {
@@ -687,9 +687,9 @@ export default class LokiQueueMetadataStore implements IQueueMetadataStore {
 
     const coll = this.db.getCollection(this.MESSAGES_COLLECTION);
     const doc = coll.findOne({
+      messageId: message.messageId,
       accountName: message.accountName,
-      queueName: message.queueName,
-      messageId: message.messageId
+      queueName: message.queueName
     });
 
     if (!doc) {
@@ -783,7 +783,7 @@ export default class LokiQueueMetadataStore implements IQueueMetadataStore {
     context?: Context
   ): void {
     const queueColl = this.db.getCollection(this.QUEUES_COLLECTION);
-    const queueDoc = queueColl.findOne({ accountName: account, name: queue });
+    const queueDoc = queueColl.findOne({ name: queue, accountName: account });
     if (!queueDoc) {
       const requestId = context ? context.contextID : undefined;
       throw StorageErrorFactory.getQueueNotFound(requestId);

--- a/src/table/persistence/LokiTableMetadataStore.ts
+++ b/src/table/persistence/LokiTableMetadataStore.ts
@@ -265,8 +265,8 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
     );
 
     const doc = tableEntityCollection.findOne({
-      PartitionKey: entity.PartitionKey,
-      RowKey: entity.RowKey
+      RowKey: entity.RowKey,
+      PartitionKey: entity.PartitionKey
     });
     if (doc) {
       throw StorageErrorFactory.getEntityAlreadyExist(context);
@@ -392,8 +392,8 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
 
     if (partitionKey !== undefined && rowKey !== undefined) {
       const doc = tableEntityCollection.findOne({
-        PartitionKey: partitionKey,
-        RowKey: rowKey
+        RowKey: rowKey,
+        PartitionKey: partitionKey
       }) as Entity;
 
       this.checkForMissingEntity(doc, context);
@@ -503,8 +503,8 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
   ): Promise<Entity | undefined> {
     const entityCollection = this.getEntityCollection(account, table, context);
     const requestedDoc = entityCollection.findOne({
-      PartitionKey: partitionKey,
-      RowKey: rowKey
+      RowKey: rowKey,
+      PartitionKey: partitionKey
     }) as Entity;
 
     return requestedDoc;
@@ -919,8 +919,8 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
     );
 
     const doc = tableEntityCollection.findOne({
-      PartitionKey: entity.PartitionKey,
-      RowKey: entity.RowKey
+      RowKey: entity.RowKey,
+      PartitionKey: entity.PartitionKey
     }) as Entity;
 
     if (!doc) {
@@ -968,8 +968,8 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
     );
 
     const doc = tableEntityCollection.findOne({
-      PartitionKey: entity.PartitionKey,
-      RowKey: entity.RowKey
+      RowKey: entity.RowKey,
+      PartitionKey: entity.PartitionKey
     }) as Entity;
 
     if (!doc) {
@@ -1062,8 +1062,8 @@ export default class LokiTableMetadataStore implements ITableMetadataStore {
       };
       // lokijs applies this insert as an upsert
       const doc = tableBatchCollection.findOne({
-        PartitionKey: entity.PartitionKey,
-        RowKey: entity.RowKey
+        RowKey: entity.RowKey,
+        PartitionKey: entity.PartitionKey
       });
       // we can't rely on upsert behavior if documents already exist
       if (doc) {


### PR DESCRIPTION
Significantly improve Azurite performance under heavy metadata lookup workloads. The issue here is that the LokiJS library only supported indexed access to data on the first predicate of a $and or $or clause. This is documented in the LokiJS code [here](https://github.com/techfort/LokiJS/blob/25b9a33d57509717d43b4da06d92064f2b7a6c95/src/lokijs.js#L3443).

The existing Azurite LokiMetadata store code used properties like accountName as the first property in the filter. The impact is that the find() and findOne() calls only performed an indexed lookup on the accountName. There is usually only a single account, so all blobs/queues/messages are returned, and the remaining filters/properties are applied by running a linear scan over all values in the result set. You can see the performance impact in the following CPU profile taken from a copy of Azurite running without this optimization:

<img width="686" height="256" alt="image" src="https://github.com/user-attachments/assets/63b60c3b-6f58-4f19-8830-dc67b45740b3" />

The fix here moves the properties names that have higher [selectivity](https://www.mongodb.com/docs/manual/tutorial/create-queries-that-ensure-selectivity/) to the first position in the filter object. By doing so, when LokiJS evaluates the filter object, the first (high selectivity) property is used for the initial indexed (fast) lookup which quickly prunes out nearly all of the entries in the collection. Only a few entries are left to be scanned over to compute the final result.

The impact here is substantial, in a test framework using Azurite, an initial load process took 12.5 seconds previously, and after this change only took about 9 seconds. This performance improvement only required re-ordering some fields here in the find()/findOne() API calls.
