### PR TITLE
Fixes Azurite V3 emulator not returning 412 Precondition Failed if a resource (blob) does not exist and "*" IfMatch is provided.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ General:
 
 - Performance improvements for internal metadata access using in-memory metadata store
 - Fix building failure on Node 22 platform.
+- Fix * IfMatch for non-existent resource not throwing 412 Precondition Failed
 
 ## 2025.07 Version 3.35.0
 

--- a/src/blob/conditions/WriteConditionalHeadersValidator.ts
+++ b/src/blob/conditions/WriteConditionalHeadersValidator.ts
@@ -102,10 +102,8 @@ export default class WriteConditionalHeadersValidator
       if (conditionalHeaders.ifMatch && conditionalHeaders.ifMatch.length > 0) {
         // If a request specifies both the If-Match and If-Unmodified-Since headers,
         // the request is evaluated based on the criteria specified in If-Match.
-        if (conditionalHeaders.ifMatch[0] !== "*") {
-          throw StorageErrorFactory.getConditionNotMet(context.contextId!);
-        }
-        return;
+        // Throw if there is any value in if-match for non exist blob
+        throw StorageErrorFactory.getConditionNotMet(context.contextId!);
       }
 
       if (conditionalHeaders.ifModifiedSince) {

--- a/tests/blob/conditions.test.ts
+++ b/tests/blob/conditions.test.ts
@@ -830,6 +830,38 @@ describe("WriteConditionalHeadersValidator for nonexistent resource", () => {
 
     assert.fail();
   });
+
+  it("Should throw 412 Precondition Failed for * if-match @loki @sql", () => {
+    const validator = new WriteConditionalHeadersValidator();
+    const modifiedAccessConditions = {
+      ifMatch: "*"
+    };
+
+    const expectedError = StorageErrorFactory.getConditionNotMet(
+      context.contextId!
+    );
+
+    try {
+      validator.validate(
+        context,
+        new ConditionalHeadersAdapter(context, modifiedAccessConditions),
+        new ConditionResourceAdapter(undefined)
+      );
+    } catch (error) {
+      assert.deepStrictEqual(error.statusCode, expectedError.statusCode);
+      assert.deepStrictEqual(
+        error.storageErrorCode,
+        expectedError.storageErrorCode
+      );
+      assert.deepStrictEqual(
+        error.storageErrorMessage,
+        expectedError.storageErrorMessage
+      );
+      return;
+    }
+
+    assert.fail();
+  });
 });
 
 describe("WriteConditionalHeadersValidator for exist resource", () => {


### PR DESCRIPTION
This PR fixes the issue where the Azurite V3 emulator does not return 412 Precondition Failed if a resource (blob) does not exist and "*" IfMatch is provided.

Issue #2589