### PR TITLE
Bumped undici version

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,7 +16,7 @@ General:
 - Migrate Windows/Linux binary build flow from pkg/pkg-fetch to Node.js SEA (`esbuild` + `postject`), with build-audit checks.
 - Add a temporary non-blocking legacy Node 16 smoke lane in Azure Pipelines for transition monitoring.
 - Address dependency vulnerabilities by upgrading packages: `@azure/ms-rest-js` to 2.x, `axios` to 1.x, `tedious` to 18.x, and `@azure/storage-blob`/`@azure/storage-queue` to 12.28.x/12.27.x.
-- Bump `undici` from 7.27.2 to 7.28.0 to address an SFI security item.
+- Enforce `undici` version `^7.28.0` via npm `overrides` to address an SFI security item.
 - Remove the deprecated `azure-storage` dev dependency and migrate the affected queue and table test suites to `@azure/data-tables` and other modern Azure SDK clients (adds `@azure/identity`).
 - Standardize binary data handling on `Uint8Array` instead of `Buffer` (e.g. MD5 hashes, Content-MD5, internal buffer conversions).
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,7 @@ General:
 - Migrate Windows/Linux binary build flow from pkg/pkg-fetch to Node.js SEA (`esbuild` + `postject`), with build-audit checks.
 - Add a temporary non-blocking legacy Node 16 smoke lane in Azure Pipelines for transition monitoring.
 - Address dependency vulnerabilities by upgrading packages: `@azure/ms-rest-js` to 2.x, `axios` to 1.x, `tedious` to 18.x, and `@azure/storage-blob`/`@azure/storage-queue` to 12.28.x/12.27.x.
+- Bump `undici` from 7.27.2 to 7.28.0 to address an SFI security item.
 - Remove the deprecated `azure-storage` dev dependency and migrate the affected queue and table test suites to `@azure/data-tables` and other modern Azure SDK clients (adds `@azure/identity`).
 - Standardize binary data handling on `Uint8Array` instead of `Buffer` (e.g. MD5 hashes, Content-MD5, internal buffer conversions).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "ts-mockito": "^2.6.1",
         "ts-node": "^10.0.0",
         "typescript": "^5.0.3",
+        "undici": "^7.28.0",
         "vsce": "^2.7.0"
       },
       "engines": {
@@ -8463,9 +8464,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,6 @@
         "ts-mockito": "^2.6.1",
         "ts-node": "^10.0.0",
         "typescript": "^5.0.3",
-        "undici": "^7.28.0",
         "vsce": "^2.7.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -86,8 +86,10 @@
     "ts-mockito": "^2.6.1",
     "ts-node": "^10.0.0",
     "typescript": "^5.0.3",
-    "undici": "^7.28.0",
     "vsce": "^2.7.0"
+  },
+  "overrides": {
+    "undici": "^7.28.0"
   },
   "activationEvents": [
     "onStartupFinished"

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "ts-mockito": "^2.6.1",
     "ts-node": "^10.0.0",
     "typescript": "^5.0.3",
+    "undici": "^7.28.0",
     "vsce": "^2.7.0"
   },
   "activationEvents": [


### PR DESCRIPTION
This pull request primarily updates the `undici` package to address a security issue. The update is reflected in both the `ChangeLog.md` and `package.json` files.

Dependency update for security:

* Bumped the `undici` package from version 7.27.2 to 7.28.0 in `package.json` to address an SFI security item.
