### PR TITLE
Fix FilterBlobs when where is omitted

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,7 @@ General:
 
 Blob:
 
+- Fixed service- and container-level Filter Blobs requests failing when the optional `where` query parameter is omitted.
 - Fixed blob operations hanging when a client disconnects before the operation queue processes the request. (issue #2575)
 
 Table:

--- a/src/blob/handlers/ContainerHandler.ts
+++ b/src/blob/handlers/ContainerHandler.ts
@@ -400,7 +400,7 @@ export default class ContainerHandler extends BaseHandler
       version: BLOB_API_VERSION,
       date: context.startTime,
       serviceEndpoint,
-      where: options.where!,
+      where: options.where ?? "",
       blobs: blobs,
       clientRequestId: options.requestId,
       nextMarker: `${nextMarker || ""}`

--- a/src/blob/handlers/ServiceHandler.ts
+++ b/src/blob/handlers/ServiceHandler.ts
@@ -402,7 +402,7 @@ export default class ServiceHandler extends BaseHandler
       version: BLOB_API_VERSION,
       date: context.startTime,
       serviceEndpoint,
-      where: options.where!,
+      where: options.where ?? "",
       blobs: blobs,
       clientRequestId: options.requestId,
       nextMarker: `${nextMarker || ""}`

--- a/tests/blob/apis/container.test.ts
+++ b/tests/blob/apis/container.test.ts
@@ -1265,6 +1265,12 @@ describe("ContainerAPIs", () => {
     }
     await appendBlobClient3.create({ tags: tags3 });
 
+    const resultWithoutWhere = await (
+      containerClient as any
+    ).storageClientContext.container.filterBlobs();
+    assert.strictEqual(resultWithoutWhere.where, "");
+    assert.deepStrictEqual(resultWithoutWhere.blobs, []);
+
     const expectedTags1: Tags = {};
     expectedTags1['key1'] = tags1['key1'];
     for await (const blob of containerClient.findBlobsByTags(`key1='${tags1["key1"]}'`)) {

--- a/tests/blob/apis/service.test.ts
+++ b/tests/blob/apis/service.test.ts
@@ -540,6 +540,12 @@ describe("ServiceAPIs", () => {
     tags3[key2] = "default";
     await appendBlobClient3.create({ tags: tags3 });
 
+    const resultWithoutWhere = await (
+      serviceClient as any
+    ).storageClientContext.service.filterBlobs();
+    assert.strictEqual(resultWithoutWhere.where, "");
+    assert.deepStrictEqual(resultWithoutWhere.blobs, []);
+
     const expectedTags1: Tags = {};
     expectedTags1[key1] = tags1[key1];
     for await (const blob of serviceClient.findBlobsByTags(`${key1}='${tags1[key1]}'`)) {


### PR DESCRIPTION
## What

Fix service- and container-level Filter Blobs requests that fail when the optional `where` query parameter is omitted. The handlers now serialize the required response `Where` field as an empty string while preserving the omitted filter passed to metadata storage.

## Tests

- Added regression coverage for both service and container endpoints through the SDK's authenticated protocol operations.
- Verifies the deserialized `where` value is empty and no blobs are returned.
- `npm run lint`
- `npm run build`
- Focused regression test
- `npm run test:blob` (668 passing, 3 pending)
- `npm run test:blob:in-memory` (668 passing, 3 pending)

The test is tagged `@sql`; local SQL execution was unavailable because MySQL was not running.

Supersedes #2636 and incorporates its review feedback.