### PR TITLE
Fix azurite-table banner reporting configured port instead of bound port

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,10 @@ General:
 - Fix building failure on Node 22 platform.
 - Fix * IfMatch for non-existent resource not throwing 412 Precondition Failed
 
+Table:
+
+- Fix `azurite-table` startup banner reporting the configured port (e.g. `0` when using OS-assigned ports) instead of the actual bound address. Now uses `server.getHttpServerAddress()` to match `azurite-blob` and `azurite-queue`.
+
 ## 2025.07 Version 3.35.0
 
 General:

--- a/src/table/main.ts
+++ b/src/table/main.ts
@@ -59,15 +59,13 @@ async function main() {
   // Create server instance
   const server = new TableServer(config);
 
-  const beforeStartMessage = `Azurite Table service is starting on ${config.host}:${config.port}`;
-  const afterStartMessage = `Azurite Table service successfully started on ${config.host}:${config.port}`;
   const beforeCloseMessage = `Azurite Table service is closing...`;
   const afterCloseMessage = `Azurite Table service successfully closed`;
 
   // Start Server
-  console.log(beforeStartMessage);
+  console.log(`Azurite Table service is starting on ${config.host}:${config.port}`);
   await server.start();
-  console.log(afterStartMessage);
+  console.log(`Azurite Table service successfully listens on ${server.getHttpServerAddress()}`);
   
   AzuriteTelemetryClient.init(location, !env.disableTelemetry(), env);
   await AzuriteTelemetryClient.TraceStartEvent("Table");


### PR DESCRIPTION
## Summary

- The standalone `azurite-table` entry point printed its "successfully started" banner using `config.port` evaluated before `server.start()`, so callers passing `--tablePort 0` saw `port: 0` instead of the actual OS-assigned port.
- `azurite-blob` and `azurite-queue` already inline `server.getHttpServerAddress()` after `await server.start()`; this PR brings table to parity.
- Wording is also normalized from "successfully started on" to "successfully listens on" to match the sibling providers.

Fixes #2642. Related: #145 (the original OS-assigned port feature this bug defeated for table-only callers), #2347 (table-only Storage Explorer connectivity — the divergent banner wording is the most visible symptom of the same code-path inconsistency).

## Diff

```ts
// src/table/main.ts (before)
const beforeStartMessage = `Azurite Table service is starting on ${config.host}:${config.port}`;
const afterStartMessage = `Azurite Table service successfully started on ${config.host}:${config.port}`;
...
console.log(beforeStartMessage);
await server.start();
console.log(afterStartMessage);  // evaluated before start — port still 0
```

```ts
// src/table/main.ts (after — mirrors blob/main.ts and queue/main.ts)
console.log(`Azurite Table service is starting on ${config.host}:${config.port}`);
await server.start();
console.log(`Azurite Table service successfully listens on ${server.getHttpServerAddress()}`);
```

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` (tsc) passes
- [x] Manual smoke test with `--tablePort 0`:
  ```
  Azurite Table service is starting on 127.0.0.1:0
  Azurite Table service successfully listens on http://127.0.0.1:57443
  ```
- [x] Manual smoke test with `--tablePort 12345` (explicit port still works):
  ```
  Azurite Table service is starting on 127.0.0.1:12345
  Azurite Table service successfully listens on http://127.0.0.1:12345
  ```
- [x] No tests reference the old `"successfully started on"` wording (`grep -rn "successfully started" tests/` is empty for this string).