### PR TITLE
Fix OAuth option validation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 
 General:
 
+- Fixed `--oauth` without a value crashing during startup and unsupported OAuth levels being silently ignored. Azurite now reports the supported OAuth levels across all command-line entrypoints. (issue #2525)
 - Updated `actions/checkout` from 4.4.0 to 7.0.1 and `actions/setup-node` from 4.4.0 to 7.0.0 so the CI workflows use the actions' Node.js 24 runtimes (workflow `node-version` settings are unchanged).
 - Fixed SharedKey/SharedKeyLite authentication failing when both `date` and `x-ms-date` request headers are present. Blob and Queue now sign an empty `Date` field and Table signs the `x-ms-date` value, matching Azure Storage. (issue #1385)
 - Updated lockfile-resolved (dev-only transitive via `ajv`) `fast-uri` from 3.1.5 to 3.1.7 to remediate URI authority injection and host confusion advisories.

--- a/src/blob/BlobEnvironment.ts
+++ b/src/blob/BlobEnvironment.ts
@@ -8,7 +8,10 @@ import {
   DEFAULT_BLOB_SERVER_HOST_NAME,
   DEFAULT_BLOB_KEEP_ALIVE_TIMEOUT
 } from "./utils/constants";
-import { shouldSkipApiVersionCheck } from "../common/utils/environment";
+import {
+  parseOAuthLevel,
+  shouldSkipApiVersionCheck
+} from "../common/utils/environment";
 
 if (!(args as any).config.name) {
   args
@@ -129,7 +132,7 @@ export default class BlobEnvironment implements IBlobEnvironment {
   }
 
   public oauth(): string | undefined {
-    return this.flags.oauth;
+    return parseOAuthLevel(this.flags.oauth);
   }
 
   public disableProductStyleUrl(): boolean {

--- a/src/common/ConfigurationBase.ts
+++ b/src/common/ConfigurationBase.ts
@@ -6,6 +6,7 @@ import { DEFAULT_EXTENT_MEMORY_LIMIT, SharedChunkStore } from "./persistence/Mem
 import { totalmem } from "os";
 import logger from "./Logger";
 import IEnvironment from "./IEnvironment";
+import { parseOAuthLevel } from "./utils/environment";
 
 export enum CertOptions {
   Default,
@@ -91,13 +92,7 @@ export default abstract class ConfigurationBase {
   }
 
   public getOAuthLevel(): undefined | OAuthLevel {
-    if (this.oauth) {
-      if (this.oauth.toLowerCase() === "basic") {
-        return OAuthLevel.BASIC;
-      }
-    }
-
-    return;
+    return parseOAuthLevel(this.oauth);
   }
 
   public getHttpServerAddress(): string {

--- a/src/common/Environment.ts
+++ b/src/common/Environment.ts
@@ -19,7 +19,7 @@ import {
 } from "../table/utils/constants";
 
 import IEnvironment from "./IEnvironment";
-import { shouldSkipApiVersionCheck } from "./utils/environment";
+import { parseOAuthLevel, shouldSkipApiVersionCheck } from "./utils/environment";
 
 args
   .option(
@@ -198,7 +198,7 @@ export default class Environment implements IEnvironment {
   }
 
   public oauth(): string | undefined {
-    return this.flags.oauth;
+    return parseOAuthLevel(this.flags.oauth);
   }
 
   public inMemoryPersistence(): boolean {

--- a/src/common/models.ts
+++ b/src/common/models.ts
@@ -1,3 +1,3 @@
 export enum OAuthLevel {
-  BASIC // Phase 1
+  BASIC = "basic" // Phase 1
 }

--- a/src/common/utils/environment.ts
+++ b/src/common/utils/environment.ts
@@ -1,3 +1,24 @@
+import { OAuthLevel } from "../models";
+
+export function parseOAuthLevel(value: unknown): OAuthLevel | undefined {
+  if (value === undefined) {
+    return;
+  }
+
+  if (
+    typeof value === "string" &&
+    Object.values(OAuthLevel).includes(value.toLowerCase() as OAuthLevel)
+  ) {
+    return value.toLowerCase() as OAuthLevel;
+  }
+
+  throw new RangeError(
+    `Must provide a valid value for parameter --oauth. Supported values: ${Object.values(
+      OAuthLevel
+    ).join(", ")}.`
+  );
+}
+
 /**
  * Determines whether API version checks should be skipped.
  *

--- a/src/queue/QueueEnvironment.ts
+++ b/src/queue/QueueEnvironment.ts
@@ -5,7 +5,10 @@ import {
   DEFAULT_QUEUE_LISTENING_PORT,
   DEFAULT_QUEUE_SERVER_HOST_NAME
 } from "./utils/constants";
-import { shouldSkipApiVersionCheck } from "../common/utils/environment";
+import {
+  parseOAuthLevel,
+  shouldSkipApiVersionCheck
+} from "../common/utils/environment";
 
 args
   .option(
@@ -113,7 +116,7 @@ export default class QueueEnvironment implements IQueueEnvironment {
   }
 
   public oauth(): string | undefined {
-    return this.flags.oauth;
+    return parseOAuthLevel(this.flags.oauth);
   }
 
   public disableProductStyleUrl(): boolean {

--- a/src/table/TableEnvironment.ts
+++ b/src/table/TableEnvironment.ts
@@ -9,7 +9,10 @@ import {
   DEFAULT_TABLE_SERVER_HOST_NAME,
   DEFAULT_TABLE_KEEP_ALIVE_TIMEOUT
 } from "./utils/constants";
-import { shouldSkipApiVersionCheck } from "../common/utils/environment";
+import {
+  parseOAuthLevel,
+  shouldSkipApiVersionCheck
+} from "../common/utils/environment";
 
 args
   .option(
@@ -152,7 +155,7 @@ export default class TableEnvironment implements ITableEnvironment {
   }
 
   public oauth(): string | undefined {
-    return this.flags.oauth;
+    return parseOAuthLevel(this.flags.oauth);
   }
 
   public cert(): string | undefined {

--- a/tests/blob/blobEnvironment.test.ts
+++ b/tests/blob/blobEnvironment.test.ts
@@ -28,4 +28,22 @@ describe("BlobEnvironment", () => {
 
     assert.strictEqual(env.skipApiVersionCheck(), true);
   });
+
+  it("rejects --oauth without a value @loki", () => {
+    process.argv.push("--oauth");
+
+    assert.throws(
+      () => new BlobEnvironment().oauth(),
+      /Must provide a valid value for parameter --oauth/
+    );
+  });
+
+  it("rejects an unsupported --oauth value @loki", () => {
+    process.argv.push("--oauth", "invalid");
+
+    assert.throws(
+      () => new BlobEnvironment().oauth(),
+      /Must provide a valid value for parameter --oauth/
+    );
+  });
 });

--- a/tests/common/environment.test.ts
+++ b/tests/common/environment.test.ts
@@ -1,7 +1,10 @@
 import * as assert from "assert";
 
 import Environment from "../../src/common/Environment";
-import { shouldSkipApiVersionCheck } from "../../src/common/utils/environment";
+import {
+  parseOAuthLevel,
+  shouldSkipApiVersionCheck
+} from "../../src/common/utils/environment";
 
 describe("Environment", () => {
   const originalArgv = process.argv;
@@ -28,6 +31,34 @@ describe("Environment", () => {
     const env = new Environment();
 
     assert.strictEqual(env.skipApiVersionCheck(), true);
+  });
+
+  it("rejects --oauth without a value @loki", () => {
+    process.argv.push("--oauth");
+
+    assert.throws(
+      () => new Environment().oauth(),
+      /Must provide a valid value for parameter --oauth/
+    );
+  });
+
+  it("rejects an unsupported --oauth value @loki", () => {
+    process.argv.push("--oauth", "invalid");
+
+    assert.throws(
+      () => new Environment().oauth(),
+      /Must provide a valid value for parameter --oauth/
+    );
+  });
+
+  describe("parseOAuthLevel", () => {
+    it("accepts basic case-insensitively @loki", () => {
+      assert.strictEqual(parseOAuthLevel("BASIC"), "basic");
+    });
+
+    it("returns undefined when OAuth is not configured @loki", () => {
+      assert.strictEqual(parseOAuthLevel(undefined), undefined);
+    });
   });
 
   describe("shouldSkipApiVersionCheck", () => {

--- a/tests/queue/queueEnvironment.test.ts
+++ b/tests/queue/queueEnvironment.test.ts
@@ -28,4 +28,22 @@ describe("QueueEnvironment", () => {
 
     assert.strictEqual(env.skipApiVersionCheck(), true);
   });
+
+  it("rejects --oauth without a value @loki", () => {
+    process.argv.push("--oauth");
+
+    assert.throws(
+      () => new QueueEnvironment().oauth(),
+      /Must provide a valid value for parameter --oauth/
+    );
+  });
+
+  it("rejects an unsupported --oauth value @loki", () => {
+    process.argv.push("--oauth", "invalid");
+
+    assert.throws(
+      () => new QueueEnvironment().oauth(),
+      /Must provide a valid value for parameter --oauth/
+    );
+  });
 });

--- a/tests/table/tableEnvironment.test.ts
+++ b/tests/table/tableEnvironment.test.ts
@@ -28,4 +28,22 @@ describe("TableEnvironment", () => {
 
     assert.strictEqual(env.skipApiVersionCheck(), true);
   });
+
+  it("rejects --oauth without a value @loki", () => {
+    process.argv.push("--oauth");
+
+    assert.throws(
+      () => new TableEnvironment().oauth(),
+      /Must provide a valid value for parameter --oauth/
+    );
+  });
+
+  it("rejects an unsupported --oauth value @loki", () => {
+    process.argv.push("--oauth", "invalid");
+
+    assert.throws(
+      () => new TableEnvironment().oauth(),
+      /Must provide a valid value for parameter --oauth/
+    );
+  });
 });


### PR DESCRIPTION
## Description

Fixes #2525.
This pull request introduces stricter validation for the oauth flag across multiple environment classes and improves type safety in the ConfigurationBase class as highlighted in https://github.com/Azure/Azurite/issues/2525 . The main changes ensure that only the value "basic" is accepted for the oauth flag, with an appropriate error thrown for invalid values.
`args` parses a bare `--oauth` flag as boolean `true`, which previously reached `ConfigurationBase.getOAuthLevel()` and crashed on `toLowerCase()`. Unsupported string values were also silently ignored.

This change:
- represents supported OAuth levels with a string enum;
- validates OAuth values in one shared `parseOAuthLevel` function;
- applies validation to `azurite`, `azurite-blob`, `azurite-queue`, and `azurite-table`, including programmatic configuration;
- reports the supported values for missing or invalid arguments;
- adds regression tests and an Upcoming Release changelog entry.

This incorporates the unresolved review feedback from #2554 by avoiding a hard-coded value in four implementations, centralizing validation, and adding tests and changelog coverage.

## Validation

- 22 focused environment tests pass
- `npm run lint`
- `npm run build`
- `git diff --check`
- Built CLI smoke test: all four entrypoints exit with a clear error for bare `--oauth` and `--oauth invalid`; no crash, hang, listener startup, or silent acceptance