### PR TITLE
Return structured Queue responses for unexpected errors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,10 @@ Blob:
 
 - Fixed blob operations hanging when a client disconnects before the operation queue processes the request. (issue #2575)
 
+Queue:
+
+- Return a structured `InternalError` XML response for unexpected Queue errors instead of an empty HTTP 500 response. (related to issue #1687)
+
 Table:
 
 - Fix `azurite-table` startup banner reporting the configured port (e.g. `0` when using OS-assigned ports) instead of the actual bound address. Now uses `server.getHttpServerAddress()` to match `azurite-blob` and `azurite-queue`.

--- a/src/queue/generated/middleware/error.middleware.ts
+++ b/src/queue/generated/middleware/error.middleware.ts
@@ -4,6 +4,7 @@ import IRequest from "../IRequest";
 import IResponse from "../IResponse";
 import { NextFunction } from "../MiddlewareFactory";
 import ILogger from "../utils/ILogger";
+import StorageErrorFactory from "../../errors/StorageErrorFactory";
 
 /**
  * ErrorMiddleware handles following 2 kinds of errors thrown from previous middleware or handlers:
@@ -39,71 +40,9 @@ export default function errorMiddleware(
     return next(err);
   }
 
-  // Only handle ServerError, for other customized error types hand over to
-  // other error handlers.
+  let responseError: MiddlewareError;
   if (err instanceof MiddlewareError) {
-    logger.error(
-      `ErrorMiddleware: Received a MiddlewareError, fill error information to HTTP response`,
-      context.contextID
-    );
-
-    logger.error(
-      `ErrorMiddleware: ErrorName=${err.name} ErrorMessage=${
-        err.message
-      }  ErrorHTTPStatusCode=${err.statusCode} ErrorHTTPStatusMessage=${
-        err.statusMessage
-      } ErrorHTTPHeaders=${JSON.stringify(
-        err.headers
-      )} ErrorHTTPBody=${JSON.stringify(err.body)} ErrorStack=${JSON.stringify(
-        err.stack
-      )}`,
-      context.contextID
-    );
-
-    logger.error(
-      `ErrorMiddleware: Set HTTP code: ${err.statusCode}`,
-      context.contextID
-    );
-
-    res.setStatusCode(err.statusCode);
-    if (err.statusMessage) {
-      logger.error(
-        `ErrorMiddleware: Set HTTP status message: ${err.statusMessage}`,
-        context.contextID
-      );
-      res.setStatusMessage(err.statusMessage);
-    }
-
-    if (err.headers) {
-      for (const key in err.headers) {
-        if (err.headers.hasOwnProperty(key)) {
-          const value = err.headers[key];
-          if (value) {
-            logger.error(
-              `ErrorMiddleware: Set HTTP Header: ${key}=${value}`,
-              context.contextID
-            );
-            res.setHeader(key, value);
-          }
-        }
-      }
-    }
-
-    if (err.contentType && req.getMethod() !== "HEAD") {
-      logger.error(
-        `ErrorMiddleware: Set content type: ${err.contentType}`,
-        context.contextID
-      );
-      res.setContentType(err.contentType);
-    }
-
-    logger.error(
-      `ErrorMiddleware: Set HTTP body: ${JSON.stringify(err.body)}`,
-      context.contextID
-    );
-    if (err.body && req.getMethod() !== "HEAD") {
-      res.getBodyStream().write(err.body);
-    }
+    responseError = err;
   } else if (err instanceof Error) {
     logger.error(
       `ErrorMiddleware: Received an error, fill error information to HTTP response`,
@@ -115,19 +54,78 @@ export default function errorMiddleware(
       } ErrorStack=${JSON.stringify(err.stack)}`,
       context.contextID
     );
-    logger.error(`ErrorMiddleware: Set HTTP code: ${500}`, context.contextID);
-    res.setStatusCode(500);
-
-    // logger.error(
-    //   `ErrorMiddleware: Set error message: ${err.message}`,
-    //   context.contextID
-    // );
-    // res.getBodyStream().write(err.message);
+    responseError = StorageErrorFactory.InternalError(context.contextID);
   } else {
     logger.warn(
       `ErrorMiddleware: Received unhandled error object`,
       context.contextID
     );
+    return next();
+  }
+
+  if (responseError instanceof MiddlewareError) {
+    logger.error(
+      `ErrorMiddleware: Received a MiddlewareError, fill error information to HTTP response`,
+      context.contextID
+    );
+
+    logger.error(
+      `ErrorMiddleware: ErrorName=${responseError.name} ErrorMessage=${
+        responseError.message
+      }  ErrorHTTPStatusCode=${responseError.statusCode} ErrorHTTPStatusMessage=${
+        responseError.statusMessage
+      } ErrorHTTPHeaders=${JSON.stringify(
+        responseError.headers
+      )} ErrorHTTPBody=${JSON.stringify(responseError.body)} ErrorStack=${JSON.stringify(
+        responseError.stack
+      )}`,
+      context.contextID
+    );
+
+    logger.error(
+      `ErrorMiddleware: Set HTTP code: ${responseError.statusCode}`,
+      context.contextID
+    );
+
+    res.setStatusCode(responseError.statusCode);
+    if (responseError.statusMessage) {
+      logger.error(
+        `ErrorMiddleware: Set HTTP status message: ${responseError.statusMessage}`,
+        context.contextID
+      );
+      res.setStatusMessage(responseError.statusMessage);
+    }
+
+    if (responseError.headers) {
+      for (const key in responseError.headers) {
+        if (responseError.headers.hasOwnProperty(key)) {
+          const value = responseError.headers[key];
+          if (value) {
+            logger.error(
+              `ErrorMiddleware: Set HTTP Header: ${key}=${value}`,
+              context.contextID
+            );
+            res.setHeader(key, value);
+          }
+        }
+      }
+    }
+
+    if (responseError.contentType && req.getMethod() !== "HEAD") {
+      logger.error(
+        `ErrorMiddleware: Set content type: ${responseError.contentType}`,
+        context.contextID
+      );
+      res.setContentType(responseError.contentType);
+    }
+
+    logger.error(
+      `ErrorMiddleware: Set HTTP body: ${JSON.stringify(responseError.body)}`,
+      context.contextID
+    );
+    if (responseError.body && req.getMethod() !== "HEAD") {
+      res.getBodyStream().write(responseError.body);
+    }
   }
 
   next();

--- a/tests/queue/unit/error.middleware.test.ts
+++ b/tests/queue/unit/error.middleware.test.ts
@@ -3,8 +3,8 @@ import { Writable } from "stream";
 
 import Context from "../../../src/queue/generated/Context";
 import IRequest, {
+  HttpMethod
 } from "../../../src/queue/generated/IRequest";
-});
 import IResponse from "../../../src/queue/generated/IResponse";
 import errorMiddleware from "../../../src/queue/generated/middleware/error.middleware";
 import ILogger from "../../../src/queue/generated/utils/ILogger";
@@ -74,7 +74,7 @@ describe("Queue error middleware @loki", () => {
 
   ["POST", "HEAD"].forEach((method) => {
     it(`returns an InternalError response for unexpected ${method} errors`, () => {
-      const context = new Context({});
+      const context = new Context({}, "context");
       context.contextID = "request-id";
       const { response, getBody } = createResponse();
       let nextCalled = false;

--- a/tests/queue/unit/error.middleware.test.ts
+++ b/tests/queue/unit/error.middleware.test.ts
@@ -1,0 +1,110 @@
+import * as assert from "assert";
+import { Writable } from "stream";
+
+import Context from "../../../src/queue/generated/Context";
+import IRequest, {
+} from "../../../src/queue/generated/IRequest";
+});
+import IResponse from "../../../src/queue/generated/IResponse";
+import errorMiddleware from "../../../src/queue/generated/middleware/error.middleware";
+import ILogger from "../../../src/queue/generated/utils/ILogger";
+import { QUEUE_API_VERSION } from "../../../src/queue/utils/constants";
+
+describe("Queue error middleware @loki", () => {
+  function createRequest(method: HttpMethod): IRequest {
+    return {
+      getMethod: () => method
+    } as IRequest;
+  }
+
+  function createResponse() {
+    const chunks: Buffer[] = [];
+    const headers: Record<string, string> = {};
+    let statusCode = 200;
+    let statusMessage = "";
+    const bodyStream = new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(Buffer.from(chunk));
+        callback();
+      }
+    });
+
+    const response: IResponse = {
+      setStatusCode: (code) => {
+        statusCode = code;
+        return response;
+      },
+      getStatusCode: () => statusCode,
+      setStatusMessage: (message) => {
+        statusMessage = message;
+        return response;
+      },
+      getStatusMessage: () => statusMessage,
+      setHeader: (field, value) => {
+        if (value !== undefined) {
+          headers[field.toLowerCase()] = String(value);
+        }
+        return response;
+      },
+      getHeader: (field) => headers[field.toLowerCase()],
+      getHeaders: () => headers,
+      headersSent: () => false,
+      setContentType: (value) => {
+        if (value !== undefined) {
+          headers["content-type"] = value;
+        }
+        return response;
+      },
+      getBodyStream: () => bodyStream
+    };
+
+    return {
+      response,
+      getBody: () => Buffer.concat(chunks).toString("utf8")
+    };
+  }
+
+  const logger: ILogger = {
+    error: () => undefined,
+    warn: () => undefined,
+    info: () => undefined,
+    verbose: () => undefined,
+    debug: () => undefined
+  };
+
+  ["POST", "HEAD"].forEach((method) => {
+    it(`returns an InternalError response for unexpected ${method} errors`, () => {
+      const context = new Context({});
+      context.contextID = "request-id";
+      const { response, getBody } = createResponse();
+      let nextCalled = false;
+
+      errorMiddleware(
+        context,
+        new Error("ENOENT: C:\\private\\queue-storage"),
+        createRequest(method as HttpMethod),
+        response,
+        () => {
+          nextCalled = true;
+        },
+        logger
+      );
+
+      assert.strictEqual(response.getStatusCode(), 500);
+      assert.strictEqual(response.getHeader("x-ms-error-code"), "InternalError");
+      assert.strictEqual(response.getHeader("x-ms-request-id"), "request-id");
+      assert.strictEqual(response.getHeader("x-ms-version"), QUEUE_API_VERSION);
+      assert.strictEqual(nextCalled, true);
+
+      if (method === "HEAD") {
+        assert.strictEqual(response.getHeader("content-type"), undefined);
+        assert.strictEqual(getBody(), "");
+      } else {
+        assert.strictEqual(response.getHeader("content-type"), "application/xml");
+        assert.match(getBody(), /<Code>InternalError<\/Code>/);
+        assert.match(getBody(), /RequestId:request-id/);
+        assert.doesNotMatch(getBody(), /private|queue-storage/);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Unexpected errors in the Queue generated middleware currently produce an empty HTTP 500 response. Queue SDK clients then fail while parsing that response because it is not valid Storage error XML.

This change converts unexpected `Error` instances to the existing Queue `InternalError` response and sends them through the normal middleware serialization path. The original exception remains available in server logs, while the client receives a safe Storage-compatible response without filesystem or other internal details.

Related to #1687. This addresses the malformed error response; recovery from missing persistence directories is outside this change.

## Changes

- Return Queue `InternalError` XML, request ID, error code, and API version headers for unexpected errors.
- Preserve HEAD response body and content-type suppression.
- Add focused POST and HEAD middleware regression coverage.
- Add an Upcoming Release changelog entry.

## Validation

- VS Code TypeScript diagnostics pass for the changed source and test files.
- `git diff --check` passes.
- Focused Mocha tests were not run because the local checkout does not have the required Mocha/ts-node dependencies installed.