### PR TITLE
Support startFrom on List Blobs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -57,6 +57,7 @@ Blob:
 - Harden transactional checksum validation for `PutBlob`, `StageBlock`, `AppendBlock`, and `PutPage`: unified MD5/CRC64 validation logic with accurate `InvalidMd5`/`InvalidHeaderValue` (malformed) and `Md5Mismatch`/`Crc64Mismatch` (mismatch) errors, matching real Azure semantics verified against live.
 - Fix `x-ms-blob-content-md5` precedence over `Content-MD5` for `PutBlob` transit integrity verification, matching real Azure behavior.
 - Make `CopyBlobFromURL` echo back the source `Content-MD5` when supplied via `x-ms-source-content-md5`, matching real Azure behavior.
+- Added support for the `startFrom` query parameter on `List Blobs` (service version `2026-02-06`), which begins a flat or hierarchical listing at the given blob name. Unlike `marker`, which is exclusive, `startFrom` is inclusive, and the two compose when paging a listing that began at `startFrom`. Previously the parameter was accepted but ignored.
 
 Queue:
 

--- a/README.md
+++ b/README.md
@@ -1060,7 +1060,7 @@ Detailed support matrix:
   - Set Container ACL
   - Delete Container
   - Lease Container
-  - List Blobs
+  - List Blobs (supports the startFrom parameter added in API version 2026-02-06)
   - Put Blob (Create append blob is not supported)
   - Get Blob
   - Get Blob Properties

--- a/src/blob/handlers/ContainerHandler.ts
+++ b/src/blob/handlers/ContainerHandler.ts
@@ -677,7 +677,8 @@ export default class ContainerHandler extends BaseHandler
       options.maxresults,
       marker,
       includeSnapshots,
-      includeUncommittedBlobs
+      includeUncommittedBlobs,
+      request.getQuery("startFrom")
     );
 
     const serviceEndpoint = `${request.getEndpoint()}/${accountName}`;
@@ -783,7 +784,8 @@ export default class ContainerHandler extends BaseHandler
       options.maxresults,
       marker,
       includeSnapshots,
-      includeUncommittedBlobs
+      includeUncommittedBlobs,
+      request.getQuery("startFrom")
     );
 
     const serviceEndpoint = `${request.getEndpoint()}/${accountName}`;

--- a/src/blob/handlers/ContainerHandler.ts
+++ b/src/blob/handlers/ContainerHandler.ts
@@ -680,7 +680,8 @@ export default class ContainerHandler extends BaseHandler
       options.maxresults,
       marker,
       includeSnapshots,
-      includeUncommittedBlobs
+      includeUncommittedBlobs,
+      request.getQuery("startFrom")
     );
 
     const serviceEndpoint = `${request.getEndpoint()}/${accountName}`;
@@ -786,7 +787,8 @@ export default class ContainerHandler extends BaseHandler
       options.maxresults,
       marker,
       includeSnapshots,
-      includeUncommittedBlobs
+      includeUncommittedBlobs,
+      request.getQuery("startFrom")
     );
 
     const serviceEndpoint = `${request.getEndpoint()}/${accountName}`;

--- a/src/blob/persistence/IBlobMetadataStore.ts
+++ b/src/blob/persistence/IBlobMetadataStore.ts
@@ -495,7 +495,8 @@ export interface IBlobMetadataStore
     maxResults?: number,
     marker?: string,
     includeSnapshots?: boolean,
-    includeUncommittedBlobs?: boolean
+    includeUncommittedBlobs?: boolean,
+    startFrom?: string
   ): Promise<[BlobModel[], BlobPrefixModel[], string | undefined]>;
 
   listAllBlobs(

--- a/src/blob/persistence/LokiBlobMetadataStore.ts
+++ b/src/blob/persistence/LokiBlobMetadataStore.ts
@@ -919,7 +919,8 @@ export default class LokiBlobMetadataStore
     maxResults: number = DEFAULT_LIST_BLOBS_MAX_RESULTS,
     marker: string = "",
     includeSnapshots?: boolean,
-    includeUncommittedBlobs?: boolean
+    includeUncommittedBlobs?: boolean,
+    startFrom?: string
   ): Promise<[BlobModel[], BlobPrefixModel[], string | undefined]> {
     const query: any = {};
     if (prefix !== "") {
@@ -947,6 +948,12 @@ export default class LokiBlobMetadataStore
         .find(query)
         .where((obj) => {
           return obj.name > marker!;
+        })
+        .where((obj) => {
+          // startFrom is inclusive where marker is exclusive, and the two
+          // compose: paging a listing that began at startFrom advances the
+          // marker past it anyway.
+          return startFrom === undefined ? true : obj.name >= startFrom;
         })
         .where((obj) => {
           return includeSnapshots ? true : obj.snapshot.length === 0;

--- a/src/blob/persistence/SqlBlobMetadataStore.ts
+++ b/src/blob/persistence/SqlBlobMetadataStore.ts
@@ -1300,7 +1300,8 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
     maxResults: number = DEFAULT_LIST_BLOBS_MAX_RESULTS,
     marker?: string,
     includeSnapshots?: boolean,
-    includeUncommittedBlobs?: boolean
+    includeUncommittedBlobs?: boolean,
+    startFrom?: string
   ): Promise<[BlobModel[], BlobPrefixModel[], any | undefined]> {
     return this.sequelize.transaction(async (t) => {
       await this.assertContainerExists(context, account, container, t);
@@ -1325,6 +1326,19 @@ export default class SqlBlobMetadataStore implements IBlobMetadataStore {
           } else {
             whereQuery.blobName = {
               [Op.gt]: marker
+            };
+          }
+        }
+
+        // startFrom is inclusive where marker is exclusive, and the two
+        // compose: paging a listing that began at startFrom advances the
+        // marker past it anyway.
+        if (startFrom !== undefined) {
+          if (whereQuery.blobName !== undefined) {
+            whereQuery.blobName[Op.gte] = startFrom;
+          } else {
+            whereQuery.blobName = {
+              [Op.gte]: startFrom
             };
           }
         }

--- a/tests/blob/apis/container.test.ts
+++ b/tests/blob/apis/container.test.ts
@@ -4,6 +4,7 @@ import {
   AccountSASServices,
   AnonymousCredential,
   BlobServiceClient,
+  ContainerClient,
   generateAccountSASQueryParameters,
   newPipeline,
   StorageSharedKeyCredential,
@@ -1712,4 +1713,100 @@ describe("ContainerAPIs", () => {
     assert.strictEqual(false, await containerClient.exists());
     assert.strictEqual(false, await blockBlobClient.exists());
   });
+
+  it("listBlobsFlat with startFrom should begin at that blob name @loki @sql", async () => {
+    // "b&c" needs encoding to survive the query string: a bare & ends the
+    // parameter, leaving a startFrom of "b" that admits one blob too many.
+    const names = ["a", "b", "b&c", "c"];
+    for (const name of names) {
+      await containerClient.getBlockBlobClient(name).upload("", 0);
+    }
+
+    const listFrom = async (startFrom: string) => {
+      const page = (
+        await listBlobsWithStartFrom(startFrom).listBlobsFlat().byPage().next()
+      ).value;
+      return page.segment.blobItems.map((item: any) => item.name);
+    };
+
+    // startFrom is inclusive, unlike the marker
+    assert.deepStrictEqual(await listFrom("b"), ["b", "b&c", "c"]);
+    assert.deepStrictEqual(await listFrom("b&c"), ["b&c", "c"]);
+    // A name no blob carries still starts the listing at the right place
+    assert.deepStrictEqual(await listFrom("b0"), ["c"]);
+    // One before every blob returns them all, as delta lake asks for
+    assert.deepStrictEqual(await listFrom("0"), names);
+
+    for (const name of names) {
+      await containerClient.getBlockBlobClient(name).delete();
+    }
+  });
+
+  it("listBlobsByHierarchy with startFrom should begin at that blob name @loki @sql", async () => {
+    const names = ["a/1", "a/2", "b/1", "c"];
+    for (const name of names) {
+      await containerClient.getBlockBlobClient(name).upload("", 0);
+    }
+
+    const listFrom = async (startFrom: string) => {
+      const page = (
+        await listBlobsWithStartFrom(startFrom)
+          .listBlobsByHierarchy("/")
+          .byPage()
+          .next()
+      ).value;
+      return [
+        (page.segment.blobPrefixes ?? []).map((p: any) => p.name),
+        page.segment.blobItems.map((item: any) => item.name)
+      ];
+    };
+
+    // startFrom selects blobs before the delimiter squashes them into
+    // prefixes, so a prefix survives only while one of its blobs does.
+    assert.deepStrictEqual(await listFrom("0"), [["a/", "b/"], ["c"]]);
+    assert.deepStrictEqual(await listFrom("a/2"), [["a/", "b/"], ["c"]]);
+    assert.deepStrictEqual(await listFrom("b/"), [["b/"], ["c"]]);
+    assert.deepStrictEqual(await listFrom("c"), [[], ["c"]]);
+
+    for (const name of names) {
+      await containerClient.getBlockBlobClient(name).delete();
+    }
+  });
+
+  // The JS SDK has no startFrom yet, so put it on the wire by rewriting the
+  // query of a SAS-authenticated request.  A blob name is arbitrary text, so
+  // it is encoded the way a client would have to encode it.
+  function listBlobsWithStartFrom(startFrom: string): ContainerClient {
+    const storageSharedKeyCredential = new StorageSharedKeyCredential(
+      EMULATOR_ACCOUNT_NAME,
+      EMULATOR_ACCOUNT_KEY
+    );
+    const tmr = new Date();
+    tmr.setDate(tmr.getDate() + 1);
+    const sas = generateAccountSASQueryParameters(
+      {
+        expiresOn: tmr,
+        permissions: AccountSASPermissions.parse("rl"),
+        resourceTypes: AccountSASResourceTypes.parse("sco").toString(),
+        services: AccountSASServices.parse("b").toString(),
+        version: "2020-04-08"
+      },
+      storageSharedKeyCredential as StorageSharedKeyCredential
+    ).toString();
+
+    const pipeline = newPipeline(new AnonymousCredential(), {
+      retryOptions: { maxTries: 1 },
+      keepAliveOptions: { enable: false }
+    });
+    pipeline.factories.unshift(
+      new QueryRequestPolicyFactory(
+        "restype=container",
+        `restype=container&startFrom=${encodeURIComponent(startFrom)}`
+      )
+    );
+    return new BlobServiceClient(
+      `${baseURL}?${sas}`,
+      pipeline
+    ).getContainerClient(containerName);
+  }
 });

--- a/tests/blob/apis/container.test.ts
+++ b/tests/blob/apis/container.test.ts
@@ -4,6 +4,7 @@ import {
   AccountSASServices,
   AnonymousCredential,
   BlobServiceClient,
+  ContainerClient,
   generateAccountSASQueryParameters,
   newPipeline,
   StorageSharedKeyCredential,
@@ -1713,4 +1714,111 @@ describe("ContainerAPIs", () => {
     assert.strictEqual(false, await containerClient.exists());
     assert.strictEqual(false, await blockBlobClient.exists());
   });
+
+  it("listBlobsFlat with startFrom should begin at that blob name @loki @sql", async () => {
+    // "b&c" needs encoding to survive the query string: a bare & ends the
+    // parameter, leaving a startFrom of "b" that admits one blob too many.
+    const names = ["a", "b", "b&c", "c"];
+    for (const name of names) {
+      await containerClient.getBlockBlobClient(name).upload("", 0);
+    }
+
+    const listFrom = async (startFrom: string) => {
+      const page = (
+        await listBlobsWithStartFrom(startFrom).listBlobsFlat().byPage().next()
+      ).value;
+      return page.segment.blobItems.map((item: any) => item.name);
+    };
+
+    // startFrom is inclusive, unlike the marker
+    assert.deepStrictEqual(await listFrom("b"), ["b", "b&c", "c"]);
+    assert.deepStrictEqual(await listFrom("b&c"), ["b&c", "c"]);
+    // A name no blob carries still starts the listing at the right place
+    assert.deepStrictEqual(await listFrom("b0"), ["c"]);
+    // One before every blob returns them all, as delta lake asks for
+    assert.deepStrictEqual(await listFrom("0"), names);
+
+    // Paging composes with startFrom: every page request carries both
+    // parameters, and the exclusive marker advances past the inclusive
+    // startFrom blob rather than re-admitting it.
+    const pages: string[][] = [];
+    for await (const page of listBlobsWithStartFrom("b")
+      .listBlobsFlat()
+      .byPage({ maxPageSize: 1 })) {
+      pages.push(page.segment.blobItems.map((item: any) => item.name));
+    }
+    assert.deepStrictEqual(pages, [["b"], ["b&c"], ["c"]]);
+
+    for (const name of names) {
+      await containerClient.getBlockBlobClient(name).delete();
+    }
+  });
+
+  it("listBlobsByHierarchy with startFrom should begin at that blob name @loki @sql", async () => {
+    const names = ["a/1", "a/2", "b/1", "c"];
+    for (const name of names) {
+      await containerClient.getBlockBlobClient(name).upload("", 0);
+    }
+
+    const listFrom = async (startFrom: string) => {
+      const page = (
+        await listBlobsWithStartFrom(startFrom)
+          .listBlobsByHierarchy("/")
+          .byPage()
+          .next()
+      ).value;
+      return [
+        (page.segment.blobPrefixes ?? []).map((p: any) => p.name),
+        page.segment.blobItems.map((item: any) => item.name)
+      ];
+    };
+
+    // startFrom selects blobs before the delimiter squashes them into
+    // prefixes, so a prefix survives only while one of its blobs does.
+    assert.deepStrictEqual(await listFrom("0"), [["a/", "b/"], ["c"]]);
+    assert.deepStrictEqual(await listFrom("a/2"), [["a/", "b/"], ["c"]]);
+    assert.deepStrictEqual(await listFrom("b/"), [["b/"], ["c"]]);
+    assert.deepStrictEqual(await listFrom("c"), [[], ["c"]]);
+
+    for (const name of names) {
+      await containerClient.getBlockBlobClient(name).delete();
+    }
+  });
+
+  // The JS SDK has no startFrom yet, so put it on the wire by rewriting the
+  // query of a SAS-authenticated request.  A blob name is arbitrary text, so
+  // it is encoded the way a client would have to encode it.
+  function listBlobsWithStartFrom(startFrom: string): ContainerClient {
+    const storageSharedKeyCredential = new StorageSharedKeyCredential(
+      EMULATOR_ACCOUNT_NAME,
+      EMULATOR_ACCOUNT_KEY
+    );
+    const tmr = new Date();
+    tmr.setDate(tmr.getDate() + 1);
+    const sas = generateAccountSASQueryParameters(
+      {
+        expiresOn: tmr,
+        permissions: AccountSASPermissions.parse("rl"),
+        resourceTypes: AccountSASResourceTypes.parse("sco").toString(),
+        services: AccountSASServices.parse("b").toString(),
+        version: "2020-04-08"
+      },
+      storageSharedKeyCredential as StorageSharedKeyCredential
+    ).toString();
+
+    const pipeline = newPipeline(new AnonymousCredential(), {
+      retryOptions: { maxTries: 1 },
+      keepAliveOptions: { enable: false }
+    });
+    pipeline.factories.unshift(
+      new QueryRequestPolicyFactory(
+        "restype=container",
+        `restype=container&startFrom=${encodeURIComponent(startFrom)}`
+      )
+    );
+    return new BlobServiceClient(
+      `${baseURL}?${sas}`,
+      pipeline
+    ).getContainerClient(containerName);
+  }
 });


### PR DESCRIPTION
Service version 2026-02-06 adds a startFrom query parameter to List
Blobs, which begins a listing at a given blob name.  Azurite accepts that
version but ignored the parameter, so a client asking to start partway
through was handed the container from the beginning.

Unlike marker, which is a name Azurite has already returned and which it
treats as exclusive, startFrom names any blob and includes it.  The two
compose rather than conflict: paging a listing that began at startFrom
carries a marker past it, so both filters can apply and neither has to
exclude the other.

Both metadata stores learn the parameter, and the handlers read it off
the request rather than the generated operation parameters, since the
swagger this repository generates from predates it.

The tests drive the parameter by rewriting the query of a
SAS-authenticated request, the same way the include= tests do, because
the JavaScript SDK this repository depends on has no startFrom yet.  A
blob name is arbitrary text, so the value is encoded as a client would
have to encode it, and one of the names carries an ampersand: unencoded
it would end the parameter early and leave a startFrom that admits a blob
too many.

The hierarchical listing takes the parameter too, so it is covered as
well.  A delimiter squashes blobs into prefixes after startFrom has
selected them, so a prefix survives exactly while one of its blobs does.