### PR TITLE
Use a user-owned PAT to trigger Copilot's coding agent on Dependabot PRs

### DIFF
--- a/.github/workflows/copilot-dependabot-agent.yml
+++ b/.github/workflows/copilot-dependabot-agent.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Ask Copilot to work the PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: gh pr comment "$PR_NUMBER" --body-file .github/copilot-dependabot-instructions.md


### PR DESCRIPTION
## Why

`copilot-dependabot-agent.yml` posts an `@copilot ...` comment on new Dependabot PRs to hand them to GitHub Copilot's coding agent. We confirmed (via PR timeline `copilot_work_started` events) that comments authored by `github-actions[bot]` using the default `GITHUB_TOKEN` never actually trigger the coding agent — only comments from a real user account with write access do. This is enforced by an org-level, locked Copilot Cloud Agent policy ("Only allow automations to be triggered by users with write access").

This matches how other Azure-org repos (`apiops-cli`, `fleet`, `agents-on-aks`, `azure-sdk-tools`'s gh-aw workflows) solve the same problem: a classic/fine-grained PAT from a real account with a Copilot seat, stored as a repo secret.

## Change

Swap the token used for the `gh pr comment` step from `secrets.GITHUB_TOKEN` to `secrets.COPILOT_ASSIGN_TOKEN` (a classic PAT, `public_repo` scope only, since Azurite is public). The secret has already been added to this repo.

## Test plan

- [ ] Confirm the next Dependabot PR gets a `@copilot` comment authored by the PAT owner
- [ ] Confirm a `copilot_work_started` timeline event appears shortly after