### PR TITLE
Update node version to address critical CVEs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ General:
 - Performance improvements for internal metadata access using in-memory metadata store
 - Fix building failure on Node 22 platform.
 - Fix * IfMatch for non-existent resource not throwing 412 Precondition Failed
+- Update node version to address critical CVEs
 
 ## 2025.07 Version 3.35.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ General:
 - Performance improvements for internal metadata access using in-memory metadata store
 - Fix building failure on Node 22 platform.
 - Fix * IfMatch for non-existent resource not throwing 412 Precondition Failed
-- Update node version to address critical CVEs
+- Update Node 22 Alpine base image from 3.21 to 3.23 to address critical CVEs
 
 ## 2025.07 Version 3.35.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Builder
 #
-FROM node:22-alpine3.21 as builder
+FROM node:22-alpine3.23 as builder
 
 WORKDIR /opt/azurite
 
@@ -18,7 +18,7 @@ RUN npm run build && \
 
 # Production image
 #
-FROM node:22-alpine3.21
+FROM node:22-alpine3.23
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
Old image trivy scan:
Total: 26 (UNKNOWN: 0, LOW: 3, MEDIUM: 17, HIGH: 4, CRITICAL: 2)

New image trivy scan:
Total: 2 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 1)
Zlib is the current critical here and does not have a fix since it was recently discovered.

Tests continue to pass without issue
