### PR TITLE
Fix blob hang after client disconnect

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,10 @@ General:
 - Updated the lockfile-resolved `@types/vscode` dev dependency from 1.134.0 to 1.136.0 for current VS Code API declarations; added `tests/common/vscStatusBarItem.test.ts` covering the extension status bar transitions against the updated typings.
 - Updated the lockfile-resolved `globals` dev dependency from 17.11.0 to 17.12.0 for a refreshed list of environment global identifiers used by ESLint config.
 
+Blob:
+
+- Fixed blob operations hanging when a client disconnects before the operation queue processes the request. (issue #2575)
+
 Table:
 
 - Fix `azurite-table` startup banner reporting the configured port (e.g. `0` when using OS-assigned ports) instead of the actual bound address. Now uses `server.getHttpServerAddress()` to match `azurite-blob` and `azurite-queue`.

--- a/src/common/persistence/FSExtentStore.ts
+++ b/src/common/persistence/FSExtentStore.ts
@@ -518,6 +518,17 @@ export default class FSExtentStore implements IExtentStore {
       let count: number = 0;
       let wsEnd = false;
 
+      if (!rs.readable) {
+        this.logger.debug(
+          `FSExtentStore:streamPipe() Readable stream is not readable, rejecting streamPipe.`,
+          contextId
+        );
+        reject(
+          new Error(`FSExtentStore:streamPipe() Readable stream is not readable.`)
+        );
+        return;
+      }
+
       rs.on("data", data => {
         count += data.length;
         if (!ws.write(data)) {

--- a/tests/blob/fsStore.test.ts
+++ b/tests/blob/fsStore.test.ts
@@ -52,6 +52,19 @@ describe("FSExtentStore", () => {
     assert.strictEqual(await readIntoString(readable3), "Test");
   });
 
+  it("should handle destroyed input stream during appendExtent @loki", async () => {
+    const store = new FSExtentStore(metadataStore, DEFAULT_BLOB_PERSISTENCE_ARRAY, logger);
+    await store.init();
+
+    const stream = Readable.from("Test", { objectMode: false });
+    stream.destroy();
+
+    await assert.rejects(
+      store.appendExtent(stream),
+      new Error(`FSExtentStore:streamPipe() Readable stream is not readable.`)
+    );
+  });
+
   it("should append and read back a sliced Buffer @loki", async () => {
     const store = new FSExtentStore(metadataStore, DEFAULT_BLOB_PERSISTENCE_ARRAY, logger);
     await store.init();


### PR DESCRIPTION
## Summary

Carries forward @nvartolomei's fix from #2575 on top of current `main`.
BugFix: Prevent hang when client disconnects under load

In Azurite, all operations are managed through concurrent operation queues. A bug was identified where operations could hang indefinitely if the client disconnected before the operation was processed.

This occurred because Azurite would attempt to attach event handlers to the request's readable stream (body) after it had already been closed by the client's disconnection. Since a closed stream emits no further events (like 'data', 'close', or 'error'), the operation would never complete, causing a permanent hang.

This fix addresses the issue by checking if the request stream is still readable before attaching any event handlers. This ensures that we only process requests that are still active, preventing the hang and allowing
the queues to continue processing other operations.
- reject `FSExtentStore.streamPipe()` immediately when a queued request stream is no longer readable
- add regression coverage for a destroyed input stream
- document the fix in the upcoming release changelog
- address all three Copilot review comments from #2575 by using `assert.rejects`, naming the destroyed-stream scenario precisely, and simplifying the error construction

## Validation

- reproduced the original failure mode: terminal listeners attached after a stream is destroyed never fire and the operation times out
- `npx mocha --require ts-node/register --timeout 10000 --grep @loki --exit tests/blob/fsStore.test.ts` (5 passing)
- `npm run build`
- `npm run lint`
- `git diff --check`

Supersedes #2575.