### PR TITLE
Fixed Bad exe issue

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,10 +4,6 @@
 
 ## Upcoming Release
 
-General:
-
-- Fix Windows SEA executable build producing a corrupted/bad `.exe` by stripping the Authenticode signature from the copied Node.js binary before injecting the SEA blob via `postject`.
-
 ## 2026.06 Version 3.36.0
 
 General:
@@ -23,6 +19,7 @@ General:
 - Enforce `undici` version `^7.28.0` via npm `overrides` to address an SFI security item.
 - Remove the deprecated `azure-storage` dev dependency and migrate the affected queue and table test suites to `@azure/data-tables` and other modern Azure SDK clients (adds `@azure/identity`).
 - Standardize binary data handling on `Uint8Array` instead of `Buffer` (e.g. MD5 hashes, Content-MD5, internal buffer conversions).
+- Fix Windows SEA executable build producing a corrupted/bad `.exe` by stripping the Authenticode signature from the copied Node.js binary before injecting the SEA blob via `postject`.
 
 Blob:
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 ## Upcoming Release
 
+General:
+
+- Fix Windows SEA executable build producing a corrupted/bad `.exe` by stripping the Authenticode signature from the copied Node.js binary before injecting the SEA blob via `postject`.
+
 ## 2026.06 Version 3.36.0
 
 General:

--- a/scripts/buildExe.js
+++ b/scripts/buildExe.js
@@ -145,7 +145,7 @@ function removeAuthenticodeSignature(binaryPath) {
   }
 
   const peOffset = bytes.readUInt32LE(0x3c);
-  if (peOffset + 24 > bytes.length) {
+  if (peOffset + 26 > bytes.length) {
     throw new Error(`Invalid PE header offset ${peOffset} for file length ${bytes.length}: ${binaryPath}`);
   }
 

--- a/scripts/buildExe.js
+++ b/scripts/buildExe.js
@@ -66,6 +66,7 @@ async function build() {
   run(process.execPath, ['--experimental-sea-config', seaConfigPath]);
 
   cpSync(process.execPath, outputExe);
+  removeAuthenticodeSignature(outputExe);
 
   await rcedit(outputExe, {
     'version-string': {
@@ -135,4 +136,35 @@ function run(command, args) {
   if (result.status !== 0) {
     throw new Error(`Command failed with exit code ${result.status}: ${command} ${args.join(' ')}`);
   }
+}
+
+function removeAuthenticodeSignature(binaryPath) {
+  const bytes = fs.readFileSync(binaryPath);
+  const peOffset = bytes.readUInt32LE(0x3c);
+  const optionalHeaderStart = peOffset + 24;
+  const optionalHeaderMagic = bytes.readUInt16LE(optionalHeaderStart);
+
+  let dataDirectoryStart;
+  if (optionalHeaderMagic === 0x10b) {
+    dataDirectoryStart = optionalHeaderStart + 96;
+  } else if (optionalHeaderMagic === 0x20b) {
+    dataDirectoryStart = optionalHeaderStart + 112;
+  } else {
+    throw new Error(`Unsupported PE optional header magic: 0x${optionalHeaderMagic.toString(16)}`);
+  }
+
+  const securityDirectoryEntry = dataDirectoryStart + 8 * 4;
+  const certTableFileOffset = bytes.readUInt32LE(securityDirectoryEntry);
+  const certTableSize = bytes.readUInt32LE(securityDirectoryEntry + 4);
+
+  // Clear IMAGE_DIRECTORY_ENTRY_SECURITY so no stale certificate pointer remains after postject.
+  bytes.writeUInt32LE(0, securityDirectoryEntry);
+  bytes.writeUInt32LE(0, securityDirectoryEntry + 4);
+
+  if (certTableSize > 0 && certTableFileOffset + certTableSize === bytes.length) {
+    fs.writeFileSync(binaryPath, bytes.subarray(0, certTableFileOffset));
+    return;
+  }
+
+  fs.writeFileSync(binaryPath, bytes);
 }

--- a/scripts/buildExe.js
+++ b/scripts/buildExe.js
@@ -140,7 +140,19 @@ function run(command, args) {
 
 function removeAuthenticodeSignature(binaryPath) {
   const bytes = fs.readFileSync(binaryPath);
+  if (bytes.length < 0x40) {
+    throw new Error(`File is too small to be a valid PE executable: ${binaryPath}`);
+  }
+
   const peOffset = bytes.readUInt32LE(0x3c);
+  if (peOffset + 24 > bytes.length) {
+    throw new Error(`Invalid PE header offset ${peOffset} for file length ${bytes.length}: ${binaryPath}`);
+  }
+
+  if (bytes.toString('ascii', peOffset, peOffset + 4) !== 'PE\0\0') {
+    throw new Error(`Missing PE signature at offset ${peOffset}: ${binaryPath}`);
+  }
+
   const optionalHeaderStart = peOffset + 24;
   const optionalHeaderMagic = bytes.readUInt16LE(optionalHeaderStart);
 
@@ -154,12 +166,35 @@ function removeAuthenticodeSignature(binaryPath) {
   }
 
   const securityDirectoryEntry = dataDirectoryStart + 8 * 4;
+  if (securityDirectoryEntry + 8 > bytes.length) {
+    throw new Error(
+      `PE security directory entry is out of range: offset=${securityDirectoryEntry}, fileLength=${bytes.length}`
+    );
+  }
+
   const certTableFileOffset = bytes.readUInt32LE(securityDirectoryEntry);
   const certTableSize = bytes.readUInt32LE(securityDirectoryEntry + 4);
 
   // Clear IMAGE_DIRECTORY_ENTRY_SECURITY so no stale certificate pointer remains after postject.
   bytes.writeUInt32LE(0, securityDirectoryEntry);
   bytes.writeUInt32LE(0, securityDirectoryEntry + 4);
+
+  if (certTableSize === 0) {
+    fs.writeFileSync(binaryPath, bytes);
+    return;
+  }
+
+  if (
+    certTableFileOffset === 0 ||
+    certTableFileOffset > bytes.length ||
+    certTableSize > bytes.length - certTableFileOffset
+  ) {
+    throw new Error(
+      `Invalid PE certificate table range: offset=${certTableFileOffset}, size=${certTableSize}, fileLength=${bytes.length}`
+    );
+  }
+
+  bytes.fill(0, certTableFileOffset, certTableFileOffset + certTableSize);
 
   if (certTableSize > 0 && certTableFileOffset + certTableSize === bytes.length) {
     fs.writeFileSync(binaryPath, bytes.subarray(0, certTableFileOffset));


### PR DESCRIPTION
This pull request addresses a critical issue with building Windows SEA executables by ensuring that any existing Authenticode signature is stripped from the copied Node.js binary before injecting the SEA blob. This prevents the production of corrupted or invalid `.exe` files during the build process.

**Windows SEA Executable Build Fixes:**

* Introduced a new `removeAuthenticodeSignature` function in `scripts/buildExe.js` to programmatically remove any Authenticode signature from the Node.js binary before further modification.
* Updated the build process in `scripts/buildExe.js` to invoke `removeAuthenticodeSignature` after copying the Node.js binary, ensuring the executable is in a clean state before resource injection.

**Documentation:**

* Added a note in `ChangeLog.md` describing the fix for corrupted/bad Windows SEA `.exe` builds by stripping the Authenticode signature before injecting the SEA blob.
