### PR TITLE
Added few scripts for testing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "sarif-viewer.connectToGithubCodeScanning": "on"
 }

--- a/scripts/azurite-cli.ps1
+++ b/scripts/azurite-cli.ps1
@@ -1,0 +1,229 @@
+# azurite-cli.ps1
+# Reusable helpers for testing a local Azurite instance with the official Azure CLI (`az storage`).
+#
+# Quick start:
+#   . .\scripts\azurite-cli.ps1     # dot-source to load the functions into your session
+#   Use-Azurite                     # point the Azure CLI at local Azurite (sets connection string)
+#   az storage container list -o table
+#
+# After Use-Azurite, every `az storage ...` command targets Azurite automatically.
+#
+# Optional convenience wrappers (thin shortcuts over `az storage`):
+#   Test-AzuriteBlob                # runs a full blob lifecycle smoke test
+#   Test-AzuriteQueue               # runs a full queue lifecycle smoke test
+#   Test-AzuriteTable               # runs a full table lifecycle smoke test
+#   Test-AzuriteAll                 # runs blob + queue + table smoke tests
+#   New-AzuriteContainer mycontainer
+#   Send-AzuriteBlob  mycontainer ./file.txt myblob.txt
+#   Get-AzuriteBlobs  mycontainer
+#   Receive-AzuriteBlob mycontainer myblob.txt ./out.txt
+
+# --- Default Azurite emulator credentials (well-known, safe for local dev only) ---
+$script:AzCliAccount = 'devstoreaccount1'
+$script:AzCliKey     = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=='
+$script:AzCliHost    = '127.0.0.1'
+
+# Populated by Use-Azurite; passed explicitly via --connection-string on every `az` call
+# so it works even when `az` is the Windows az.exe invoked from WSL (env vars don't cross).
+$script:AzCliCS = $null
+
+function Use-Azurite {
+    <#
+        Points the Azure CLI at the local Azurite instance for the current shell session.
+        Builds the connection string (covers Blob, Queue and Table), stores it in
+        $script:AzCliCS, and also exports AZURE_STORAGE_CONNECTION_STRING for ad-hoc commands.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$AzHost = $script:AzCliHost,
+        [int]$BlobPort  = 10000,
+        [int]$QueuePort = 10001,
+        [int]$TablePort = 10002
+    )
+
+    $cs = @(
+        "DefaultEndpointsProtocol=http"
+        "AccountName=$script:AzCliAccount"
+        "AccountKey=$script:AzCliKey"
+        "BlobEndpoint=http://${AzHost}:$BlobPort/$script:AzCliAccount"
+        "QueueEndpoint=http://${AzHost}:$QueuePort/$script:AzCliAccount"
+        "TableEndpoint=http://${AzHost}:$TablePort/$script:AzCliAccount"
+    ) -join ';'
+
+    $script:AzCliCS = $cs
+    $env:AZURE_STORAGE_CONNECTION_STRING = $cs
+    Write-Host "Azure CLI is now pointed at Azurite ($AzHost  blob:$BlobPort queue:$QueuePort table:$TablePort)." -ForegroundColor Green
+    Write-Host "Helpers pass --connection-string explicitly, so this works in WSL too." -ForegroundColor DarkGray
+}
+
+function Clear-Azurite {
+    <# Removes the Azurite connection string so `az` targets real Azure / your login again. #>
+    $script:AzCliCS = $null
+    Remove-Item Env:AZURE_STORAGE_CONNECTION_STRING -ErrorAction SilentlyContinue
+    Write-Host "Cleared Azurite connection string." -ForegroundColor Yellow
+}
+
+function Assert-AzuriteContext {
+    if (-not $script:AzCliCS) {
+        Write-Host "Connection string not set. Running Use-Azurite for you..." -ForegroundColor Yellow
+        Use-Azurite
+    }
+}
+
+# --- Thin convenience wrappers (entirely optional; plain `az storage` works too) ---
+
+function New-AzuriteContainer {
+    param([Parameter(Mandatory)][string]$Name)
+    Assert-AzuriteContext
+    az storage container create --name $Name --connection-string $script:AzCliCS --output table
+}
+
+function Send-AzuriteBlob {
+    param(
+        [Parameter(Mandatory)][string]$Container,
+        [Parameter(Mandatory)][string]$File,
+        [string]$Name
+    )
+    Assert-AzuriteContext
+    if (-not $Name) { $Name = Split-Path $File -Leaf }
+    az storage blob upload --container-name $Container --name $Name --file $File --overwrite --connection-string $script:AzCliCS --output table
+}
+
+function Get-AzuriteBlobs {
+    param([Parameter(Mandatory)][string]$Container)
+    Assert-AzuriteContext
+    az storage blob list --container-name $Container --connection-string $script:AzCliCS --output table
+}
+
+function Receive-AzuriteBlob {
+    param(
+        [Parameter(Mandatory)][string]$Container,
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Destination
+    )
+    Assert-AzuriteContext
+    az storage blob download --container-name $Container --name $Name --file $Destination --connection-string $script:AzCliCS --output none
+    Write-Host "Downloaded '$Name' -> '$Destination'" -ForegroundColor Green
+}
+
+function Test-AzuriteBlob {
+    <# End-to-end blob smoke test: create container, upload, list, download, verify, cleanup. #>
+    [CmdletBinding()]
+    param([string]$Container = "smoketest$((Get-Random -Maximum 9999))")
+
+    Assert-AzuriteContext
+    $tmpDir  = [System.IO.Path]::GetTempPath()   # cross-platform (Windows/Linux/macOS)
+    $tmpUp   = Join-Path $tmpDir "azurite-up-$([guid]::NewGuid()).txt"
+    $tmpDown = Join-Path $tmpDir "azurite-down-$([guid]::NewGuid()).txt"
+    $content = "azurite smoke test @ $(Get-Date -Format o)"
+
+    try {
+        Write-Host "`n[1/5] Create container '$Container'" -ForegroundColor Cyan
+        az storage container create --name $Container --connection-string $script:AzCliCS --output table
+
+        Write-Host "`n[2/5] Upload blob 'hello.txt'" -ForegroundColor Cyan
+        Set-Content -Path $tmpUp -Value $content -Encoding ascii
+        az storage blob upload --container-name $Container --name hello.txt --file $tmpUp --overwrite --connection-string $script:AzCliCS --output table
+
+        Write-Host "`n[3/5] List blobs" -ForegroundColor Cyan
+        az storage blob list --container-name $Container --connection-string $script:AzCliCS --output table
+
+        Write-Host "`n[4/5] Download blob" -ForegroundColor Cyan
+        az storage blob download --container-name $Container --name hello.txt --file $tmpDown --connection-string $script:AzCliCS --output none
+        $roundTrip = (Get-Content $tmpDown -Raw).Trim()
+        if ($roundTrip -eq $content) {
+            Write-Host "Round-trip OK: content matches." -ForegroundColor Green
+        } else {
+            Write-Host "Round-trip MISMATCH!`n expected: $content`n got:      $roundTrip" -ForegroundColor Red
+        }
+
+        Write-Host "`n[5/5] Cleanup (delete container)" -ForegroundColor Cyan
+        az storage container delete --name $Container --connection-string $script:AzCliCS --output table
+        Write-Host "`nSmoke test complete." -ForegroundColor Green
+    }
+    finally {
+        Remove-Item $tmpUp, $tmpDown -ErrorAction SilentlyContinue
+    }
+}
+
+function Test-AzuriteQueue {
+    <# End-to-end queue smoke test: create queue, enqueue, peek, verify, cleanup. #>
+    [CmdletBinding()]
+    param([string]$Queue = "smoketestq$((Get-Random -Maximum 99999))")
+
+    Assert-AzuriteContext
+    $content = "azurite queue smoke test @ $(Get-Date -Format o)"
+
+    Write-Host "`n[1/4] Create queue '$Queue'" -ForegroundColor Cyan
+    az storage queue create --name $Queue --connection-string $script:AzCliCS --output table
+
+    Write-Host "`n[2/4] Enqueue message" -ForegroundColor Cyan
+    az storage message put --queue-name $Queue --content $content --connection-string $script:AzCliCS --output table
+
+    Write-Host "`n[3/4] Peek and verify message" -ForegroundColor Cyan
+    $roundTrip = (az storage message peek --queue-name $Queue --num-messages 1 --connection-string $script:AzCliCS --query "[0].content" -o tsv).Trim()
+    if ($roundTrip -eq $content) {
+        Write-Host "Round-trip OK: message content matches." -ForegroundColor Green
+    }
+    else {
+        Write-Host "Round-trip MISMATCH!`n expected: $content`n got:      $roundTrip" -ForegroundColor Red
+    }
+
+    Write-Host "`n[4/4] Cleanup (delete queue)" -ForegroundColor Cyan
+    az storage queue delete --name $Queue --connection-string $script:AzCliCS --output table
+    Write-Host "`nQueue smoke test complete." -ForegroundColor Green
+}
+
+function Test-AzuriteTable {
+    <# End-to-end table smoke test: create table, insert entity, query, verify, cleanup. #>
+    [CmdletBinding()]
+    param([string]$Table = "smoketab$((Get-Random -Maximum 99999))")
+
+    Assert-AzuriteContext
+    $partitionKey = "pk$((Get-Random -Maximum 99999))"
+    $rowKey = "rk$((Get-Random -Maximum 99999))"
+    $value = "azurite_table_smoke_$(Get-Date -Format 'yyyyMMddTHHmmssZ')"
+
+    Write-Host "`n[1/4] Create table '$Table'" -ForegroundColor Cyan
+    az storage table create --name $Table --connection-string $script:AzCliCS --output table
+
+    Write-Host "`n[2/4] Insert entity" -ForegroundColor Cyan
+    az storage entity insert --table-name $Table --entity PartitionKey=$partitionKey RowKey=$rowKey Message=$value --connection-string $script:AzCliCS --output table
+
+    Write-Host "`n[3/4] Query and verify entity" -ForegroundColor Cyan
+    $roundTrip = (az storage entity query --table-name $Table --filter "PartitionKey eq '$partitionKey' and RowKey eq '$rowKey'" --select Message --connection-string $script:AzCliCS --query "items[0].Message" -o tsv).Trim()
+    if ($roundTrip -eq $value) {
+        Write-Host "Round-trip OK: entity value matches." -ForegroundColor Green
+    }
+    else {
+        Write-Host "Round-trip MISMATCH!`n expected: $value`n got:      $roundTrip" -ForegroundColor Red
+    }
+
+    Write-Host "`n[4/4] Cleanup (delete table)" -ForegroundColor Cyan
+    az storage table delete --name $Table --connection-string $script:AzCliCS --output table
+    Write-Host "`nTable smoke test complete." -ForegroundColor Green
+}
+
+function Test-AzuriteAll {
+    <# Full Azurite smoke test across Blob, Queue and Table. #>
+    [CmdletBinding()]
+    param()
+
+    Assert-AzuriteContext
+    Test-AzuriteBlob
+    Test-AzuriteQueue
+    Test-AzuriteTable
+}
+
+# When this script is RUN directly (.\scripts\azurite-cli.ps1) it auto-configures the
+# connection string and runs full blob/queue/table smoke tests - no extra input needed.
+# When it is DOT-SOURCED (. .\scripts\azurite-cli.ps1) it just loads the functions.
+if ($MyInvocation.InvocationName -ne '.') {
+    Use-Azurite
+    Test-AzuriteAll
+}
+else {
+    Write-Host "azurite-cli helpers loaded. Run 'Use-Azurite' to begin, then any 'az storage ...' command." -ForegroundColor DarkGray
+    Write-Host "Try smoke tests with: Test-AzuriteBlob, Test-AzuriteQueue, Test-AzuriteTable" -ForegroundColor DarkGray
+    Write-Host "Run all three with: Test-AzuriteAll" -ForegroundColor DarkGray
+}

--- a/scripts/azurite-cli.sh
+++ b/scripts/azurite-cli.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# azurite-cli.sh
+# Reusable helpers for testing a local Azurite instance with the official Azure CLI (`az storage`).
+# Bash equivalent of scripts/azurite-cli.ps1 — works on Linux, macOS, and WSL (no PowerShell needed).
+#
+# Quick start:
+#   source ./scripts/azurite-cli.sh     # load the functions into your current shell
+#   use_azurite                         # point the Azure CLI at local Azurite (sets connection string)
+#   az storage container list -o table
+#
+# After use_azurite, every `az storage ...` command targets Azurite automatically.
+#
+# Optional convenience wrappers (thin shortcuts over `az storage`):
+#   test_azurite_blob                   # runs a full blob lifecycle smoke test
+#   test_azurite_queue                  # runs a full queue lifecycle smoke test
+#   test_azurite_table                  # runs a full table lifecycle smoke test
+#   test_azurite_all                    # runs blob + queue + table smoke tests
+#   new_azurite_container mycontainer
+#   send_azurite_blob  mycontainer ./file.txt myblob.txt
+#   get_azurite_blobs  mycontainer
+#   receive_azurite_blob mycontainer myblob.txt ./out.txt
+
+# --- Default Azurite emulator credentials (well-known, safe for local dev only) ---
+AZ_CLI_ACCOUNT='devstoreaccount1'
+AZ_CLI_KEY='Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=='
+AZ_CLI_HOST='127.0.0.1'
+
+# Populated by use_azurite; consumed (explicitly) by every wrapper below.
+# NOTE: in WSL `az` is often the Windows az.exe, which does NOT see Linux exported
+# env vars. So helpers pass --connection-string "$AZ_CLI_CS" explicitly on every call.
+AZ_CLI_CS=''
+
+use_azurite() {
+    # Builds the Azurite connection string (covers Blob, Queue and Table) and stores it
+    # in AZ_CLI_CS. Also exports AZURE_STORAGE_CONNECTION_STRING for ad-hoc `az` commands.
+    # Optional args: host blobPort queuePort tablePort
+    local az_host="${1:-$AZ_CLI_HOST}"
+    local blob_port="${2:-10000}"
+    local queue_port="${3:-10001}"
+    local table_port="${4:-10002}"
+
+    AZ_CLI_CS="DefaultEndpointsProtocol=http;AccountName=${AZ_CLI_ACCOUNT};AccountKey=${AZ_CLI_KEY};BlobEndpoint=http://${az_host}:${blob_port}/${AZ_CLI_ACCOUNT};QueueEndpoint=http://${az_host}:${queue_port}/${AZ_CLI_ACCOUNT};TableEndpoint=http://${az_host}:${table_port}/${AZ_CLI_ACCOUNT};"
+    export AZURE_STORAGE_CONNECTION_STRING="$AZ_CLI_CS"
+
+    echo "Azure CLI is now pointed at Azurite (${az_host}  blob:${blob_port} queue:${queue_port} table:${table_port})."
+    echo "Helpers pass --connection-string explicitly, so this works in WSL too."
+}
+
+clear_azurite() {
+    # Removes the Azurite connection string so `az` targets real Azure / your login again.
+    AZ_CLI_CS=''
+    unset AZURE_STORAGE_CONNECTION_STRING
+    echo "Cleared Azurite connection string."
+}
+
+assert_azurite_context() {
+    if [ -z "${AZ_CLI_CS:-}" ]; then
+        echo "Connection string not set. Running use_azurite for you..."
+        use_azurite
+    fi
+}
+
+# --- Thin convenience wrappers (entirely optional; plain `az storage` works too) ---
+
+new_azurite_container() {
+    # usage: new_azurite_container <name>
+    assert_azurite_context
+    az storage container create --name "$1" --connection-string "$AZ_CLI_CS" --output table
+}
+
+send_azurite_blob() {
+    # usage: send_azurite_blob <container> <file> [blob-name]
+    assert_azurite_context
+    local container="$1" file="$2" name="${3:-}"
+    if [ -z "$name" ]; then name="$(basename "$file")"; fi
+    az storage blob upload --container-name "$container" --name "$name" --file "$file" --overwrite --connection-string "$AZ_CLI_CS" --output table
+}
+
+get_azurite_blobs() {
+    # usage: get_azurite_blobs <container>
+    assert_azurite_context
+    az storage blob list --container-name "$1" --connection-string "$AZ_CLI_CS" --output table
+}
+
+receive_azurite_blob() {
+    # usage: receive_azurite_blob <container> <blob-name> <destination>
+    assert_azurite_context
+    az storage blob download --container-name "$1" --name "$2" --file "$3" --connection-string "$AZ_CLI_CS" --output none
+    echo "Downloaded '$2' -> '$3'"
+}
+
+test_azurite_blob() {
+    # End-to-end blob smoke test: create container, upload, list, download, verify, cleanup.
+    # usage: test_azurite_blob [container-name]
+    assert_azurite_context
+
+    local container="${1:-smoketest$RANDOM}"
+    # Use the current directory for temp files so the path is valid for both a
+    # Linux-native az and a Windows az.exe invoked from WSL (/mnt/c/...).
+    local tmp_up="./.azurite-up-$$-$RANDOM.txt"
+    local tmp_down="./.azurite-down-$$-$RANDOM.txt"
+    local content="azurite smoke test @ $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    # shellcheck disable=SC2317
+    _cleanup() { rm -f "$tmp_up" "$tmp_down"; }
+    trap _cleanup RETURN
+
+    echo ""
+    echo "[1/5] Create container '$container'"
+    az storage container create --name "$container" --connection-string "$AZ_CLI_CS" --output table
+
+    echo ""
+    echo "[2/5] Upload blob 'hello.txt'"
+    printf '%s' "$content" > "$tmp_up"
+    az storage blob upload --container-name "$container" --name hello.txt --file "$tmp_up" --overwrite --connection-string "$AZ_CLI_CS" --output table
+
+    echo ""
+    echo "[3/5] List blobs"
+    az storage blob list --container-name "$container" --connection-string "$AZ_CLI_CS" --output table
+
+    echo ""
+    echo "[4/5] Download blob"
+    az storage blob download --container-name "$container" --name hello.txt --file "$tmp_down" --connection-string "$AZ_CLI_CS" --output none
+    local round_trip
+    round_trip="$(cat "$tmp_down" 2>/dev/null)"
+    if [ "$round_trip" = "$content" ]; then
+        echo "Round-trip OK: content matches."
+    else
+        echo "Round-trip MISMATCH!"
+        echo " expected: $content"
+        echo " got:      $round_trip"
+    fi
+
+    echo ""
+    echo "[5/5] Cleanup (delete container)"
+    az storage container delete --name "$container" --connection-string "$AZ_CLI_CS" --output table
+    echo ""
+    echo "Smoke test complete."
+}
+
+test_azurite_queue() {
+    # End-to-end queue smoke test: create queue, enqueue, peek, verify, cleanup.
+    # usage: test_azurite_queue [queue-name]
+    assert_azurite_context
+
+    local queue="${1:-smoketestq$RANDOM}"
+    local content="azurite queue smoke test @ $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    echo ""
+    echo "[1/4] Create queue '$queue'"
+    az storage queue create --name "$queue" --connection-string "$AZ_CLI_CS" --output table
+
+    echo ""
+    echo "[2/4] Enqueue message"
+    az storage message put --queue-name "$queue" --content "$content" --connection-string "$AZ_CLI_CS" --output table
+
+    echo ""
+    echo "[3/4] Peek and verify message"
+    local round_trip
+    round_trip="$(az storage message peek --queue-name "$queue" --num-messages 1 --connection-string "$AZ_CLI_CS" --query "[0].content" -o tsv 2>/dev/null | tr -d '\r')"
+    if [ "$round_trip" = "$content" ]; then
+        echo "Round-trip OK: message content matches."
+    else
+        echo "Round-trip MISMATCH!"
+        echo " expected: $content"
+        echo " got:      $round_trip"
+    fi
+
+    echo ""
+    echo "[4/4] Cleanup (delete queue)"
+    az storage queue delete --name "$queue" --connection-string "$AZ_CLI_CS" --output table
+    echo ""
+    echo "Queue smoke test complete."
+}
+
+test_azurite_table() {
+    # End-to-end table smoke test: create table, insert entity, query, verify, cleanup.
+    # usage: test_azurite_table [table-name]
+    assert_azurite_context
+
+    local table="${1:-smoketab$RANDOM}"
+    local partition_key="pk$RANDOM"
+    local row_key="rk$RANDOM"
+    local value="azurite_table_smoke_$(date -u +%Y%m%dT%H%M%SZ)"
+
+    echo ""
+    echo "[1/4] Create table '$table'"
+    az storage table create --name "$table" --connection-string "$AZ_CLI_CS" --output table
+
+    echo ""
+    echo "[2/4] Insert entity"
+    az storage entity insert --table-name "$table" --entity PartitionKey="$partition_key" RowKey="$row_key" Message="$value" --connection-string "$AZ_CLI_CS" --output table
+
+    echo ""
+    echo "[3/4] Query and verify entity"
+    local round_trip
+    round_trip="$(az storage entity query --table-name "$table" --filter "PartitionKey eq '$partition_key' and RowKey eq '$row_key'" --select Message --connection-string "$AZ_CLI_CS" --query "items[0].Message" -o tsv 2>/dev/null | tr -d '\r')"
+    if [ "$round_trip" = "$value" ]; then
+        echo "Round-trip OK: entity value matches."
+    else
+        echo "Round-trip MISMATCH!"
+        echo " expected: $value"
+        echo " got:      $round_trip"
+    fi
+
+    echo ""
+    echo "[4/4] Cleanup (delete table)"
+    az storage table delete --name "$table" --connection-string "$AZ_CLI_CS" --output table
+    echo ""
+    echo "Table smoke test complete."
+}
+
+test_azurite_all() {
+    # Full Azurite smoke test across Blob, Queue and Table.
+    # usage: test_azurite_all
+    assert_azurite_context
+
+    test_azurite_blob
+    test_azurite_queue
+    test_azurite_table
+}
+
+# When this script is SOURCED (source ./scripts/azurite-cli.sh) it just loads the functions.
+# When it is RUN directly (./scripts/azurite-cli.sh) it auto-configures the connection
+# string and runs full blob/queue/table smoke tests - no extra input needed.
+if [ -n "${BASH_SOURCE:-}" ] && [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+    echo "azurite-cli helpers loaded. Run 'use_azurite' to begin, then any 'az storage ...' command."
+    echo "Try smoke tests with: test_azurite_blob, test_azurite_queue, test_azurite_table"
+    echo "Run all three with: test_azurite_all"
+else
+    use_azurite
+    test_azurite_all
+fi

--- a/scripts/azurite-rest.ps1
+++ b/scripts/azurite-rest.ps1
@@ -1,0 +1,325 @@
+# azurite-rest.ps1
+# Helper to fire raw REST calls against Azurite using Shared Key (HMAC-SHA256) auth.
+#
+# Usage examples (run from a PowerShell prompt after dot-sourcing this file):
+#   . .\scripts\azurite-rest.ps1
+#   Invoke-Azurite -Service blob  -Method PUT -Resource 'mycontainer' -Query @{ restype = 'container' }
+#   Invoke-Azurite -Service blob  -Method GET -Resource ''           -Query @{ comp = 'list' }   # list containers
+#   Invoke-Azurite -Service blob  -Method PUT -Resource 'mycontainer/hello.txt' -Body 'Hello Azurite' -Headers @{ 'x-ms-blob-type' = 'BlockBlob' }
+#   Invoke-Azurite -Service blob  -Method GET -Resource 'mycontainer/hello.txt'
+#   Invoke-Azurite -Service blob  -Method GET -Resource 'mycontainer' -Query @{ restype = 'container'; comp = 'list' }  # list blobs
+#   Invoke-Azurite -Service blob  -Method DELETE -Resource 'mycontainer/hello.txt'
+#
+#   Invoke-Azurite -Service queue -Method PUT -Resource 'myqueue'
+#   Invoke-Azurite -Service queue -Method POST -Resource 'myqueue/messages' -Body '<QueueMessage><MessageText>aGVsbG8=</MessageText></QueueMessage>' -Headers @{ 'Content-Type' = 'application/xml' }
+#
+# Table service (different signature scheme - use Invoke-AzuriteTable):
+#   Invoke-AzuriteTable -Method POST -Resource 'Tables' -Body '{"TableName":"mytable"}'
+#   Invoke-AzuriteTable -Method GET  -Resource 'Tables'
+#   Invoke-AzuriteTable -Method POST -Resource 'mytable' -Body '{"PartitionKey":"p1","RowKey":"r1","Name":"Alice"}'
+#   Invoke-AzuriteTable -Method GET  -Resource "mytable(PartitionKey='p1',RowKey='r1')"
+#   Invoke-AzuriteTable -Method DELETE -Resource "mytable(PartitionKey='p1',RowKey='r1')" -Headers @{ 'If-Match' = '*' }
+
+$script:AzAccount = 'devstoreaccount1'
+$script:AzKey     = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=='
+$script:AzPorts   = @{ blob = 10000; queue = 10001; table = 10002 }
+
+function Invoke-Azurite {
+    param(
+        [ValidateSet('blob', 'queue', 'table')]
+        [string]$Service = 'blob',
+
+        [string]$Method = 'GET',
+
+        # Path after the account, e.g. 'mycontainer/hello.txt'
+        [string]$Resource = '',
+
+        # Query string parameters as a hashtable, e.g. @{ restype = 'container' }
+        [hashtable]$Query = @{},
+
+        # Extra request headers (e.g. x-ms-blob-type)
+        [hashtable]$Headers = @{},
+
+        # Request body (string)
+        [string]$Body = ''
+    )
+
+    $port = $script:AzPorts[$Service]
+    $apiVersion = '2025-05-05'
+    $date = [DateTime]::UtcNow.ToString('R')
+
+    # Build canonicalized query string (sorted, lowercased keys)
+    $sortedKeys = $Query.Keys | Sort-Object
+    $queryParts = foreach ($k in $sortedKeys) { "$($k.ToLowerInvariant()):$($Query[$k])" }
+    $canonicalizedQuery = ($queryParts -join "`n")
+
+    $uriQuery = ''
+    if ($Query.Count -gt 0) {
+        $pairs = foreach ($k in $sortedKeys) {
+            "$([uri]::EscapeDataString($k))=$([uri]::EscapeDataString([string]$Query[$k]))"
+        }
+        $uriQuery = '?' + ($pairs -join '&')
+    }
+
+    $bodyBytes  = [System.Text.Encoding]::UTF8.GetBytes($Body)
+    $contentLen = if ($bodyBytes.Length -gt 0) { "$($bodyBytes.Length)" } else { '' }
+    $contentType = if ($Headers.ContainsKey('Content-Type')) { $Headers['Content-Type'] } else { '' }
+
+    # Canonicalized headers: all x-ms-* headers, lowercased, sorted, joined with \n
+    $msHeaders = @{
+        'x-ms-date'    = $date
+        'x-ms-version' = $apiVersion
+    }
+    foreach ($h in $Headers.Keys) {
+        if ($h.ToLowerInvariant().StartsWith('x-ms-')) { $msHeaders[$h.ToLowerInvariant()] = $Headers[$h] }
+    }
+    $canonHeaders = ($msHeaders.Keys | Sort-Object | ForEach-Object { "$($_):$($msHeaders[$_])" }) -join "`n"
+
+    # Canonicalized resource. NOTE: for the emulator the account name appears twice.
+    $resourcePath = "/$script:AzAccount/$script:AzAccount"
+    if ($Resource) { $resourcePath += "/$Resource" }
+    $canonResource = $resourcePath
+    if ($canonicalizedQuery) { $canonResource += "`n$canonicalizedQuery" }
+
+    # String-to-sign (Blob/Queue Shared Key)
+    $stringToSign = @(
+        $Method.ToUpperInvariant()
+        ''               # Content-Encoding
+        ''               # Content-Language
+        $contentLen      # Content-Length ('' if 0)
+        ''               # Content-MD5
+        $contentType     # Content-Type
+        ''               # Date (using x-ms-date instead)
+        ''               # If-Modified-Since
+        ''               # If-Match
+        ''               # If-None-Match
+        ''               # If-Unmodified-Since
+        ''               # Range
+        $canonHeaders
+        $canonResource
+    ) -join "`n"
+
+    $keyBytes = [Convert]::FromBase64String($script:AzKey)
+    $hmac = [System.Security.Cryptography.HMACSHA256]::new($keyBytes)
+    $sig = [Convert]::ToBase64String($hmac.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($stringToSign)))
+    $authHeader = "SharedKey $($script:AzAccount):$sig"
+
+    $allHeaders = @{
+        'x-ms-date'     = $date
+        'x-ms-version'  = $apiVersion
+        'Authorization' = $authHeader
+    }
+    foreach ($h in $Headers.Keys) {
+        if ($h -ne 'Content-Type') { $allHeaders[$h] = $Headers[$h] }
+    }
+
+    $url = "http://127.0.0.1:$port/$script:AzAccount"
+    if ($Resource) { $url += "/$Resource" }
+    $url += $uriQuery
+
+    Write-Host ">> $Method $url" -ForegroundColor Cyan
+
+    $params = @{
+        Uri     = $url
+        Method  = $Method
+        Headers = $allHeaders
+    }
+    if ($bodyBytes.Length -gt 0) {
+        $params['Body'] = $bodyBytes
+        if ($contentType) { $params['ContentType'] = $contentType }
+    }
+
+    try {
+        Invoke-WebRequest @params -UseBasicParsing
+    }
+    catch {
+        Write-Host "ERROR: $($_.Exception.Message)" -ForegroundColor Red
+        # PowerShell 7+ exposes the response body here:
+        if ($_.ErrorDetails -and $_.ErrorDetails.Message) {
+            Write-Host $_.ErrorDetails.Message -ForegroundColor Yellow
+        }
+        # Windows PowerShell 5.1 fallback:
+        elseif ($_.Exception.Response -and ($_.Exception.Response -is [System.Net.HttpWebResponse])) {
+            $reader = [System.IO.StreamReader]::new($_.Exception.Response.GetResponseStream())
+            Write-Host $reader.ReadToEnd() -ForegroundColor Yellow
+        }
+    }
+}
+
+function Invoke-AzuriteTable {
+    # Table service uses a simpler 'SharedKey' signature than Blob/Queue:
+    #   StringToSign = VERB + \n + Content-MD5 + \n + Content-Type + \n + Date + \n + CanonicalizedResource
+    param(
+        [string]$Method = 'GET',
+
+        # Table resource, e.g. 'Tables', 'mytable', or "mytable(PartitionKey='p',RowKey='r')"
+        [string]$Resource = 'Tables',
+
+        # Query string parameters as a hashtable (only 'comp' participates in signing)
+        [hashtable]$Query = @{},
+
+        # Extra request headers (e.g. If-Match)
+        [hashtable]$Headers = @{},
+
+        # Request body (JSON string)
+        [string]$Body = ''
+    )
+
+    $port = $script:AzPorts['table']
+    $apiVersion = '2025-05-05'
+    $date = [DateTime]::UtcNow.ToString('R')
+
+    $bodyBytes = [System.Text.Encoding]::UTF8.GetBytes($Body)
+    # Content-Type is only sent (and therefore only signed) when there is a body.
+    if ($bodyBytes.Length -gt 0) {
+        $contentType = if ($Headers.ContainsKey('Content-Type')) { $Headers['Content-Type'] } else { 'application/json' }
+    }
+    else {
+        $contentType = ''
+    }
+
+    # Build query string for the URL (sorted)
+    $sortedKeys = $Query.Keys | Sort-Object
+    $uriQuery = ''
+    if ($Query.Count -gt 0) {
+        $pairs = foreach ($k in $sortedKeys) {
+            "$([uri]::EscapeDataString($k))=$([uri]::EscapeDataString([string]$Query[$k]))"
+        }
+        $uriQuery = '?' + ($pairs -join '&')
+    }
+
+    # CanonicalizedResource for Table = /account/resource, plus ?comp=... only if present.
+    # For the emulator the account name appears twice.
+    $canonResource = "/$script:AzAccount/$script:AzAccount/$Resource"
+    if ($Query.ContainsKey('comp')) { $canonResource += "?comp=$($Query['comp'])" }
+
+    $stringToSign = @(
+        $Method.ToUpperInvariant()
+        ''               # Content-MD5
+        $contentType     # Content-Type
+        $date            # Date
+        $canonResource
+    ) -join "`n"
+
+    $keyBytes = [Convert]::FromBase64String($script:AzKey)
+    $hmac = [System.Security.Cryptography.HMACSHA256]::new($keyBytes)
+    $sig = [Convert]::ToBase64String($hmac.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($stringToSign)))
+    $authHeader = "SharedKey $($script:AzAccount):$sig"
+
+    $allHeaders = @{
+        'x-ms-date'     = $date
+        'Date'          = $date
+        'x-ms-version'  = $apiVersion
+        'Authorization' = $authHeader
+        'Accept'        = 'application/json;odata=nometadata'
+        'DataServiceVersion' = '3.0;NetFx'
+    }
+    foreach ($h in $Headers.Keys) {
+        if ($h -ne 'Content-Type') { $allHeaders[$h] = $Headers[$h] }
+    }
+
+    $url = "http://127.0.0.1:$port/$script:AzAccount/$Resource$uriQuery"
+    Write-Host ">> $Method $url" -ForegroundColor Cyan
+
+    $params = @{
+        Uri     = $url
+        Method  = $Method
+        Headers = $allHeaders
+    }
+    if ($bodyBytes.Length -gt 0) {
+        $params['Body'] = $bodyBytes
+        $params['ContentType'] = $contentType
+    }
+
+    try {
+        Invoke-WebRequest @params -UseBasicParsing
+    }
+    catch {
+        Write-Host "ERROR: $($_.Exception.Message)" -ForegroundColor Red
+        if ($_.ErrorDetails -and $_.ErrorDetails.Message) {
+            Write-Host $_.ErrorDetails.Message -ForegroundColor Yellow
+        }
+        elseif ($_.Exception.Response -and ($_.Exception.Response -is [System.Net.HttpWebResponse])) {
+            $reader = [System.IO.StreamReader]::new($_.Exception.Response.GetResponseStream())
+            Write-Host $reader.ReadToEnd() -ForegroundColor Yellow
+        }
+    }
+}
+
+function Test-AzuriteRest {
+    # End-to-end smoke test of the raw REST helpers across Blob, Queue and Table.
+    # Includes explicit round-trip assertions so failures are visible and actionable.
+    $container = "resttest$(Get-Random -Maximum 9999)"
+    $queue     = "resttest$(Get-Random -Maximum 9999)"
+    $table     = "resttest$(Get-Random -Maximum 9999)"
+
+    Write-Host "`n===== BLOB =====" -ForegroundColor Magenta
+    Write-Host "[1] Create container" -ForegroundColor Cyan
+    $blobCreate = Invoke-Azurite -Service blob -Method PUT -Resource $container -Query @{ restype = 'container' }
+    if (-not $blobCreate) { throw "Blob create container failed." }
+
+    Write-Host "[2] Upload blob" -ForegroundColor Cyan
+    $blobUpload = Invoke-Azurite -Service blob -Method PUT -Resource "$container/hello.txt" -Body 'Hello Azurite REST' -Headers @{ 'x-ms-blob-type' = 'BlockBlob'; 'Content-Type' = 'text/plain' }
+    if (-not $blobUpload) { throw "Blob upload failed." }
+
+    Write-Host "[3] Download blob and verify" -ForegroundColor Cyan
+    $blobGet = Invoke-Azurite -Service blob -Method GET -Resource "$container/hello.txt"
+    if (-not $blobGet) { throw "Blob download failed." }
+    $blob = $blobGet.Content
+    if ($blob -ne 'Hello Azurite REST') { throw "Blob round-trip mismatch. Expected 'Hello Azurite REST', got '$blob'." }
+    Write-Host "Round-trip OK: blob content matches." -ForegroundColor Green
+
+    Write-Host "[4] Delete container" -ForegroundColor Cyan
+    $blobDelete = Invoke-Azurite -Service blob -Method DELETE -Resource $container -Query @{ restype = 'container' }
+    if (-not $blobDelete) { throw "Blob delete container failed." }
+
+    Write-Host "`n===== QUEUE =====" -ForegroundColor Magenta
+    Write-Host "[1] Create queue" -ForegroundColor Cyan
+    $queueCreate = Invoke-Azurite -Service queue -Method PUT -Resource $queue
+    if (-not $queueCreate) { throw "Queue create failed." }
+
+    Write-Host "[2] Put message" -ForegroundColor Cyan
+    $queuePut = Invoke-Azurite -Service queue -Method POST -Resource "$queue/messages" -Body '<QueueMessage><MessageText>aGVsbG8=</MessageText></QueueMessage>' -Headers @{ 'Content-Type' = 'application/xml' }
+    if (-not $queuePut) { throw "Queue put message failed." }
+
+    Write-Host "[3] Peek messages and verify" -ForegroundColor Cyan
+    $queuePeek = Invoke-Azurite -Service queue -Method GET -Resource "$queue/messages" -Query @{ peekonly = 'true' }
+    if (-not $queuePeek) { throw "Queue peek failed." }
+    [xml]$queueXml = $queuePeek.Content
+    $msgBase64 = $queueXml.QueueMessagesList.QueueMessage.MessageText
+    $decodedMsg = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($msgBase64))
+    if ($decodedMsg -ne 'hello') { throw "Queue round-trip mismatch. Expected 'hello', got '$decodedMsg'." }
+    Write-Host "Round-trip OK: queue message matches." -ForegroundColor Green
+
+    Write-Host "[4] Delete queue" -ForegroundColor Cyan
+    $queueDelete = Invoke-Azurite -Service queue -Method DELETE -Resource $queue
+    if (-not $queueDelete) { throw "Queue delete failed." }
+
+    Write-Host "`n===== TABLE =====" -ForegroundColor Magenta
+    Write-Host "[1] Create table" -ForegroundColor Cyan
+    $tableCreate = Invoke-AzuriteTable -Method POST -Resource 'Tables' -Body "{`"TableName`":`"$table`"}"
+    if (-not $tableCreate) { throw "Table create failed." }
+
+    Write-Host "[2] Insert entity" -ForegroundColor Cyan
+    $tableInsert = Invoke-AzuriteTable -Method POST -Resource $table -Body '{"PartitionKey":"p1","RowKey":"r1","Name":"Alice"}'
+    if (-not $tableInsert) { throw "Table insert entity failed." }
+
+    Write-Host "[3] Query entity and verify" -ForegroundColor Cyan
+    $tableGet = Invoke-AzuriteTable -Method GET -Resource "$table(PartitionKey='p1',RowKey='r1')"
+    if (-not $tableGet) { throw "Table query entity failed." }
+    $entity = $tableGet.Content | ConvertFrom-Json
+    if ($entity.Name -ne 'Alice') { throw "Table round-trip mismatch. Expected Name='Alice', got '$($entity.Name)'." }
+    Write-Host "Round-trip OK: table entity matches." -ForegroundColor Green
+
+    Write-Host "[4] Delete table" -ForegroundColor Cyan
+    $tableDelete = Invoke-AzuriteTable -Method DELETE -Resource "Tables('$table')" -Headers @{ 'If-Match' = '*' }
+    if (-not $tableDelete) { throw "Table delete failed." }
+
+    Write-Host "`nREST smoke test complete. All checks passed." -ForegroundColor Green
+}
+
+# When RUN directly (.\scripts\azurite-rest.ps1) auto-run the full REST smoke test.
+# When DOT-SOURCED (. .\scripts\azurite-rest.ps1) just load the functions.
+if ($MyInvocation.InvocationName -ne '.') {
+    Test-AzuriteRest
+}


### PR DESCRIPTION
This pull request introduces reusable helper scripts for working with a local Azurite emulator using the Azure CLI, supporting both PowerShell and Bash environments. These scripts provide convenience functions and end-to-end smoke tests for Blob, Queue, and Table storage, making local development and testing with Azurite much easier across Windows, Linux, macOS, and WSL.
